### PR TITLE
feat: MCP에 carousel 도구 4종 추가

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { registerRevisionTools } from './tools/revisions.js';
 import { registerMediaTools } from './tools/media.js';
 import { registerVideoTools } from './tools/video.js';
 import { registerBlogPostTools } from './tools/blog-posts.js';
+import { registerCarouselTools } from './tools/carousels.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -49,6 +50,9 @@ async function main(): Promise<void> {
 
   // Blog post tools (AWC blog — blog_posts table, markdown → PlateJS)
   registerBlogPostTools(server, supabaseUrl, supabaseKey);
+
+  // Carousel tools (AWC carousels table — slide deck CRUD)
+  registerCarouselTools(server, supabaseUrl, supabaseKey);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   registerBlogPostTools(server, supabaseUrl, supabaseKey);
 
   // Carousel tools (AWC carousels table — slide deck CRUD)
-  registerCarouselTools(server, supabaseUrl, supabaseKey);
+  registerCarouselTools(server, adapter, supabaseUrl, supabaseKey);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/carousels.ts
+++ b/src/tools/carousels.ts
@@ -1,0 +1,246 @@
+import { z } from 'zod';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// ─── Types ────────────────────────────────────────────────
+interface CarouselSlide {
+  id: string;
+  templateId: string;
+  label: string;
+  category: 'cover' | 'hook' | 'body' | 'cta';
+  content: Record<string, unknown>;
+  overrides: Record<string, unknown>;
+}
+
+interface CarouselRow {
+  id: string;
+  title: string;
+  caption: string | null;
+  slides: CarouselSlide[];
+  created_at: string;
+  updated_at: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────
+function uid(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function ok(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function err(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+// ─── Slide input schema ───────────────────────────────────
+const slideInputSchema = z.object({
+  templateId: z
+    .string()
+    .min(1)
+    .describe(
+      'Template id — e.g. "cover-bold", "body-text", "body-quote", "body-numbered", "cta-question", "cta-save". Use list_carousels to discover template ids in use.'
+    ),
+  category: z
+    .enum(['cover', 'hook', 'body', 'cta'])
+    .describe('Slide role in the deck'),
+  label: z.string().min(1).describe('Human-readable label (e.g. "커버", "본문 1", "CTA")'),
+  content: z
+    .record(z.unknown())
+    .describe('Slide content fields (title/subtitle/body/items/etc. — shape depends on template)'),
+  overrides: z
+    .record(z.unknown())
+    .optional()
+    .describe('Style/brand overrides (backgroundColor, accentColor, etc.)'),
+});
+
+// ─── Registration ─────────────────────────────────────────
+export function registerCarouselTools(
+  server: McpServer,
+  supabaseUrl: string,
+  supabaseKey: string
+): void {
+  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+  // ── list_carousels ─────────────────────────────────────
+  server.tool(
+    'list_carousels',
+    'List carousels. Returns summary (id, title, caption, slide_count, timestamps). Use get_carousel for full slide data.',
+    {
+      limit: z.number().min(1).max(100).optional().describe('Max results (default 50)'),
+      offset: z.number().min(0).optional().describe('Offset for pagination'),
+    },
+    async (params) => {
+      try {
+        const limit = params.limit ?? 50;
+        const offset = params.offset ?? 0;
+        const { data, error } = await sb
+          .from('carousels')
+          .select('id, title, caption, slides, created_at, updated_at')
+          .order('updated_at', { ascending: false })
+          .range(offset, offset + limit - 1);
+        if (error) throw new Error(error.message);
+
+        const carousels = (data || []).map((row: any) => ({
+          id: row.id,
+          title: row.title,
+          caption: row.caption,
+          slide_count: Array.isArray(row.slides) ? row.slides.length : 0,
+          created_at: row.created_at,
+          updated_at: row.updated_at,
+        }));
+        return ok({ carousels, count: carousels.length });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+
+  // ── get_carousel ───────────────────────────────────────
+  server.tool(
+    'get_carousel',
+    'Get a single carousel by id (full slide data included).',
+    {
+      id: z.string().describe('Carousel id (e.g. "carousel-abc123")'),
+    },
+    async (params) => {
+      try {
+        const { data, error } = await sb
+          .from('carousels')
+          .select('*')
+          .eq('id', params.id)
+          .single();
+        if (error) throw new Error(error.message);
+        return ok({ carousel: data as CarouselRow });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+
+  // ── create_carousel ────────────────────────────────────
+  server.tool(
+    'create_carousel',
+    [
+      'Create a new carousel with the given slides.',
+      'Each slide must include templateId, category, label, and content.',
+      'Slide ids are auto-generated (e.g. "slide-abc123") — do not provide them.',
+      'Typical structure: 1 cover slide + several body slides + 1 cta slide.',
+    ].join(' '),
+    {
+      title: z.string().min(1).describe('Carousel title (shown in Studio listings)'),
+      caption: z.string().optional().describe('Optional social-post caption draft'),
+      slides: z
+        .array(slideInputSchema)
+        .min(1)
+        .max(20)
+        .describe('Ordered list of slides (at least 1, max 20)'),
+    },
+    async (params) => {
+      try {
+        const carouselId = uid('carousel');
+        const slides: CarouselSlide[] = params.slides.map((s) => ({
+          id: uid('slide'),
+          templateId: s.templateId,
+          category: s.category,
+          label: s.label,
+          content: s.content,
+          overrides: s.overrides ?? {},
+        }));
+
+        const payload = {
+          id: carouselId,
+          title: params.title,
+          caption: params.caption ?? null,
+          slides,
+        };
+
+        const { data, error } = await sb
+          .from('carousels')
+          .insert(payload)
+          .select()
+          .single();
+        if (error) throw new Error(error.message);
+
+        const row = data as CarouselRow;
+        return ok({
+          message: 'Carousel created',
+          carousel: {
+            id: row.id,
+            title: row.title,
+            caption: row.caption,
+            slide_count: row.slides.length,
+            created_at: row.created_at,
+          },
+        });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+
+  // ── update_carousel ────────────────────────────────────
+  server.tool(
+    'update_carousel',
+    [
+      'Update an existing carousel. Any of title, caption, or slides can be replaced.',
+      'If slides are provided, they REPLACE the existing slides entirely (not merged).',
+      'Each new slide gets a fresh auto-generated id unless one is explicitly passed.',
+    ].join(' '),
+    {
+      id: z.string().describe('Carousel id to update'),
+      title: z.string().optional().describe('New title'),
+      caption: z.string().optional().describe('New caption (pass empty string to clear)'),
+      slides: z
+        .array(slideInputSchema.extend({ id: z.string().optional() }))
+        .optional()
+        .describe('New slides array (replaces existing slides entirely)'),
+    },
+    async (params) => {
+      try {
+        const update: Record<string, unknown> = {
+          updated_at: new Date().toISOString(),
+        };
+        if (params.title !== undefined) update.title = params.title;
+        if (params.caption !== undefined) update.caption = params.caption;
+        if (params.slides) {
+          update.slides = params.slides.map((s: any) => ({
+            id: s.id || uid('slide'),
+            templateId: s.templateId,
+            category: s.category,
+            label: s.label,
+            content: s.content,
+            overrides: s.overrides ?? {},
+          }));
+        }
+
+        const { data, error } = await sb
+          .from('carousels')
+          .update(update)
+          .eq('id', params.id)
+          .select()
+          .single();
+        if (error) throw new Error(error.message);
+
+        const row = data as CarouselRow;
+        return ok({
+          message: 'Carousel updated',
+          carousel: {
+            id: row.id,
+            title: row.title,
+            caption: row.caption,
+            slide_count: row.slides.length,
+            updated_at: row.updated_at,
+          },
+        });
+      } catch (e) {
+        return err(e);
+      }
+    }
+  );
+}

--- a/src/tools/carousels.ts
+++ b/src/tools/carousels.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CMSAdapter } from '../adapters/interface.js';
 
 // ─── Types ────────────────────────────────────────────────
 interface CarouselSlide {
@@ -60,12 +61,34 @@ const slideInputSchema = z.object({
 });
 
 // ─── Registration ─────────────────────────────────────────
+// NOTE: SupabaseAdapter 에 carousel CRUD 메서드가 없어 여기서 raw Supabase
+// client 를 그대로 사용한다. adapter 는 logActivity() 를 통한 감사 추적 용도로만
+//주입. 중장기로는 CMSAdapter 에 carousel 메서드 추가해 adapter 일원화 권장.
 export function registerCarouselTools(
   server: McpServer,
+  adapter: CMSAdapter,
   supabaseUrl: string,
   supabaseKey: string
 ): void {
   const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+  const logCarouselActivity = async (
+    action: 'create' | 'update',
+    itemId: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> => {
+    try {
+      await adapter.logActivity({
+        action,
+        collection: 'carousels',
+        item_id: itemId,
+        actor_type: 'agent',
+        payload,
+      });
+    } catch {
+      // activity 로깅 실패는 tool 실행을 막지 않는다 (best-effort).
+    }
+  };
 
   // ── list_carousels ─────────────────────────────────────
   server.tool(
@@ -168,6 +191,10 @@ export function registerCarouselTools(
         if (error) throw new Error(error.message);
 
         const row = data as CarouselRow;
+        await logCarouselActivity('create', row.id, {
+          title: row.title,
+          slide_count: row.slides.length,
+        });
         return ok({
           message: 'Carousel created',
           carousel: {
@@ -228,6 +255,12 @@ export function registerCarouselTools(
         if (error) throw new Error(error.message);
 
         const row = data as CarouselRow;
+        await logCarouselActivity('update', row.id, {
+          title_changed: params.title !== undefined,
+          caption_changed: params.caption !== undefined,
+          slides_replaced: Array.isArray(params.slides),
+          slide_count: row.slides.length,
+        });
         return ok({
           message: 'Carousel updated',
           carousel: {


### PR DESCRIPTION
## Summary

agentic-cms MCP에 `carousels` 테이블 조작용 도구 4종을 추가합니다. 에이전트가 자연어로 캐러셀을 생성/조회/수정할 수 있게 됩니다.

> 연관 브랜치: [feat/mcp-blog-post-tools (#12)](https://github.com/intellieffect/agentic-cms/pull/12) — 독립적으로 설계되어 서로 간섭 없음. 병합 시 `server.ts`에서 import/register 라인만 trivial하게 충돌 해결.

## 추가된 MCP 도구

| 도구 | 역할 |
|------|------|
| `list_carousels` | 목록 (id, title, caption, slide_count, timestamps). 슬라이드 내용은 제외하여 컨텍스트 절약 |
| `get_carousel` | 단건 조회 (슬라이드 전체 포함) |
| **`create_carousel`** | 새 캐러셀 생성. title + caption + slides[] |
| `update_carousel` | 수정. slides 제공 시 기존 슬라이드 완전 교체 (부분 merge 아님) |

## 설계 선택

- **delete 미제공** — 파괴적 작업은 Studio 대시보드에서 수동 처리하도록 강제
- **id 자동 생성** — 기존 `carousel-store.ts`의 `uid()` 패턴(`carousel-xxxxx`, `slide-xxxxx`) 재현하여 기존 데이터와 일관성 유지
- **template_id 엄격 enum 미사용** — 템플릿 카탈로그가 40+개이고 변경 주기 있음. 백엔드 검증 없이 통과시키고 렌더 단계에서 fallback 처리에 의존 (기존 studio API와 동일한 정책)
- **별도 Supabase 클라이언트** — `CMSAdapter` 인터페이스 확장 없이 blog-posts와 마찬가지로 tool 모듈 안에서 자체 client 생성 → 기존 CMS 도구에 영향 0

## 슬라이드 스키마

\`\`\`ts
{
  templateId: string   // e.g. "cover-bold", "body-text", "cta-question"
  category: 'cover' | 'hook' | 'body' | 'cta'
  label: string
  content: Record<string, unknown>  // 템플릿별 상이
  overrides?: Record<string, unknown>
}
\`\`\`

## Test plan

- [x] TypeScript 빌드 통과 (`npm run build`)
- [x] MCP 서버 기동 + `tools/list`에 신규 4개 노출 확인
- [x] `list_carousels` E2E 호출 → 기존 데이터 2건 정상 반환 확인
- [ ] Claude Code 재시작 후 `create_carousel`로 샘플 캐러셀 생성 E2E
- [ ] Studio(`/carousel/[id]`)에서 생성된 캐러셀 렌더링 검증