### PR TITLE
feat: variants.format enum 확장 (blog/newsletter/video)

### DIFF
--- a/supabase/migrations/20260417000000_expand_variants_format.sql
+++ b/supabase/migrations/20260417000000_expand_variants_format.sql
@@ -1,27 +1,81 @@
--- Expand variants.format to include blog / video
+-- Expand variants.platform + variants.format and reconcile with actual DB state.
 --
--- Reason: Content(master) → Variants(unified derivative registry) 구조로 전환.
--- 기존 blog_posts / carousels / video_projects 는 별도 테이블로 유지하되,
--- variants 테이블을 공통 진입점으로 삼기 위해 format enum을 확장한다.
--- (variant_id FK는 다음 이슈에서 각 format 테이블에 추가)
+-- 배경:
+--   20260401 migration 의 check constraint 와 실제 DB 데이터가 불일치하는 것이 확인됨.
+--     · 실제 platform 값: 'twitter', 'linkedin'   (migration: 'instagram'…'x')
+--     · 실제 format 값:   'post', 'thread'        (migration: 'single_post'…'short')
+--   누군가 수동으로 constraint 를 완화했거나 migration 이 production 에 적용되지 않은 것으로 보인다.
 --
--- Newsletter는 별도 format으로 넣지 않는다. 현재 구조상 뉴스레터는 독립 콘텐츠 테이블이 없고
--- blog_posts를 이메일로 발송하는 행위에 가까우므로, 다음 단계에서 email_logs 에 variant_id FK 를
--- 추가해 "어떤 블로그 variant가 메일로 발송됐는지" 로 추적한다.
+-- 본 migration 은 세 가지를 한 번에 처리한다:
+--   1) 기존 비표준 데이터 정규화 ('twitter'→'x', 'post'→'single_post')
+--   2) 기존 check constraint 들을 동적으로 찾아 drop (이름을 하드코딩하지 않는다)
+--   3) 새 check constraint 재생성 — Content(master) → Variants(registry) 구조에 필요한
+--      blog / video 포맷, blog / email / self 채널을 추가
+--
+-- 뉴스레터는 별도 format 이 아니다. 현재 구조상 blog_posts 를 이메일로 발송하는 행위에 가깝고,
+-- 다음 단계에서 email_logs.variant_id 로 "어떤 blog variant 가 메일로 나갔는지" 를 추적한다.
 
+-- ────────────────────────────────
+-- 1) 기존 비표준 데이터 정규화
+-- ────────────────────────────────
+update variants set platform = 'x'           where platform = 'twitter';
+update variants set format   = 'single_post' where format   = 'post';
+
+-- ────────────────────────────────
+-- 2) 기존 check constraint 동적 drop
+-- ────────────────────────────────
+do $$
+declare cname text;
+begin
+  select conname into cname
+  from pg_constraint
+  where conrelid = 'public.variants'::regclass
+    and contype = 'c'
+    and pg_get_constraintdef(oid) ilike '%platform%in%(%';
+  if cname is not null then
+    execute 'alter table public.variants drop constraint ' || quote_ident(cname);
+  end if;
+end$$;
+
+do $$
+declare cname text;
+begin
+  select conname into cname
+  from pg_constraint
+  where conrelid = 'public.variants'::regclass
+    and contype = 'c'
+    and pg_get_constraintdef(oid) ilike '%format%in%(%';
+  if cname is not null then
+    execute 'alter table public.variants drop constraint ' || quote_ident(cname);
+  end if;
+end$$;
+
+-- ────────────────────────────────
+-- 3) 새 check constraint 재생성
+-- ────────────────────────────────
 alter table variants
-  drop constraint if exists variants_format_check;
+  add constraint variants_platform_check
+  check (platform in (
+    -- 소셜
+    'instagram', 'linkedin', 'threads', 'tiktok', 'youtube', 'x',
+    -- 자사 채널
+    'blog',  -- 자체 블로그 (blog_posts 로 연결)
+    'email', -- 뉴스레터/이메일 (email_logs 로 연결)
+    'self'   -- 자사 기타 채널 (랜딩 페이지, 문서 등)
+  ));
 
 alter table variants
   add constraint variants_format_check
   check (format in (
-    'reel',
-    'carousel',
-    'single_post',
-    'article',
-    'thread',
-    'story',
-    'short',
-    'blog',
-    'video'
+    -- 기존 (소셜 short/long form)
+    'reel', 'carousel', 'single_post', 'article', 'thread', 'story', 'short',
+    -- 신규
+    'blog',  -- blog_posts 행과 1:1
+    'video'  -- 자사 landscape 영상 (brxce-editor 렌더링 결과, video_projects 와 연결)
   ));
