### PR TITLE
feat: MCP에 blog_posts 도구 5종 추가

### DIFF
--- a/scripts/insert-blog-drafts.mjs
+++ b/scripts/insert-blog-drafts.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+// Insert AWC case-study drafts from Obsidian vault into blog_posts (status=draft).
+// - Reads markdown files, parses metadata table + body
+// - Converts body to PlateJS JSON via @awc/content-core CLI
+// - Idempotent: skips if slug already exists in blog_posts
+//
+// Usage:
+//   node scripts/insert-blog-drafts.mjs --dry-run
+//   node scripts/insert-blog-drafts.mjs
+
+import { readFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DRAFTS_DIR = '/Users/jangdongjin/Documents/Intellieffect-Vault/02-Projects/AWC/사례원문';
+const CLI_PATH = '/Users/jangdongjin/Projects/awc/packages/content-core/dist/cli.js';
+const CATEGORY_ID_CASE_STUDY = '62337e90-bb6a-4215-8ee9-222eaf352956';
+const ENV_FILE = '/Users/jangdongjin/Projects/awc/apps/studio/.env.local';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// --- Env loader (no external deps) --------------------------------
+async function loadEnv(path) {
+  const raw = await readFile(path, 'utf-8');
+  const env = {};
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (m) {
+      let v = m[2];
+      // strip surrounding quotes
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+        v = v.slice(1, -1);
+      }
+      env[m[1]] = v;
+    }
+  }
+  return env;
+}
+
+// --- Markdown parsing ---------------------------------------------
+function parseMetadataTable(md) {
+  // Find the "## 메타데이터" section and parse the pipe-separated table
+  const start = md.indexOf('## 메타데이터');
+  if (start === -1) return null;
+  const section = md.slice(start, md.indexOf('\n---', start));
+  const meta = {};
+  for (const line of section.split('\n')) {
+    const m = line.match(/^\|\s*([a-zA-Z_]+)\s*\|\s*(.*?)\s*\|\s*$/);
+    if (!m) continue;
+    const key = m[1].trim();
+    const val = m[2].trim();
+    if (key === '필드' || val === '값' || val.startsWith('---')) continue;
+    meta[key] = val;
+  }
+  return meta;
+}
+
+function extractBody(md) {
+  const marker = '## 본문';
+  const idx = md.indexOf(marker);
+  if (idx === -1) return null;
+  // Start from the first newline after "## 본문"
+  return md.slice(idx + marker.length).trim();
+}
+
+function estimateReadingTime(text) {
+  // Korean: ~500 chars/min rough
+  const cleaned = text.replace(/\s+/g, '');
+  return Math.max(1, Math.round(cleaned.length / 500));
+}
+
+// --- CLI invocation ------------------------------------------------
+function runConvertPlate(markdownBody, topic) {
+  return new Promise((resolve, reject) => {
+    const args = [CLI_PATH, 'convert-plate', '--topic', topic, '--category', 'case-study'];
+    const child = spawn('node', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`convert-plate exited ${code}: ${stderr}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch (e) {
+        reject(new Error(`Failed to parse convert-plate output: ${e.message}`));
+      }
+    });
+    child.stdin.write(markdownBody);
+    child.stdin.end();
+  });
+}
+
+// --- Supabase REST helpers ----------------------------------------
+async function sbGet(env, path) {
+  const res = await fetch(`${env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/${path}`, {
+    headers: {
+      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+    },
+  });
+  if (!res.ok) throw new Error(`GET ${path} → ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function sbInsert(env, table, payload) {
+  const res = await fetch(`${env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/${table}`, {
+    method: 'POST',
+    headers: {
+      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`INSERT ${table} → ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+// --- Main ---------------------------------------------------------
+async function main() {
+  console.error(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE INSERT'}`);
+  const env = await loadEnv(ENV_FILE);
+  if (!env.NEXT_PUBLIC_SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing Supabase env vars');
+  }
+
+  if (!existsSync(CLI_PATH)) {
+    throw new Error(`CLI not built: ${CLI_PATH}. Run 'pnpm --filter @awc/content-core build' first.`);
+  }
+
+  // Whitelist only the 12 target drafts (exclude WESPION-Roomfit which has different structure)
+  const targets = [
+    '광고대행SaaS-초안-2026-04-14.md',
+    '골프아카데미-초안-2026-04-14.md',
+    '마케팅대행사-초안-2026-04-16.md',
+    '물류중개-초안-2026-04-17.md',
+    '법무법인-초안-2026-04-16.md',
+    '보험설계사-초안-2026-04-17.md',
+    '뷰티이커머스-초안-2026-04-16.md',
+    '빌딩중개-초안-2026-04-14.md',
+    '온라인어학원-초안-2026-04-16.md',
+    '인테리어시공-초안-2026-04-17.md',
+    '카페프랜차이즈-초안-2026-04-16.md',
+    '피부과클리닉-초안-2026-04-16.md',
+  ];
+
+  // Existing slugs to skip duplicates
+  const existing = await sbGet(env, 'blog_posts?select=slug');
+  const existingSlugs = new Set(existing.map((r) => r.slug));
+
+  const prepared = [];
+  for (const file of targets) {
+    const full = join(DRAFTS_DIR, file);
+    const md = await readFile(full, 'utf-8');
+    const meta = parseMetadataTable(md);
+    if (!meta) {
+      console.error(`SKIP (no meta): ${file}`);
+      continue;
+    }
+    const body = extractBody(md);
+    if (!body) {
+      console.error(`SKIP (no body): ${file}`);
+      continue;
+    }
+    const title = meta.title;
+    const slug = meta.slug;
+    const excerpt = meta.excerpt || null;
+    const meta_description = meta.meta_description || null;
+    const meta_keywords = meta.meta_keywords
+      ? meta.meta_keywords.split(',').map((k) => k.trim()).filter(Boolean)
+      : [];
+    const reading_time = meta.reading_time ? parseInt(meta.reading_time, 10) : estimateReadingTime(body);
+
+    if (!title || !slug) {
+      console.error(`SKIP (missing title/slug): ${file}`);
+      continue;
+    }
+
+    if (existingSlugs.has(slug)) {
+      console.error(`SKIP (slug exists): ${file} → ${slug}`);
+      continue;
+    }
+
+    console.error(`Converting: ${file} → slug=${slug}`);
+    const plateContent = await runConvertPlate(body, title);
+
+    prepared.push({
+      file,
+      payload: {
+        title,
+        slug,
+        excerpt,
+        content: plateContent,
+        meta_title: `${title} | AWC`,
+        meta_description,
+        meta_keywords,
+        status: 'draft',
+        reading_time,
+        ai_generated: false,
+      },
+    });
+  }
+
+  console.error(`\nPrepared ${prepared.length} payloads.`);
+  for (const p of prepared) {
+    console.error(`  - ${p.payload.slug} — ${p.payload.title.slice(0, 60)}`);
+  }
+
+  if (DRY_RUN) {
+    console.error('\nDRY RUN complete. Re-run without --dry-run to insert.');
+    // Output slugs+titles as JSON for easy inspection
+    console.log(JSON.stringify(prepared.map((p) => ({
+      file: p.file,
+      slug: p.payload.slug,
+      title: p.payload.title,
+      excerpt: p.payload.excerpt,
+      meta_keywords: p.payload.meta_keywords,
+      reading_time: p.payload.reading_time,
+      plate_nodes: p.payload.content.length,
+    })), null, 2));
+    return;
+  }
+
+  // Live insert
+  const inserted = [];
+  for (const p of prepared) {
+    const [row] = await sbInsert(env, 'blog_posts', p.payload);
+    await sbInsert(env, 'blog_post_categories', {
+      post_id: row.id,
+      category_id: CATEGORY_ID_CASE_STUDY,
+    });
+    inserted.push({ slug: row.slug, id: row.id });
+    console.error(`INSERTED: ${row.slug} (${row.id})`);
+  }
+
+  console.log(JSON.stringify({ inserted, count: inserted.length }, null, 2));
+}
+
+main().catch((e) => {
+  console.error('FATAL:', e.message);
+  process.exit(1);
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { registerActivityTools } from './tools/activity.js';
 import { registerRevisionTools } from './tools/revisions.js';
 import { registerMediaTools } from './tools/media.js';
 import { registerVideoTools } from './tools/video.js';
+import { registerBlogPostTools } from './tools/blog-posts.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -45,6 +46,9 @@ async function main(): Promise<void> {
 
   // Video editor tools
   registerVideoTools(server, editorApiUrl);
+
+  // Blog post tools (AWC blog — blog_posts table, markdown → PlateJS)
+  registerBlogPostTools(server, supabaseUrl, supabaseKey);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/blog-posts.ts
+++ b/src/tools/blog-posts.ts
@@ -33,35 +33,59 @@ interface BlogCategory {
   description: string | null;
 }
 
-const DEFAULT_CLI_PATH =
-  process.env.CONTENT_CORE_CLI_PATH ||
-  '/Users/jangdongjin/Projects/awc/packages/content-core/dist/cli.js';
+const CLI_PATH = process.env.CONTENT_CORE_CLI_PATH;
+const CLI_TIMEOUT_MS = Number(process.env.CONTENT_CORE_CLI_TIMEOUT_MS ?? 30_000);
 
 function convertMarkdownToPlate(markdown: string, topic: string, category: string): Promise<unknown[]> {
   return new Promise((resolve, reject) => {
-    if (!existsSync(DEFAULT_CLI_PATH)) {
+    if (!CLI_PATH) {
       reject(
         new Error(
-          `content-core CLI not found at ${DEFAULT_CLI_PATH}. Build with 'pnpm --filter @awc/content-core build' or set CONTENT_CORE_CLI_PATH.`
+          `CONTENT_CORE_CLI_PATH is not set. Set the env var to the absolute path of @awc/content-core dist/cli.js before invoking this tool.`
         )
       );
       return;
     }
-    const args = [DEFAULT_CLI_PATH, 'convert-plate', '--topic', topic, '--category', category];
+    if (!existsSync(CLI_PATH)) {
+      reject(
+        new Error(
+          `content-core CLI not found at ${CLI_PATH}. Build with 'pnpm --filter @awc/content-core build' or fix CONTENT_CORE_CLI_PATH.`
+        )
+      );
+      return;
+    }
+    const args = [CLI_PATH, 'convert-plate', '--topic', topic, '--category', category];
     const child = spawn('node', args, { stdio: ['pipe', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      settle(() =>
+        reject(new Error(`convert-plate CLI timed out after ${CLI_TIMEOUT_MS}ms (set CONTENT_CORE_CLI_TIMEOUT_MS to raise).`))
+      );
+    }, CLI_TIMEOUT_MS);
     child.stdout.on('data', (d) => (stdout += d.toString()));
     child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('error', (e) => settle(() => reject(e)));
     child.on('close', (code) => {
       if (code !== 0) {
-        reject(new Error(`convert-plate exited ${code}: ${stderr}`));
+        settle(() => reject(new Error(`convert-plate exited ${code}: ${stderr}`)));
         return;
       }
       try {
-        resolve(JSON.parse(stdout));
+        const parsed = JSON.parse(stdout);
+        settle(() => resolve(parsed));
       } catch (e) {
-        reject(new Error(`Failed to parse convert-plate output: ${e instanceof Error ? e.message : String(e)}`));
+        settle(() =>
+          reject(new Error(`Failed to parse convert-plate output: ${e instanceof Error ? e.message : String(e)}`))
+        );
       }
     });
     child.stdin.write(markdown);
@@ -277,15 +301,19 @@ export function registerBlogPostTools(
 
         const post = inserted as BlogPostRow;
 
-        // 6. Link category if provided
+        // 6. Link category if provided. Roll back the blog_post insert on failure
+        //    so we never leave an orphaned post (Supabase JS SDK has no multi-statement
+        //    transaction — manual compensation is the safest option here).
         if (categoryId) {
           const { error: linkErr } = await sb
             .from('blog_post_categories')
             .insert({ post_id: post.id, category_id: categoryId });
           if (linkErr) {
-            throw new Error(
-              `blog_post inserted (id=${post.id}) but category link failed: ${linkErr.message}`
-            );
+            const { error: delErr } = await sb.from('blog_posts').delete().eq('id', post.id);
+            const delNote = delErr
+              ? ` (rollback also failed: ${delErr.message} — manual cleanup required for blog_post id=${post.id})`
+              : ' (blog_post insert rolled back)';
+            throw new Error(`Failed to link category: ${linkErr.message}${delNote}`);
           }
         }
 

--- a/src/tools/blog-posts.ts
+++ b/src/tools/blog-posts.ts
@@ -1,0 +1,370 @@
+import { z } from 'zod';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Types for blog_posts table
+interface BlogPostRow {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  content: unknown[];
+  meta_title: string | null;
+  meta_description: string | null;
+  meta_keywords: string[] | null;
+  status: 'draft' | 'published' | 'archived';
+  reading_time: number;
+  ai_generated: boolean;
+  thumbnail_url: string | null;
+  thumbnail_alt: string | null;
+  thumbnail_credit: string | null;
+  view_count: number;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BlogCategory {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+}
+
+const DEFAULT_CLI_PATH =
+  process.env.CONTENT_CORE_CLI_PATH ||
+  '/Users/jangdongjin/Projects/awc/packages/content-core/dist/cli.js';
+
+function convertMarkdownToPlate(markdown: string, topic: string, category: string): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    if (!existsSync(DEFAULT_CLI_PATH)) {
+      reject(
+        new Error(
+          `content-core CLI not found at ${DEFAULT_CLI_PATH}. Build with 'pnpm --filter @awc/content-core build' or set CONTENT_CORE_CLI_PATH.`
+        )
+      );
+      return;
+    }
+    const args = [DEFAULT_CLI_PATH, 'convert-plate', '--topic', topic, '--category', category];
+    const child = spawn('node', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`convert-plate exited ${code}: ${stderr}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch (e) {
+        reject(new Error(`Failed to parse convert-plate output: ${e instanceof Error ? e.message : String(e)}`));
+      }
+    });
+    child.stdin.write(markdown);
+    child.stdin.end();
+  });
+}
+
+function ok(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function err(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+export function registerBlogPostTools(
+  server: McpServer,
+  supabaseUrl: string,
+  supabaseKey: string
+): void {
+  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+  // ─── list_blog_categories ────────────────────────────────
+  server.tool(
+    'list_blog_categories',
+    'List all blog post categories (name, slug, description). Use to find the correct category slug before creating a post.',
+    {},
+    async () => {
+      try {
+        const { data, error } = await sb.from('blog_categories').select('id, name, slug, description');
+        if (error) throw new Error(error.message);
+        return ok({ categories: data as BlogCategory[], count: (data || []).length });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+
+  // ─── list_blog_posts ─────────────────────────────────────
+  server.tool(
+    'list_blog_posts',
+    'List blog posts with optional filters. Returns summary fields (not full PlateJS content).',
+    {
+      status: z.enum(['draft', 'published', 'archived']).optional().describe('Filter by status'),
+      category_slug: z.string().optional().describe('Filter by category slug (e.g. "case-study")'),
+      limit: z.number().min(1).max(100).optional().describe('Max results (default 50)'),
+    },
+    async (params) => {
+      try {
+        let query = sb
+          .from('blog_posts')
+          .select(
+            'id, title, slug, status, excerpt, reading_time, view_count, created_at, updated_at, published_at, blog_post_categories(blog_categories(id, name, slug))'
+          )
+          .order('created_at', { ascending: false })
+          .limit(params.limit ?? 50);
+
+        if (params.status) query = query.eq('status', params.status);
+
+        const { data, error } = await query;
+        if (error) throw new Error(error.message);
+
+        let posts = (data || []).map((row: any) => ({
+          ...row,
+          categories: (row.blog_post_categories || []).map((pc: any) => pc.blog_categories).filter(Boolean),
+          blog_post_categories: undefined,
+        }));
+
+        if (params.category_slug) {
+          posts = posts.filter((p: any) =>
+            (p.categories || []).some((c: any) => c.slug === params.category_slug)
+          );
+        }
+
+        return ok({ posts, count: posts.length });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+
+  // ─── get_blog_post ───────────────────────────────────────
+  server.tool(
+    'get_blog_post',
+    'Get a single blog post (including full PlateJS content) by ID or slug.',
+    {
+      id_or_slug: z.string().describe('Blog post UUID or slug'),
+    },
+    async (params) => {
+      try {
+        const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(params.id_or_slug);
+        const { data, error } = await sb
+          .from('blog_posts')
+          .select(
+            '*, blog_post_categories(blog_categories(id, name, slug)), blog_post_tags(blog_tags(id, name, slug))'
+          )
+          .eq(isUuid ? 'id' : 'slug', params.id_or_slug)
+          .single();
+        if (error) throw new Error(error.message);
+        const post = {
+          ...(data as any),
+          categories: ((data as any)?.blog_post_categories || [])
+            .map((pc: any) => pc.blog_categories)
+            .filter(Boolean),
+          tags: ((data as any)?.blog_post_tags || [])
+            .map((pt: any) => pt.blog_tags)
+            .filter(Boolean),
+          blog_post_categories: undefined,
+          blog_post_tags: undefined,
+        };
+        return ok({ post });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+
+  // ─── create_blog_post_from_markdown ──────────────────────
+  server.tool(
+    'create_blog_post_from_markdown',
+    [
+      'Convert a Markdown body to PlateJS JSON and insert as a draft blog post.',
+      'Status is ALWAYS "draft" — agents cannot publish directly; Studio review is required.',
+      'Optionally links the post to an existing category by slug.',
+      'Uses @awc/content-core CLI (convert-plate) for Markdown → PlateJS conversion.',
+    ].join(' '),
+    {
+      title: z.string().describe('Post title'),
+      slug: z
+        .string()
+        .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'slug must be lowercase-hyphen (English only)')
+        .describe('URL-friendly English slug. Lowercase letters, digits, hyphens only.'),
+      markdown_body: z.string().min(10).describe('Full blog post body in Markdown (will be converted to PlateJS)'),
+      excerpt: z.string().optional().describe('Short summary (~100 chars, shown in listings)'),
+      meta_title: z.string().optional().describe('SEO meta_title (defaults to "{title} | AWC")'),
+      meta_description: z.string().optional().describe('SEO meta_description (~155 chars)'),
+      meta_keywords: z.array(z.string()).optional().describe('SEO keyword array'),
+      reading_time: z.number().int().min(1).max(60).optional().describe('Estimated reading time in minutes'),
+      category_slug: z
+        .string()
+        .optional()
+        .describe('Blog category slug (e.g. "case-study", "column"). Use list_blog_categories to discover.'),
+      ai_generated: z
+        .boolean()
+        .optional()
+        .describe('true if the agent generated the full text; false if human-written content'),
+      thumbnail_url: z.string().url().optional().describe('Optional thumbnail image URL'),
+    },
+    async (params) => {
+      try {
+        // 1. Check slug uniqueness
+        const { data: existing } = await sb
+          .from('blog_posts')
+          .select('id')
+          .eq('slug', params.slug)
+          .maybeSingle();
+        if (existing) throw new Error(`Slug already exists: ${params.slug}`);
+
+        // 2. Resolve category (optional)
+        let categoryId: string | null = null;
+        if (params.category_slug) {
+          const { data: cat, error: catErr } = await sb
+            .from('blog_categories')
+            .select('id')
+            .eq('slug', params.category_slug)
+            .single();
+          if (catErr || !cat) {
+            throw new Error(`Category not found for slug: ${params.category_slug}`);
+          }
+          categoryId = (cat as { id: string }).id;
+        }
+
+        // 3. Convert markdown → PlateJS
+        const plateContent = await convertMarkdownToPlate(
+          params.markdown_body,
+          params.title,
+          params.category_slug || 'case-study'
+        );
+
+        // 4. Estimate reading_time if missing
+        const readingTime =
+          params.reading_time ??
+          Math.max(1, Math.round(params.markdown_body.replace(/\s+/g, '').length / 500));
+
+        // 5. Insert blog_posts row (always draft)
+        const insertPayload = {
+          title: params.title,
+          slug: params.slug,
+          excerpt: params.excerpt ?? null,
+          content: plateContent,
+          meta_title: params.meta_title ?? `${params.title} | AWC`,
+          meta_description: params.meta_description ?? null,
+          meta_keywords: params.meta_keywords ?? [],
+          status: 'draft' as const,
+          reading_time: readingTime,
+          ai_generated: params.ai_generated ?? false,
+          thumbnail_url: params.thumbnail_url ?? null,
+        };
+
+        const { data: inserted, error: insErr } = await sb
+          .from('blog_posts')
+          .insert(insertPayload)
+          .select()
+          .single();
+
+        if (insErr || !inserted) {
+          throw new Error(`Failed to insert blog_post: ${insErr?.message || 'unknown error'}`);
+        }
+
+        const post = inserted as BlogPostRow;
+
+        // 6. Link category if provided
+        if (categoryId) {
+          const { error: linkErr } = await sb
+            .from('blog_post_categories')
+            .insert({ post_id: post.id, category_id: categoryId });
+          if (linkErr) {
+            throw new Error(
+              `blog_post inserted (id=${post.id}) but category link failed: ${linkErr.message}`
+            );
+          }
+        }
+
+        return ok({
+          message: 'Blog post created as draft. Use Studio to review and publish.',
+          post: {
+            id: post.id,
+            slug: post.slug,
+            title: post.title,
+            status: post.status,
+            reading_time: post.reading_time,
+            category_slug: params.category_slug ?? null,
+            plate_nodes: plateContent.length,
+          },
+        });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+
+  // ─── update_blog_post ────────────────────────────────────
+  server.tool(
+    'update_blog_post',
+    [
+      'Update fields on an existing blog post (title, excerpt, meta, thumbnail, or body).',
+      'If markdown_body is provided, it will be converted to PlateJS and replace content.',
+      'Status cannot be changed to "published" via this tool — use Studio for publishing.',
+    ].join(' '),
+    {
+      id: z.string().uuid().describe('Blog post UUID'),
+      title: z.string().optional(),
+      excerpt: z.string().optional(),
+      meta_title: z.string().optional(),
+      meta_description: z.string().optional(),
+      meta_keywords: z.array(z.string()).optional(),
+      reading_time: z.number().int().min(1).max(60).optional(),
+      thumbnail_url: z.string().url().optional(),
+      status: z
+        .enum(['draft', 'archived'])
+        .optional()
+        .describe('Status (cannot be "published"; use Studio for publishing)'),
+      markdown_body: z
+        .string()
+        .optional()
+        .describe('If provided, replaces content by converting markdown → PlateJS'),
+    },
+    async (params) => {
+      try {
+        const { id, markdown_body, ...rest } = params;
+        const update: Record<string, unknown> = {
+          ...rest,
+          updated_at: new Date().toISOString(),
+        };
+
+        if (markdown_body) {
+          // Need the current title for the conversion topic; fetch it.
+          const { data: cur, error: curErr } = await sb
+            .from('blog_posts')
+            .select('title')
+            .eq('id', id)
+            .single();
+          if (curErr || !cur) throw new Error(`Blog post not found: ${id}`);
+          const topic = (update.title as string) || (cur as { title: string }).title;
+          update.content = await convertMarkdownToPlate(markdown_body, topic, 'case-study');
+        }
+
+        const { data, error: upErr } = await sb
+          .from('blog_posts')
+          .update(update)
+          .eq('id', id)
+          .select()
+          .single();
+        if (upErr) throw new Error(upErr.message);
+
+        return ok({ message: 'Blog post updated', post: data });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

agentic-cms MCP에 AWC 블로그(`blog_posts` 테이블) 조작용 도구 5종을 추가합니다. 에이전트가 자연어로 마크다운 초안을 draft 상태로 업로드할 수 있게 됩니다.

## 추가된 MCP 도구

| 도구 | 역할 |
|------|------|
| `list_blog_categories` | 카테고리 목록 조회 |
| `list_blog_posts` | 포스트 목록 (status, category_slug, limit 필터) |
| `get_blog_post` | 단건 조회 (id 또는 slug, 전체 PlateJS content 포함) |
| **`create_blog_post_from_markdown`** | Markdown → PlateJS 변환 + draft 삽입 + 카테고리 자동 연결 |
| `update_blog_post` | 포스트 수정 (단 `published` 상태 전환 불가) |

## 안전 가드

- `create_blog_post_from_markdown`은 항상 `status='draft'`로 삽입 — 에이전트가 직접 게시 불가
- `update_blog_post`의 status 옵션은 `draft` / `archived`만 허용 — `published`는 Studio 수동 전환 필요
- slug 중복 체크 + 영문 lowercase-hyphen 패턴 검증
- 카테고리 slug 존재 여부 검증

## 구현 상세

- Markdown → PlateJS 변환은 `@awc/content-core`의 `convert-plate` CLI를 subprocess로 호출
- CLI 경로는 `CONTENT_CORE_CLI_PATH` env로 오버라이드 가능 (default: `~/Projects/awc/packages/content-core/dist/cli.js`)
- Supabase 클라이언트는 blog 도구 안에서 별도 생성 (기존 `CMSAdapter` 인터페이스를 확장하지 않아 다른 도구에 영향 없음)

## 포함된 일회성 스크립트

`scripts/insert-blog-drafts.mjs` — 2026-04-17에 Vault의 12개 실전 사례 초안을 일괄 draft 삽입하기 위해 작성. MCP 추가 전에 쓰던 도구지만 향후 bulk 삽입이 필요할 때 재사용 가능하므로 보관.

## Test plan

- [x] TypeScript 빌드 통과 (`npm run build`)
- [x] MCP 서버 기동 스모크 테스트 (stdio 정상 응답)
- [x] `tools/list` 응답에 신규 5개 도구 모두 노출 확인
- [x] 스크립트로 12개 draft 실제 삽입 완료 (blog_posts 14개 드래프트 API 조회로 검증)
- [ ] Claude Code 재시작 후 실제 MCP 도구 호출 (`create_blog_post_from_markdown`)로 draft 삽입 E2E 테스트