### PR TITLE
feat: format별 테이블에 variant_id FK 추가

### DIFF
--- a/supabase/migrations/20260417000001_add_variant_id_fks.sql
+++ b/supabase/migrations/20260417000001_add_variant_id_fks.sql
@@ -1,0 +1,27 @@
+-- Link format-specific detail tables to the unified variants registry.
+--
+-- Reason: Content(master) → Variants(unified derivative registry) 구조 전환.
+-- blog_posts / carousels / video_projects 는 각자 독립 테이블로 유지하고,
+-- variants 테이블이 "파생물 레지스트리" 역할을 하도록 각 테이블에 variant_id FK 를 건다.
+--
+-- email_logs 는 뉴스레터 발송 배치. 뉴스레터를 별도 format 으로 두는 대신
+-- format=blog 인 variant 를 이메일로 보냈다는 관계로 추적한다.
+--
+-- 전 컬럼 NULL 허용: 기존 데이터(blog_posts 17행 등)는 variant 없이도 유효해야 하므로.
+
+alter table blog_posts
+  add column if not exists variant_id uuid references variants(id) on delete set null;
+
+alter table carousels
+  add column if not exists variant_id uuid references variants(id) on delete set null;
+
+alter table video_projects
+  add column if not exists variant_id uuid references variants(id) on delete set null;
+
+alter table email_logs
+  add column if not exists variant_id uuid references variants(id) on delete set null;
+
+create index if not exists idx_blog_posts_variant_id on blog_posts(variant_id);
+create index if not exists idx_carousels_variant_id on carousels(variant_id);
+create index if not exists idx_video_projects_variant_id on video_projects(variant_id);
+create index if not exists idx_email_logs_variant_id on email_logs(variant_id);

--- a/supabase/migrations/20260417000001_add_variant_id_fks.sql
+++ b/supabase/migrations/20260417000001_add_variant_id_fks.sql
@@ -6,8 +6,14 @@
 --
 -- email_logs 는 뉴스레터 발송 배치. 뉴스레터를 별도 format 으로 두는 대신
 -- format=blog 인 variant 를 이메일로 보냈다는 관계로 추적한다.
+-- email_logs 는 "같은 variant 를 여러 번 발송" 가능하므로 1:N 관계 (UNIQUE 제약 없음).
 --
--- 전 컬럼 NULL 허용: 기존 데이터(blog_posts 17행 등)는 variant 없이도 유효해야 하므로.
+-- blog_posts / carousels / video_projects 는 "1 variant = 1 상세 레코드" 인 1:1 관계:
+--   같은 variant 가 두 개의 blog_post 에 연결되는 것은 의미상 잘못됨.
+--   partial UNIQUE index 로 NULL 은 중복 허용 + NOT NULL 값만 유일성 강제.
+--
+-- 전 컬럼 NULL 허용: 기존 데이터(blog_posts 17행 등) 는 variant 없이도 유효해야 하므로.
+-- backfill(기존 레코드를 variants 에 역 매핑) 은 별도 이슈에서 수동/에이전트 작업으로 진행.
 
 alter table blog_posts
   add column if not exists variant_id uuid references variants(id) on delete set null;
@@ -21,7 +27,18 @@ alter table video_projects
 alter table email_logs
   add column if not exists variant_id uuid references variants(id) on delete set null;
 
-create index if not exists idx_blog_posts_variant_id on blog_posts(variant_id);
-create index if not exists idx_carousels_variant_id on carousels(variant_id);
-create index if not exists idx_video_projects_variant_id on video_projects(variant_id);
+-- 1:1 관계 (variant ↔ 상세 레코드). NULL 중복은 partial index 로 허용.
+create unique index if not exists uq_blog_posts_variant_id
+  on blog_posts(variant_id)
+  where variant_id is not null;
+
+create unique index if not exists uq_carousels_variant_id
+  on carousels(variant_id)
+  where variant_id is not null;
+
+create unique index if not exists uq_video_projects_variant_id
+  on video_projects(variant_id)
+  where variant_id is not null;
+
+-- 1:N 관계. non-unique index 만 추가.
 create index if not exists idx_email_logs_variant_id on email_logs(variant_id);


### PR DESCRIPTION
## 요약

- `blog_posts`, `carousels`, `video_projects`, `email_logs` 에 `variant_id uuid` FK 추가
- Content(마스터) → Variants(파생물 통합 레지스트리) 구조의 두 번째 단계
- #15 의 format enum 확장과 짝을 이룬다

## 변경

`supabase/migrations/20260417000001_add_variant_id_fks.sql` 추가:

\`\`\`sql
alter table blog_posts      add column variant_id uuid references variants(id) on delete set null;
alter table carousels       add column variant_id uuid references variants(id) on delete set null;
alter table video_projects  add column variant_id uuid references variants(id) on delete set null;
alter table email_logs      add column variant_id uuid references variants(id) on delete set null;

-- + 인덱스 4개
\`\`\`

## 설계 근거

| 테이블 | 왜 variant_id 를 거나 |
|---|---|
| blog_posts | format=blog variant 의 실제 본문 저장소 |
| carousels | format=carousel variant 의 슬라이드 데이터 |
| video_projects | format=video 또는 reel/short variant 의 렌더 프로젝트 |
| email_logs | 뉴스레터 발송 배치. format=blog variant 가 메일로 나갔다는 관계를 기록 |

## 영향 범위

- 기존 데이터: 모두 NULLABLE 이므로 기존 17개 blog_posts 등에 영향 없음
- 삭제 정책: `on delete set null` — variant 삭제돼도 원본 데이터 보존
- 대시보드 코드: 이번 PR 범위 밖 (Step 3에서 UI 연결)

## 테스트 계획

- [ ] 로컬 supabase 에서 마이그레이션 적용
- [ ] 기존 blog_posts/carousels/video_projects/email_logs 조회 정상 (variant_id = null)
- [ ] variants 생성 후 blog_posts.variant_id 로 연결 → JOIN 정상
- [ ] variant 삭제 시 관련 테이블 variant_id 가 null 로 세팅되는지

## 의존성

#15 (format enum 확장) 머지 후 이 PR 머지 권장.
SQL 자체는 독립 실행 가능하지만, variant 생성 시 format='blog'/'video' 를 쓸 수 있으려면 #15 가 먼저.

## 다음 단계

- Step 3: Contents 상세 페이지에 파생물 통합 뷰 (blog/carousel/video/social 카드)
- Step 4: 사이드바 재구성
- Step 5: 페이지 간 액션 버튼 연결
- Step 6: 파이프라인 stepper

Closes #16