### PR TITLE
test(dashboard): add e2e smoke tests for 5 uncovered route groups

### DIFF
--- a/dashboard/e2e/analytics.spec.ts
+++ b/dashboard/e2e/analytics.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Analytics', () => {
+  test('/analytics redirects to /analytics/traffic', async ({ page }) => {
+    await page.goto('/analytics');
+    await expect(page).toHaveURL('/analytics/traffic');
+  });
+
+  test('/analytics/traffic loads without error', async ({ page }) => {
+    const response = await page.goto('/analytics/traffic');
+    expect(response?.status()).toBe(200);
+  });
+
+  test('traffic page shows heading', async ({ page }) => {
+    await page.goto('/analytics/traffic');
+    await expect(page.locator('h1', { hasText: '트래픽' })).toBeVisible();
+  });
+
+  test('sidebar highlights Analytics section', async ({ page }) => {
+    await page.goto('/analytics/traffic');
+    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar.locator('text=Traffic').first()).toBeVisible();
+  });
+});

--- a/dashboard/e2e/blog-manage.spec.ts
+++ b/dashboard/e2e/blog-manage.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Blog Manage', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/blog-manage');
+  });
+
+  test('page loads at /blog-manage', async ({ page }) => {
+    await expect(page).toHaveURL('/blog-manage');
+  });
+
+  test('heading shows 블로그 관리', async ({ page }) => {
+    await expect(page.locator('h1', { hasText: '블로그 관리' })).toBeVisible();
+  });
+
+  test('sidebar Blog nav item is visible', async ({ page }) => {
+    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar.locator('text=Blog').first()).toBeVisible();
+  });
+});

--- a/dashboard/e2e/carousel.spec.ts
+++ b/dashboard/e2e/carousel.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Carousel', () => {
+  test('/carousel loads without error', async ({ page }) => {
+    const response = await page.goto('/carousel');
+    expect(response?.status()).toBe(200);
+  });
+
+  test('/carousel/references loads', async ({ page }) => {
+    const response = await page.goto('/carousel/references');
+    expect(response?.status()).toBe(200);
+  });
+
+  test('/carousel/templates loads', async ({ page }) => {
+    const response = await page.goto('/carousel/templates');
+    expect(response?.status()).toBe(200);
+  });
+
+  test('sidebar shows Carousel group', async ({ page }) => {
+    await page.goto('/carousel');
+    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar.locator('text=캐러셀').first()).toBeVisible();
+  });
+});

--- a/dashboard/e2e/newsletter.spec.ts
+++ b/dashboard/e2e/newsletter.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Newsletter', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/newsletter');
+  });
+
+  test('page loads at /newsletter', async ({ page }) => {
+    await expect(page).toHaveURL('/newsletter');
+  });
+
+  test('heading shows 뉴스레터', async ({ page }) => {
+    await expect(page.locator('h1', { hasText: '뉴스레터' })).toBeVisible();
+  });
+
+  test('sidebar Newsletter nav item is visible', async ({ page }) => {
+    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar.locator('text=Newsletter').first()).toBeVisible();
+  });
+});

--- a/dashboard/e2e/video.spec.ts
+++ b/dashboard/e2e/video.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Video', () => {
+  test('/video/projects loads', async ({ page }) => {
+    const response = await page.goto('/video/projects');
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('h1', { hasText: '영상 프로젝트' })).toBeVisible();
+  });
+
+  test('/video/references loads', async ({ page }) => {
+    const response = await page.goto('/video/references');
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('h1', { hasText: '영상 레퍼런스' })).toBeVisible();
+  });
+
+  test('/video/finished loads', async ({ page }) => {
+    const response = await page.goto('/video/finished');
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('h1', { hasText: '완료 영상' })).toBeVisible();
+  });
+
+  test('sidebar shows Video group', async ({ page }) => {
+    await page.goto('/video/projects');
+    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar.locator('text=프로젝트').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #8

## Summary
- `dashboard/e2e/`에 5개 spec 추가 (analytics, blog-manage, carousel, newsletter, video)
- 총 18개 smoke 테스트 — 페이지 로드, 헤딩 표시, 사이드바 네비 검증
- 로컬 실행 전부 통과 확인 (18/18 passed)

## 변경 파일 (5개)
- `dashboard/e2e/analytics.spec.ts` (+25)
- `dashboard/e2e/blog-manage.spec.ts` (+21)
- `dashboard/e2e/carousel.spec.ts` (+25)
- `dashboard/e2e/newsletter.spec.ts` (+21)
- `dashboard/e2e/video.spec.ts` (+28)

총 120줄 추가, 0줄 삭제.

## Test plan
- [x] `npx playwright test analytics.spec.ts blog-manage.spec.ts newsletter.spec.ts` → 10/10 pass
- [x] `npx playwright test carousel.spec.ts video.spec.ts` → 8/8 pass
- [ ] CI에서 동일하게 돌아가는지 PR #? (e2e 워크플로우) 머지 후 확인

## 참고
- mutation 없는 read-only smoke 테스트 (DB/외부 API 변경 안 함)
- PR #7 (test scripts)와 독립, 어느 쪽이 먼저 머지돼도 무방