### PR TITLE
feat: GA4 CTA 커스텀 차원(cta_id) + GSC 국가/기기 분석

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -6,6 +6,8 @@ NEXT_PUBLIC_EDITOR_API_URL=http://localhost:8092
 EDITOR_API_DIR=/path/to/brxce-editor
 
 # GA4 / GSC analytics
+# 서비스 계정 키 JSON 전체를 한 줄로. private_key 안의 실제 개행은 \n 으로 escape 필요.
+# 예: {"type":"service_account","project_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n"}
 GOOGLE_SERVICE_ACCOUNT_KEY={"type":"service_account","project_id":"...","private_key":"..."}
 
 # Blog / Newsletter

--- a/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
+++ b/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
@@ -397,6 +397,8 @@ interface GSCData {
   queries: { query: string; clicks: number; impressions: number; ctr: number; position: number }[];
   pages: { page: string; clicks: number; impressions: number; ctr: number; position: number }[];
   daily: { date: string; clicks: number; impressions: number }[];
+  countries?: { country: string; clicks: number; impressions: number; ctr: number; position: number }[];
+  devices?: { device: string; clicks: number; impressions: number; ctr: number; position: number }[];
 }
 
 function GSCTab() {
@@ -404,7 +406,7 @@ function GSCTab() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [days, setDays] = useState<Period>(7);
-  const [view, setView] = useState<"queries" | "pages">("queries");
+  const [view, setView] = useState<"queries" | "pages" | "countries" | "devices">("queries");
 
   useEffect(() => {
     let cancelled = false;
@@ -478,7 +480,7 @@ function GSCTab() {
         )}
       </div>
       <div className="flex gap-1">
-        {([["queries", "검색어"], ["pages", "페이지"]] as const).map(([key, label]) => (
+        {([["queries", "검색어"], ["pages", "페이지"], ["countries", "국가"], ["devices", "기기"]] as const).map(([key, label]) => (
           <button key={key} onClick={() => setView(key)} className={`px-3 py-1 rounded text-xs font-medium transition-colors ${view === key ? "bg-[#333] text-white" : "text-[#888] hover:text-white"}`}>{label}</button>
         ))}
       </div>
@@ -486,7 +488,7 @@ function GSCTab() {
         <table className="w-full text-xs">
           <thead>
             <tr className="border-b border-[#222] text-[#888]">
-              <th className="px-4 py-3 text-left">{view === "queries" ? "검색어" : "페이지"}</th>
+              <th className="px-4 py-3 text-left">{view === "queries" ? "검색어" : view === "pages" ? "페이지" : view === "countries" ? "국가" : "기기"}</th>
               <th className="px-4 py-3 text-right">클릭</th>
               <th className="px-4 py-3 text-right">노출</th>
               <th className="px-4 py-3 text-right">CTR</th>
@@ -494,18 +496,29 @@ function GSCTab() {
             </tr>
           </thead>
           <tbody>
-            {(view === "queries" ? data.queries : data.pages).map((r) => {
-              const label = view === "queries" ? (r as GSCData["queries"][0]).query : (r as GSCData["pages"][0]).page;
-              return (
-                <tr key={label} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
-                  <td className="px-4 py-2 text-[#ccc] max-w-[300px] truncate">{label}</td>
-                  <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.clicks)}</td>
-                  <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.impressions)}</td>
-                  <td className="px-4 py-2 text-right text-[#4ECDC4]">{(r.ctr * 100).toFixed(1)}%</td>
-                  <td className="px-4 py-2 text-right text-[#888]">{r.position.toFixed(1)}</td>
-                </tr>
-              );
-            })}
+            {(() => {
+              const rows =
+                view === "queries" ? data.queries :
+                view === "pages" ? data.pages :
+                view === "countries" ? (data.countries ?? []) :
+                (data.devices ?? []);
+              return rows.map((r) => {
+                const label =
+                  view === "queries" ? (r as GSCData["queries"][0]).query :
+                  view === "pages" ? (r as GSCData["pages"][0]).page :
+                  view === "countries" ? ((r as NonNullable<GSCData["countries"]>[0]).country) :
+                  ((r as NonNullable<GSCData["devices"]>[0]).device);
+                return (
+                  <tr key={label} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
+                    <td className="px-4 py-2 text-[#ccc] max-w-[300px] truncate">{label}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.clicks)}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.impressions)}</td>
+                    <td className="px-4 py-2 text-right text-[#4ECDC4]">{(r.ctr * 100).toFixed(1)}%</td>
+                    <td className="px-4 py-2 text-right text-[#888]">{r.position.toFixed(1)}</td>
+                  </tr>
+                );
+              });
+            })()}
           </tbody>
         </table>
       </div>

