### PR TITLE
feat(contents): 상세 페이지에 Variants & Derivatives 섹션 추가

### DIFF
--- a/dashboard/src/app/(dashboard)/contents/[id]/content-detail-view.tsx
+++ b/dashboard/src/app/(dashboard)/contents/[id]/content-detail-view.tsx
@@ -49,12 +49,25 @@ interface ContentDetailViewProps {
 
 // 각 format 별 스튜디오/상세 페이지 링크 + 아이콘 구성.
 // 데이터 없으면 (variant 만 있고 파생 레코드 없으면) link 는 null 로 두고 "아직 제작 안 됨"으로 표기.
+//
+// 전제: blog_posts / carousels / video_projects 에 걸린 partial UNIQUE index 로
+// 한 variant 에는 최대 하나의 파생 레코드만 붙는다. 따라서 아래 if 체인은 우선순위가 아니라
+// "있으면 하나"의 분기 — 만약 둘 이상 연결되는 사례가 보인다면 DB 무결성을 먼저 점검할 것.
+// 진단 편의를 위해 그런 상황이면 개발 모드에서 console.warn.
 function getDerivativeAction(variant: VariantWithDerivatives): {
   icon: typeof PenSquareIcon;
   label: string;
   href: string | null;
   status: string | null;
 } {
+  if (process.env.NODE_ENV !== "production") {
+    const linked = [variant.blog_post, variant.carousel, variant.video_project].filter(Boolean).length;
+    if (linked > 1) {
+      console.warn(
+        `[Variant ${variant.id}] 하나의 variant 에 여러 파생 레코드가 연결됨 (${linked} 개). 1:1 UNIQUE 위반 가능.`
+      );
+    }
+  }
   if (variant.blog_post) {
     return {
       icon: PenSquareIcon,

--- a/dashboard/src/app/(dashboard)/contents/[id]/content-detail-view.tsx
+++ b/dashboard/src/app/(dashboard)/contents/[id]/content-detail-view.tsx
@@ -12,8 +12,14 @@ import {
   SendIcon,
   FileTextIcon,
   Loader2Icon,
+  PenSquareIcon,
+  LayersIcon,
+  VideoIcon,
+  MailIcon,
+  SplitIcon,
+  ArrowRightIcon,
 } from "lucide-react";
-import type { Content, Revision, Publication } from "@/lib/types";
+import type { Content, Revision, Publication, VariantWithDerivatives } from "@/lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -38,9 +44,62 @@ interface ContentDetailViewProps {
   content: Content;
   revisions: Revision[];
   publications: Publication[];
+  variants: VariantWithDerivatives[];
 }
 
-export function ContentDetailView({ content, revisions, publications }: ContentDetailViewProps) {
+// 각 format 별 스튜디오/상세 페이지 링크 + 아이콘 구성.
+// 데이터 없으면 (variant 만 있고 파생 레코드 없으면) link 는 null 로 두고 "아직 제작 안 됨"으로 표기.
+function getDerivativeAction(variant: VariantWithDerivatives): {
+  icon: typeof PenSquareIcon;
+  label: string;
+  href: string | null;
+  status: string | null;
+} {
+  if (variant.blog_post) {
+    return {
+      icon: PenSquareIcon,
+      label: `Blog: ${variant.blog_post.title}`,
+      href: `/blog-manage/${variant.blog_post.id}`,
+      status: variant.blog_post.status,
+    };
+  }
+  if (variant.carousel) {
+    return {
+      icon: LayersIcon,
+      label: `Carousel: ${variant.carousel.title}`,
+      href: `/carousel/${variant.carousel.id}`,
+      status: null,
+    };
+  }
+  if (variant.video_project) {
+    return {
+      icon: VideoIcon,
+      label: `Video: ${variant.video_project.name}`,
+      href: `/video/projects`,
+      status: variant.video_project.status,
+    };
+  }
+  // 파생 레코드 아직 없음 — format 기반 fallback
+  const fallbackByFormat: Record<string, { icon: typeof PenSquareIcon; label: string; href: string | null }> = {
+    blog: { icon: PenSquareIcon, label: "Blog (아직 생성 안 됨)", href: "/blog-manage" },
+    carousel: { icon: LayersIcon, label: "Carousel (아직 생성 안 됨)", href: "/carousel" },
+    video: { icon: VideoIcon, label: "Video (아직 생성 안 됨)", href: "/video/projects" },
+    reel: { icon: VideoIcon, label: "Reel (아직 생성 안 됨)", href: "/video/projects" },
+    short: { icon: VideoIcon, label: "Short (아직 생성 안 됨)", href: "/video/projects" },
+  };
+  const fb = fallbackByFormat[variant.format];
+  if (fb) {
+    return { ...fb, status: null };
+  }
+  return {
+    icon: SplitIcon,
+    label: `${variant.platform} ${variant.format}`,
+    href: null,
+    status: null,
+  };
+}
+
+export function ContentDetailView({ content, revisions, publications, variants }: ContentDetailViewProps) {
   const [showPreview, setShowPreview] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [selectedRevision, setSelectedRevision] = useState<string | null>(null);
@@ -228,6 +287,84 @@ export function ContentDetailView({ content, revisions, publications }: ContentD
                   rows={16}
                   className="font-mono text-sm"
                 />
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Variants & Derivatives — 이 마스터에서 파생된 모든 포맷 */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="text-base">
+                Variants & Derivatives
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  {variants.length}
+                </span>
+              </CardTitle>
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/variants?content_id=${content.id}`}>
+                  <SplitIcon className="mr-1.5 h-3.5 w-3.5" />
+                  Manage Variants
+                </Link>
+              </Button>
+            </CardHeader>
+            <CardContent>
+              {variants.length === 0 ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">
+                  아직 파생물이 없습니다. 상단의{" "}
+                  <Link href={`/variants?content_id=${content.id}`} className="text-info underline">
+                    → Generate Variants
+                  </Link>{" "}
+                  로 포맷별 파생을 시작하세요.
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {variants.map((variant) => {
+                    const action = getDerivativeAction(variant);
+                    const Icon = action.icon;
+                    return (
+                      <div
+                        key={variant.id}
+                        className="flex items-center justify-between gap-3 rounded-lg border border-border p-3 hover:bg-muted/30 transition-colors"
+                      >
+                        <div className="flex items-center gap-3 min-w-0">
+                          <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2">
+                              <Badge variant="outline" className="text-xs uppercase">
+                                {variant.platform}
+                              </Badge>
+                              <Badge variant="outline" className="text-xs">
+                                {variant.format}
+                              </Badge>
+                              <Badge
+                                variant={variant.status === "published" ? "success" : variant.status === "ready" ? "info" : "secondary"}
+                                className="text-xs"
+                              >
+                                {variant.status}
+                              </Badge>
+                              {variant.emails.length > 0 && (
+                                <Badge variant="outline" className="text-xs">
+                                  <MailIcon className="mr-1 h-3 w-3" />
+                                  {variant.emails.length} 발송
+                                </Badge>
+                              )}
+                            </div>
+                            <p className="mt-1 text-sm truncate text-foreground">{action.label}</p>
+                          </div>
+                        </div>
+                        {action.href ? (
+                          <Button asChild variant="ghost" size="sm">
+                            <Link href={action.href}>
+                              <ArrowRightIcon className="h-3.5 w-3.5" />
+                            </Link>
+                          </Button>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">파생 링크 없음</span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
               )}
             </CardContent>
           </Card>

--- a/dashboard/src/app/(dashboard)/contents/[id]/content-detail-view.tsx
+++ b/dashboard/src/app/(dashboard)/contents/[id]/content-detail-view.tsx
@@ -366,9 +366,10 @@ export function ContentDetailView({ content, revisions, publications, variants }
                           </div>
                         </div>
                         {action.href ? (
-                          <Button asChild variant="ghost" size="sm">
+                          <Button asChild variant="ghost" size="sm" aria-label={`열기: ${action.label}`}>
                             <Link href={action.href}>
-                              <ArrowRightIcon className="h-3.5 w-3.5" />
+                              <ArrowRightIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                              <span className="sr-only">{action.label}</span>
                             </Link>
                           </Button>
                         ) : (

--- a/dashboard/src/app/(dashboard)/contents/[id]/page.tsx
+++ b/dashboard/src/app/(dashboard)/contents/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { Main } from "@/components/layout/main";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getContentById, getRevisions, getPublications } from "@/lib/queries";
+import { getContentById, getRevisions, getPublications, getVariantsWithDerivatives } from "@/lib/queries";
 import { ContentDetailView } from "./content-detail-view";
 
 interface PageProps {
@@ -12,10 +12,11 @@ interface PageProps {
 }
 
 async function ContentData({ id }: { id: string }) {
-  const [content, revisions, allPublications] = await Promise.all([
+  const [content, revisions, allPublications, variants] = await Promise.all([
     getContentById(id),
     getRevisions(id),
     getPublications(),
+    getVariantsWithDerivatives(id),
   ]);
 
   if (!content) notFound();
@@ -27,6 +28,7 @@ async function ContentData({ id }: { id: string }) {
       content={content}
       revisions={revisions}
       publications={publications}
+      variants={variants}
     />
   );
 }

--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -102,27 +102,39 @@ export async function getVariantsWithDerivatives(
     sb.from("email_logs").select("id, subject, status, sent_at, sent_to_count, variant_id").in("variant_id", variantIds),
   ]);
 
-  // 4개 파생 쿼리 에러는 각각 throw. RLS / 테이블명 오타 같은 장애를 silent ignore
-  // 하지 않기 위함 (Promise.all 은 reject 를 그대로 던지지 않고 data/error 객체만 반환).
-  if (blogsRes.error) throw blogsRes.error;
-  if (carouselsRes.error) throw carouselsRes.error;
-  if (videosRes.error) throw videosRes.error;
-  if (emailsRes.error) throw emailsRes.error;
+  // 파생 쿼리 에러 처리:
+  //   - "variant_id 컬럼이 존재하지 않음"(PG 42703) 은 #17 마이그레이션이 아직 실제 DB 에
+  //     적용되지 않은 transitional 상태로 간주하고 "파생 없음"으로 관대하게 처리.
+  //     (이 가드가 없으면 variants 는 있는데 FK 컬럼은 없는 배포 구간에 페이지가 깨진다)
+  //   - 그 외 에러(RLS, 테이블 누락, 타임아웃 등) 는 throw 해서 원인 파악 가능하게 남긴다.
+  const isColumnMissing = (err: { code?: string } | null | undefined) => err?.code === "42703";
+  const safeRows = <T,>(res: { data: T[] | null; error: { code?: string; message?: string } | null }, label: string): T[] => {
+    if (!res.error) return res.data ?? [];
+    if (isColumnMissing(res.error)) {
+      console.warn(`[getVariantsWithDerivatives] ${label}: variant_id column missing (migration pending) — treating as no derivatives.`);
+      return [];
+    }
+    throw res.error;
+  };
+  const blogRows = safeRows(blogsRes, "blog_posts");
+  const carouselRows = safeRows(carouselsRes, "carousels");
+  const videoRows = safeRows(videosRes, "video_projects");
+  const emailRows = safeRows(emailsRes, "email_logs");
 
   const blogByVariant = new Map<string, VariantBlogPost>();
-  for (const b of (blogsRes.data ?? []) as (VariantBlogPost & { variant_id: string })[]) {
+  for (const b of blogRows as (VariantBlogPost & { variant_id: string })[]) {
     blogByVariant.set(b.variant_id, { id: b.id, title: b.title, slug: b.slug, status: b.status });
   }
   const carouselByVariant = new Map<string, VariantCarousel>();
-  for (const c of (carouselsRes.data ?? []) as (VariantCarousel & { variant_id: string })[]) {
+  for (const c of carouselRows as (VariantCarousel & { variant_id: string })[]) {
     carouselByVariant.set(c.variant_id, { id: c.id, title: c.title, caption: c.caption });
   }
   const videoByVariant = new Map<string, VariantVideoProject>();
-  for (const v of (videosRes.data ?? []) as (VariantVideoProject & { variant_id: string })[]) {
+  for (const v of videoRows as (VariantVideoProject & { variant_id: string })[]) {
     videoByVariant.set(v.variant_id, { id: v.id, name: v.name, status: v.status });
   }
   const emailsByVariant = new Map<string, VariantEmailLog[]>();
-  for (const e of (emailsRes.data ?? []) as (VariantEmailLog & { variant_id: string })[]) {
+  for (const e of emailRows as (VariantEmailLog & { variant_id: string })[]) {
     const arr = emailsByVariant.get(e.variant_id) ?? [];
     arr.push({ id: e.id, subject: e.subject, status: e.status, sent_at: e.sent_at, sent_to_count: e.sent_to_count });
     emailsByVariant.set(e.variant_id, arr);

--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -102,6 +102,13 @@ export async function getVariantsWithDerivatives(
     sb.from("email_logs").select("id, subject, status, sent_at, sent_to_count, variant_id").in("variant_id", variantIds),
   ]);
 
+  // 4개 파생 쿼리 에러는 각각 throw. RLS / 테이블명 오타 같은 장애를 silent ignore
+  // 하지 않기 위함 (Promise.all 은 reject 를 그대로 던지지 않고 data/error 객체만 반환).
+  if (blogsRes.error) throw blogsRes.error;
+  if (carouselsRes.error) throw carouselsRes.error;
+  if (videosRes.error) throw videosRes.error;
+  if (emailsRes.error) throw emailsRes.error;
+
   const blogByVariant = new Map<string, VariantBlogPost>();
   for (const b of (blogsRes.data ?? []) as (VariantBlogPost & { variant_id: string })[]) {
     blogByVariant.set(b.variant_id, { id: b.id, title: b.title, slug: b.slug, status: b.status });

--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -5,6 +5,11 @@ import type {
   Publication,
   Topic,
   Variant,
+  VariantBlogPost,
+  VariantCarousel,
+  VariantVideoProject,
+  VariantEmailLog,
+  VariantWithDerivatives,
   PipelineStats,
   ChannelCount,
   ActivityLog,
@@ -67,6 +72,62 @@ export async function getVariants(contentId: string): Promise<Variant[]> {
     .order("created_at", { ascending: false });
   if (error) throw error;
   return data ?? [];
+}
+
+// Content 에 연결된 variants + 각 variant 의 format 별 파생 레코드.
+// PostgREST nested select 대신 별도 쿼리 + 클라이언트 조인을 쓰는 이유:
+//   variant_id FK 를 최근 (#17) 추가했을 때 PostgREST schema cache 가 즉시
+//   반영되지 않아 nested select 가 PGRST200 으로 실패하는 경우가 있었음.
+//   테이블별 IN 쿼리는 언제나 안전.
+export async function getVariantsWithDerivatives(
+  contentId: string
+): Promise<VariantWithDerivatives[]> {
+  const sb = getSupabase();
+  const { data: variants, error } = await sb
+    .from("variants")
+    .select("*")
+    .eq("content_id", contentId)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+
+  const variantList = (variants ?? []) as Variant[];
+  if (variantList.length === 0) return [];
+
+  const variantIds = variantList.map((v) => v.id);
+
+  const [blogsRes, carouselsRes, videosRes, emailsRes] = await Promise.all([
+    sb.from("blog_posts").select("id, title, slug, status, variant_id").in("variant_id", variantIds),
+    sb.from("carousels").select("id, title, caption, variant_id").in("variant_id", variantIds),
+    sb.from("video_projects").select("id, name, status, variant_id").in("variant_id", variantIds),
+    sb.from("email_logs").select("id, subject, status, sent_at, sent_to_count, variant_id").in("variant_id", variantIds),
+  ]);
+
+  const blogByVariant = new Map<string, VariantBlogPost>();
+  for (const b of (blogsRes.data ?? []) as (VariantBlogPost & { variant_id: string })[]) {
+    blogByVariant.set(b.variant_id, { id: b.id, title: b.title, slug: b.slug, status: b.status });
+  }
+  const carouselByVariant = new Map<string, VariantCarousel>();
+  for (const c of (carouselsRes.data ?? []) as (VariantCarousel & { variant_id: string })[]) {
+    carouselByVariant.set(c.variant_id, { id: c.id, title: c.title, caption: c.caption });
+  }
+  const videoByVariant = new Map<string, VariantVideoProject>();
+  for (const v of (videosRes.data ?? []) as (VariantVideoProject & { variant_id: string })[]) {
+    videoByVariant.set(v.variant_id, { id: v.id, name: v.name, status: v.status });
+  }
+  const emailsByVariant = new Map<string, VariantEmailLog[]>();
+  for (const e of (emailsRes.data ?? []) as (VariantEmailLog & { variant_id: string })[]) {
+    const arr = emailsByVariant.get(e.variant_id) ?? [];
+    arr.push({ id: e.id, subject: e.subject, status: e.status, sent_at: e.sent_at, sent_to_count: e.sent_to_count });
+    emailsByVariant.set(e.variant_id, arr);
+  }
+
+  return variantList.map((v) => ({
+    ...v,
+    blog_post: blogByVariant.get(v.id) ?? null,
+    carousel: carouselByVariant.get(v.id) ?? null,
+    video_project: videoByVariant.get(v.id) ?? null,
+    emails: emailsByVariant.get(v.id) ?? [],
+  }));
 }
 
 export async function getAllVariants(): Promise<Variant[]> {

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -59,6 +59,37 @@ export interface Variant {
   contents?: { title: string } | null;
 }
 
+// Variant 에 연결된 format 별 파생 레코드. Contents 상세의 "Derivatives" 섹션용.
+export interface VariantBlogPost {
+  id: string;
+  title: string;
+  slug: string;
+  status: string;
+}
+export interface VariantCarousel {
+  id: string;
+  title: string;
+  caption: string | null;
+}
+export interface VariantVideoProject {
+  id: string;
+  name: string;
+  status: string;
+}
+export interface VariantEmailLog {
+  id: string;
+  subject: string;
+  status: string;
+  sent_at: string | null;
+  sent_to_count: number | null;
+}
+export interface VariantWithDerivatives extends Variant {
+  blog_post: VariantBlogPost | null;
+  carousel: VariantCarousel | null;
+  video_project: VariantVideoProject | null;
+  emails: VariantEmailLog[];
+}
+
 export interface Publication {
   id: string;
   content_id: string;


### PR DESCRIPTION
## 요약

Content(마스터) → Variants(파생물 통합 레지스트리) 구조의 UI 첫 단계.
이전 PR들(#15 platform/format enum, #17 variant_id FK) 로 DB 레벨 연결을 완성했지만 대시보드에서는 "이 마스터에서 파생된 것들"을 한 화면에서 볼 수 없었다. 이 PR 이 그 가시 연결을 완성한다.

## 변경

- `types.ts`: `VariantWithDerivatives` + `VariantBlogPost` / `VariantCarousel` / `VariantVideoProject` / `VariantEmailLog` 타입 추가.
- `queries.ts`: `getVariantsWithDerivatives(contentId)` 추가.
  - PostgREST nested select 대신 **테이블별 IN 쿼리 + 클라이언트 조인** 방식.
  - 사유: #17 머지 직후 PostgREST schema cache 지연으로 nested select 가 `PGRST200` 으로 실패하는 현상을 관찰함. IN 쿼리는 언제나 안정.
- `contents/[id]/page.tsx`: `Promise.all` 에 variants fetch 추가.
- `content-detail-view.tsx`: 본문 카드 아래 새 "Variants & Derivatives" 카드.
  - variant 당 platform / format / status 배지
  - blog_post / carousel / video_project / email 연결에 따라 해당 스튜디오로 가는 → 버튼
  - 파생 레코드 미생성 시 format 기반 fallback 링크 (Blog 관리 / Carousel / Video 리스트)
  - variants 0 개일 때 "Generate Variants" 로 안내
  - 우측 상단에 "Manage Variants" 버튼 (`/variants?content_id=<id>`)

## 플로우 맥락

\`\`\`
Content (master)
  └─ Variants (registry)
       ├─ format=blog     → blog_posts 1:1    → /blog-manage/[id]
       ├─ format=carousel → carousels 1:1     → /carousel/[id]
       ├─ format=video    → video_projects 1:1 → /video/projects
       └─ (모든 variant)  → email_logs 1:N    → "N 발송" 배지
\`\`\`

이 카드가 있어야 다음 단계(Step 5 "페이지 간 다음 단계 액션 버튼") 가 의미 있는 흐름으로 연결됨.

## 영향 범위

- 기존 데이터 대부분 variant_id=null → "아직 파생물이 없습니다" 로 표시 (정상 동작)
- TypeScript 타입체크 통과
- Supabase RPC / RLS 변경 없음
- 서버 컴포넌트 패턴 유지 (page.tsx 에서 fetch → 클라이언트 컴포넌트에 prop 전달)

## 테스트 계획

- [ ] 기존 content (파생 없음) 조회 → 빈 상태 메시지
- [ ] variants 테이블에 수동 insert 후 Content 상세에서 렌더링 확인
- [ ] blog_post.variant_id / carousels.variant_id / video_projects.variant_id 로 연결 시 해당 스튜디오 링크 동작
- [ ] email_logs 레코드 있으면 "N 발송" 배지 표시

## 다음 단계 (별도 PR)

- Step 4: 사이드바 재구성 (Strategy/Pipeline/Production/Distribution)
- Step 5: 페이지 간 다음 단계 액션 버튼 (Ideas→Content, Content→Variants, Studios→Publish)
- Step 6: 페이지 상단 파이프라인 stepper

Refs #21