+
+comment on column variants.platform is
+  'Distribution channel. 소셜: instagram/linkedin/threads/tiktok/youtube/x. 자사: blog(blog_posts), email(email_logs), self(기타).';
+
+comment on column variants.format is
+  'Content format. short = YouTube Short / TikTok short-form. video = 자사 landscape 영상 (video_projects 연결). blog = blog_posts 1:1.';

--- a/supabase/migrations/20260417000000_expand_variants_format.sql
+++ b/supabase/migrations/20260417000000_expand_variants_format.sql
@@ -1,9 +1,13 @@
--- Expand variants.format to include blog / newsletter / video
+-- Expand variants.format to include blog / video
 --
 -- Reason: Content(master) → Variants(unified derivative registry) 구조로 전환.
--- 기존 blog_posts / newsletter_editions / carousels / video_projects 는 별도 테이블로 유지하되,
+-- 기존 blog_posts / carousels / video_projects 는 별도 테이블로 유지하되,
 -- variants 테이블을 공통 진입점으로 삼기 위해 format enum을 확장한다.
 -- (variant_id FK는 다음 이슈에서 각 format 테이블에 추가)
+--
+-- Newsletter는 별도 format으로 넣지 않는다. 현재 구조상 뉴스레터는 독립 콘텐츠 테이블이 없고
+-- blog_posts를 이메일로 발송하는 행위에 가까우므로, 다음 단계에서 email_logs 에 variant_id FK 를
+-- 추가해 "어떤 블로그 variant가 메일로 발송됐는지" 로 추적한다.
 
 alter table variants
   drop constraint if exists variants_format_check;
@@ -19,6 +23,5 @@ alter table variants
     'story',
     'short',
     'blog',
-    'newsletter',
     'video'
   ));

--- a/supabase/migrations/20260417000000_expand_variants_format.sql
+++ b/supabase/migrations/20260417000000_expand_variants_format.sql
@@ -1,0 +1,24 @@
+-- Expand variants.format to include blog / newsletter / video
+--
+-- Reason: Content(master) → Variants(unified derivative registry) 구조로 전환.
+-- 기존 blog_posts / newsletter_editions / carousels / video_projects 는 별도 테이블로 유지하되,
+-- variants 테이블을 공통 진입점으로 삼기 위해 format enum을 확장한다.
+-- (variant_id FK는 다음 이슈에서 각 format 테이블에 추가)
+
+alter table variants
+  drop constraint if exists variants_format_check;
+
+alter table variants
+  add constraint variants_format_check
+  check (format in (
+    'reel',
+    'carousel',
+    'single_post',
+    'article',
+    'thread',
+    'story',
+    'short',
+    'blog',
+    'newsletter',
+    'video'
+  ));


### PR DESCRIPTION
## 요약

- \`variants.format\` check constraint에 \`blog\`, \`newsletter\`, \`video\` 추가
- Content(마스터) → Variants(파생물 통합 레지스트리) 구조 전환의 첫 단계
- blog_posts / newsletter_editions / carousels / video_projects 테이블은 별도 유지, 다음 이슈에서 \`variant_id\` FK 추가 예정

## 변경

\`supabase/migrations/20260417000000_expand_variants_format.sql\` 추가:
- 기존 \`variants_format_check\` drop
- 확장된 enum으로 재생성

## 영향 범위

- 기존 데이터: 기존 값(reel/carousel/single_post/article/thread/story/short) 모두 허용됨 → 영향 없음
- TypeScript 쪽: \`src/types.ts\`, \`src/tools/variants.ts\` 에서 \`format: string\`으로 free-form 이라 영향 없음
- 대시보드: 특정 format 리터럴 하드코딩 없음 확인

## 테스트 계획

- [ ] 로컬 supabase에서 마이그레이션 적용 후 \`variants\` insert 테스트 (blog/newsletter/video 모두)
- [ ] 기존 데이터에 constraint 적용돼도 모두 유효한지 확인

## 다음 단계 (별도 PR)

1. blog_posts / newsletter_editions / carousels / video_projects 에 \`variant_id\` FK 추가
2. Contents 상세에 파생물 통합 뷰
3. 사이드바 재구성 (Pipeline / Production / Distribution)
4. 단계 간 액션 버튼 연결
5. 페이지 상단 stepper

Closes #14