--- a/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
+++ b/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
@@ -392,6 +392,32 @@ function GA4Tab() {
 }
 
 /* ─── GSC Tab ─── */
+
+// GSC 는 country 를 ISO 3166 alpha-3 소문자 (예: "kor", "usa") 로 반환.
+// 자주 나올 만한 국가만 한국어로 매핑하고 그 외는 원본 코드 유지.
+const COUNTRY_NAME_KO: Record<string, string> = {
+  kor: "대한민국", usa: "미국", jpn: "일본", chn: "중국", hkg: "홍콩", twn: "대만",
+  vnm: "베트남", tha: "태국", idn: "인도네시아", phl: "필리핀", mys: "말레이시아",
+  sgp: "싱가포르", ind: "인도", gbr: "영국", deu: "독일", fra: "프랑스", ita: "이탈리아",
+  esp: "스페인", nld: "네덜란드", swe: "스웨덴", nor: "노르웨이", fin: "핀란드",
+  pol: "폴란드", ukr: "우크라이나", rus: "러시아", tur: "튀르키예", can: "캐나다",
+  mex: "멕시코", bra: "브라질", arg: "아르헨티나", aus: "호주", nzl: "뉴질랜드",
+  are: "아랍에미리트", sau: "사우디아라비아", zaf: "남아프리카공화국", egy: "이집트",
+};
+const formatCountry = (code: string): string => {
+  const key = code.toLowerCase();
+  const name = COUNTRY_NAME_KO[key];
+  return name ? `${name} (${key.toUpperCase()})` : key.toUpperCase();
+};
+
+// GSC 는 device 를 대문자 (DESKTOP / MOBILE / TABLET) 로 반환.
+const DEVICE_NAME_KO: Record<string, string> = {
+  DESKTOP: "데스크톱",
+  MOBILE: "모바일",
+  TABLET: "태블릿",
+};
+const formatDevice = (code: string): string => DEVICE_NAME_KO[code.toUpperCase()] ?? code;
+
 interface GSCData {
   overview: { totalClicks: number; totalImpressions: number; avgCtr: number; avgPosition: number };
   queries: { query: string; clicks: number; impressions: number; ctr: number; position: number }[];
@@ -503,13 +529,17 @@ function GSCTab() {
                 view === "countries" ? (data.countries ?? []) :
                 (data.devices ?? []);
               return rows.map((r) => {
-                const label =
+                const rawKey =
                   view === "queries" ? (r as GSCData["queries"][0]).query :
                   view === "pages" ? (r as GSCData["pages"][0]).page :
                   view === "countries" ? ((r as NonNullable<GSCData["countries"]>[0]).country) :
                   ((r as NonNullable<GSCData["devices"]>[0]).device);
+                const label =
+                  view === "countries" ? formatCountry(rawKey) :
+                  view === "devices" ? formatDevice(rawKey) :
+                  rawKey;
                 return (
-                  <tr key={label} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
+                  <tr key={rawKey} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
                     <td className="px-4 py-2 text-[#ccc] max-w-[300px] truncate">{label}</td>
                     <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.clicks)}</td>
                     <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.impressions)}</td>

--- a/dashboard/src/app/api/analytics/ga4/route.ts
+++ b/dashboard/src/app/api/analytics/ga4/route.ts
@@ -4,11 +4,18 @@ import { google } from "googleapis";
 const PROPERTY_ID = "530816613";
 
 async function getClient() {
-  if (!process.env.GOOGLE_SERVICE_ACCOUNT_KEY) {
+  const raw = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+  if (!raw) {
     throw new Error("GOOGLE_SERVICE_ACCOUNT_KEY environment variable is not set");
   }
+  let credentials;
+  try {
+    credentials = JSON.parse(raw.replace(/\n/g, '\\n'));
+  } catch {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_KEY is not valid JSON");
+  }
   const auth = new google.auth.GoogleAuth({
-    credentials: JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_KEY.replace(/\n/g, '\\n')),
+    credentials,
     scopes: ["https://www.googleapis.com/auth/analytics.readonly"],
   });
   return google.analyticsdata({ version: "v1beta", auth });
@@ -30,7 +37,7 @@ export async function GET(req: NextRequest) {
       "page_not_found", "outbound_click",
     ];
 
-    const [overviewRes, pagesRes, sourcesRes, dailyRes, eventsRes] = await Promise.all([
+    const [overviewRes, pagesRes, sourcesRes, dailyRes, eventsRes, ctaRes] = await Promise.all([
       client.properties.runReport({
         property: `properties/${PROPERTY_ID}`,
         requestBody: {
@@ -102,6 +109,22 @@ export async function GET(req: NextRequest) {
           orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
         },
       }),
+      // CTA별 클릭 수 (커스텀 차원 등록됨)
+      client.properties.runReport({
+        property: `properties/${PROPERTY_ID}`,
+        requestBody: {
+          dateRanges: [{ startDate, endDate: "today" }],
+          dimensions: [{ name: "customEvent:cta_id" }],
+          metrics: [{ name: "eventCount" }],
+          dimensionFilter: {
+            filter: {
+              fieldName: "eventName",
+              stringFilter: { value: "cta_click" },
+            },
+          },
+          orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+        },
+      }),
     ]);
 
     const ov = overviewRes.data.rows?.[0]?.metricValues || [];
@@ -168,10 +191,11 @@ export async function GET(req: NextRequest) {
       logins: get("login"),
     };
 
-    // CTA 클릭 — cta_id별 분석은 GA4 커스텀 차원 등록 후 가능, 현재는 총 클릭수만
-    const ctaClicks: { ctaId: string; count: number }[] = [];
-    const ctaTotal = get("cta_click");
-    if (ctaTotal > 0) ctaClicks.push({ ctaId: "total", count: ctaTotal });
+    // CTA 클릭 — cta_id별 분석 (GA4 커스텀 차원 등록됨)
+    const ctaClicks = (ctaRes.data.rows || []).map((r) => ({
+      ctaId: r.dimensionValues?.[0]?.value || "",
+      count: Number(r.metricValues?.[0]?.value || 0),
+    }));
 
     return NextResponse.json({ overview, pages, sources, daily, events, conversions, ctaClicks });
   } catch (e: unknown) {

--- a/dashboard/src/app/api/analytics/gsc/route.ts
+++ b/dashboard/src/app/api/analytics/gsc/route.ts
@@ -4,11 +4,18 @@ import { google } from "googleapis";
 const SITE_URL = "https://agenticworkflows.club";
 
 async function getClient() {
-  if (!process.env.GOOGLE_SERVICE_ACCOUNT_KEY) {
+  const raw = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+  if (!raw) {
     throw new Error("GOOGLE_SERVICE_ACCOUNT_KEY environment variable is not set");
   }
+  let credentials;
+  try {
+    credentials = JSON.parse(raw.replace(/\n/g, '\\n'));
+  } catch {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_KEY is not valid JSON");
+  }
   const auth = new google.auth.GoogleAuth({
-    credentials: JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_KEY.replace(/\n/g, '\\n')),
+    credentials,
     scopes: ["https://www.googleapis.com/auth/webmasters.readonly"],
   });
   return google.searchconsole({ version: "v1", auth });
@@ -28,7 +35,7 @@ export async function GET(req: NextRequest) {
   try {
     const client = await getClient();
 
-    const [queriesRes, pagesRes, dailyRes] = await Promise.all([
+    const [queriesRes, pagesRes, dailyRes, countriesRes, devicesRes] = await Promise.all([
       client.searchanalytics.query({
         siteUrl: SITE_URL,
         requestBody: {
@@ -53,6 +60,23 @@ export async function GET(req: NextRequest) {
           startDate: formatDate(startDate),
           endDate: formatDate(endDate),
           dimensions: ["date"],
+        },
+      }),
+      client.searchanalytics.query({
+        siteUrl: SITE_URL,
+        requestBody: {
+          startDate: formatDate(startDate),
+          endDate: formatDate(endDate),
+          dimensions: ["country"],
+          rowLimit: 20,
+        },
+      }),
+      client.searchanalytics.query({
+        siteUrl: SITE_URL,
+        requestBody: {
+          startDate: formatDate(startDate),
+          endDate: formatDate(endDate),
+          dimensions: ["device"],
         },
       }),
     ]);
@@ -87,11 +111,29 @@ export async function GET(req: NextRequest) {
         ? queries.reduce((s, q) => s + q.position, 0) / queries.length
         : 0;
 
+    const countries = (countriesRes.data.rows || []).map((r) => ({
+      country: r.keys?.[0] || "",
+      clicks: r.clicks || 0,
+      impressions: r.impressions || 0,
+      ctr: r.ctr || 0,
+      position: r.position || 0,
+    }));
+
+    const devices = (devicesRes.data.rows || []).map((r) => ({
+      device: r.keys?.[0] || "",
+      clicks: r.clicks || 0,
+      impressions: r.impressions || 0,
+      ctr: r.ctr || 0,
+      position: r.position || 0,
+    }));
+
     return NextResponse.json({
       overview: { totalClicks, totalImpressions, avgCtr, avgPosition },
       queries,
       pages,
       daily,
+      countries,
+      devices,
     });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Unknown error";

--- a/dashboard/src/app/api/analytics/gsc/route.ts
+++ b/dashboard/src/app/api/analytics/gsc/route.ts
@@ -77,6 +77,7 @@ export async function GET(req: NextRequest) {
           startDate: formatDate(startDate),
           endDate: formatDate(endDate),
           dimensions: ["device"],
+          rowLimit: 10,
         },
       }),
     ]);


### PR DESCRIPTION
## 요약

PR #5 (feat/traffic-analytics) 의 순수 delta 만 최신 main 기준으로 재적용.
원 브랜치는 오래돼 main 과 7 파일 충돌 (package/analytics/sidebar 등) 발생해
rebase 대신 main 기반 새 브랜치로 이식.

## 변경

- **GA4 CTA 커스텀 차원** (`dashboard/src/app/api/analytics/ga4/route.ts`)
  · `customEvent:cta_id` 차원 쿼리 추가
  · `ctaClicks` 응답을 cta_id 별로 분해 (기존: `{ctaId:"total", count}` 하나)

- **GSC 국가/기기 분석** (`dashboard/src/app/api/analytics/gsc/route.ts`)
  · `country`, `device` 차원 쿼리 추가
  · 응답에 `countries`, `devices` 배열 포함

- **GSC 탭 UI 확장** (`dashboard/src/app/(dashboard)/analytics/traffic/page.tsx`)
  · view 토글에 "국가" / "기기" 추가

- **JSON.parse 에러 개선 (안전성)** (ga4 + gsc)
  · getClient 의 JSON.parse 를 try/catch 로 감싸서 parse 실패 시 친절한 메시지
  · env 값 일부가 에러 메시지에 섞여 나올 가능성 차단

- **`.env.example` 주석** — private_key \\n escape 규칙 안내

## 이전 PR 과의 관계

- PR #5 는 close 예정 (main 과의 충돌 과다 + 내용 대부분 여기로 이식됨)
- PR #5 의 대규모 파일 변경(package/e2e 세팅 등) 중 이식해야 할 부분은 없음
  → main 의 후속 커밋들로 이미 대체/추가됨

## 테스트 계획

- [ ] GA4 에 cta_click 이벤트가 있는 기간 조회 → ctaClicks 에 cta_id 별 분해되는지 확인
- [ ] GSC API 로 countries/devices 데이터 조회 정상
- [ ] 트래픽 페이지 GSC 탭에서 국가/기기 view 토글 렌더링
- [ ] GOOGLE_SERVICE_ACCOUNT_KEY 가 잘못된 JSON 이면 "is not valid JSON" 에러

## 영향 범위

- TypeScript 타입체크 통과 확인
- package.json / deps 변경 없음 (googleapis 이미 main 에 있음)