### PR TITLE
chore(dashboard): add Playwright e2e test scripts

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,10 @@
     "dev:editor": "node scripts/start-editor.js",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:update": "playwright test --update-snapshots"
   },
   "dependencies": {
     "@platejs/basic-nodes": "^49.0.0",


### PR DESCRIPTION
Closes #6

## Summary
- `dashboard/package.json` scripts에 Playwright 실행 명령 추가
- 기존 e2e 테스트 12개를 팀원이 쉽게 실행할 수 있도록 DX 개선

## 변경 파일
- `dashboard/package.json` (scripts 3줄 추가)

```json
"test:e2e": "playwright test",
"test:e2e:ui": "playwright test --ui",
"test:e2e:update": "playwright test --update-snapshots"
```

## Test plan
- [x] `npx playwright --version` 확인 (1.58.2 설치 확인)
- [ ] 머지 후 `cd dashboard && npm run test:e2e` 로컬 실행 확인