### PR TITLE
feat(sidebar): 파이프라인 플로우 기준으로 재구성

### DIFF
--- a/dashboard/src/components/layout/app-sidebar.tsx
+++ b/dashboard/src/components/layout/app-sidebar.tsx
@@ -33,33 +33,56 @@ import {
   SidebarMenuButton,
 } from "@/components/ui/sidebar";
 
-const cmsNavItems = [
+// 파이프라인 플로우 기준 재구성:
+//   Overview → Strategy → Pipeline(Ideas→Contents→Variants)
+//     → Production(Media) → Carousel Studio → Video Studio
+//     → Distribution(Blog/Newsletter/Publications) → Intelligence(Analytics/Activity)
+//
+// 기존 URL 경로는 모두 유지 — 그룹명과 순서만 재배치.
+
+type NavItem = { title: string; url: string; icon: React.ComponentType };
+
+const overviewNavItems: NavItem[] = [
   { title: "Dashboard", url: "/", icon: LayoutDashboardIcon },
+];
+
+const strategyNavItems: NavItem[] = [
   { title: "Topics", url: "/topics", icon: TagIcon },
-  { title: "Contents", url: "/contents", icon: FileTextIcon },
+];
+
+const pipelineNavItems: NavItem[] = [
   { title: "Ideas", url: "/ideas", icon: LightbulbIcon },
-  { title: "Publications", url: "/publications", icon: SendIcon },
+  { title: "Contents", url: "/contents", icon: FileTextIcon },
   { title: "Variants", url: "/variants", icon: SplitIcon },
-  { title: "Activity", url: "/activity", icon: ActivityIcon },
+];
+
+const productionNavItems: NavItem[] = [
   { title: "Media", url: "/media", icon: ImageIcon },
-  { title: "Blog", url: "/blog-manage", icon: PenSquareIcon },
-  { title: "Newsletter", url: "/newsletter", icon: MailIcon },
 ];
 
-const videoNavItems = [
-  { title: "프로젝트", url: "/video/projects", icon: VideoIcon },
-  { title: "레퍼런스", url: "/video/references", icon: BookmarkCheckIcon },
-  { title: "완료 영상", url: "/video/finished", icon: FilmIcon },
-];
-
-const carouselNavItems = [
+const carouselNavItems: NavItem[] = [
   { title: "캐러셀", url: "/carousel", icon: LayersIcon },
   { title: "레퍼런스", url: "/carousel/references", icon: BookmarkCheckIcon },
   { title: "템플릿", url: "/carousel/templates", icon: LayoutTemplateIcon },
 ];
 
-const analyticsNavItems = [
+const videoNavItems: NavItem[] = [
+  { title: "프로젝트", url: "/video/projects", icon: VideoIcon },
+  { title: "레퍼런스", url: "/video/references", icon: BookmarkCheckIcon },
+  { title: "완료 영상", url: "/video/finished", icon: FilmIcon },
+];
+
+const distributionNavItems: NavItem[] = [
+  { title: "Blog", url: "/blog-manage", icon: PenSquareIcon },
+  { title: "Newsletter", url: "/newsletter", icon: MailIcon },
+  { title: "Publications", url: "/publications", icon: SendIcon },
+];
+
+const intelligenceNavItems: NavItem[] = [
+  // 하위에 페이지가 늘어나면 그룹명을 유지하고 item 은 구체명(Traffic) 을 쓴다.
+  // 기존 e2e 테스트(analytics.spec.ts) 가 "Traffic" text 로 assert 하므로 유지.
   { title: "Traffic", url: "/analytics/traffic", icon: TrendingUpIcon },
+  { title: "Activity", url: "/activity", icon: ActivityIcon },
 ];
 
 export function AppSidebar() {
@@ -72,10 +95,7 @@ export function AppSidebar() {
     return pathname.startsWith(url);
   };
 
-  const renderNavGroup = (
-    label: string,
-    items: typeof cmsNavItems
-  ) => (
+  const renderNavGroup = (label: string, items: NavItem[]) => (
     <SidebarGroup>
       <SidebarGroupLabel>{label}</SidebarGroupLabel>
       <SidebarMenu>
@@ -107,10 +127,14 @@ export function AppSidebar() {
         </div>
       </SidebarHeader>
       <SidebarContent>
-        {renderNavGroup("CMS", cmsNavItems)}
-        {renderNavGroup("Analytics", analyticsNavItems)}
-        {renderNavGroup("영상 (Video)", videoNavItems)}
-        {renderNavGroup("캐러셀 (Carousel)", carouselNavItems)}
+        {renderNavGroup("Overview", overviewNavItems)}
+        {renderNavGroup("Strategy", strategyNavItems)}
+        {renderNavGroup("Pipeline", pipelineNavItems)}
+        {renderNavGroup("Production", productionNavItems)}
+        {renderNavGroup("Carousel Studio", carouselNavItems)}
+        {renderNavGroup("Video Studio", videoNavItems)}
+        {renderNavGroup("Distribution", distributionNavItems)}
+        {renderNavGroup("Intelligence", intelligenceNavItems)}
       </SidebarContent>
       <SidebarFooter>
         <div className="px-2 py-2 text-xs text-muted-foreground">

--- a/dashboard/src/components/layout/app-sidebar.tsx
+++ b/dashboard/src/components/layout/app-sidebar.tsx
@@ -90,8 +90,9 @@ export function AppSidebar() {
 
   const isActive = (url: string) => {
     if (url === "/") return pathname === "/";
+    // /carousel 은 list 페이지, /carousel/references / /carousel/templates 는 별도 항목이라
+    // startsWith 대신 정확 일치로 active 판정해야 올바른 아이템만 하이라이트된다.
     if (url === "/carousel") return pathname === "/carousel";
-    if (url === "/analytics") return pathname === "/analytics";
     return pathname.startsWith(url);
   };
 
@@ -131,8 +132,8 @@ export function AppSidebar() {
         {renderNavGroup("Strategy", strategyNavItems)}
         {renderNavGroup("Pipeline", pipelineNavItems)}
         {renderNavGroup("Production", productionNavItems)}
-        {renderNavGroup("Carousel Studio", carouselNavItems)}
-        {renderNavGroup("Video Studio", videoNavItems)}
+        {renderNavGroup("Carousel", carouselNavItems)}
+        {renderNavGroup("Video", videoNavItems)}
         {renderNavGroup("Distribution", distributionNavItems)}
         {renderNavGroup("Intelligence", intelligenceNavItems)}
       </SidebarContent>

--- a/dashboard/src/components/layout/app-sidebar.tsx
+++ b/dashboard/src/components/layout/app-sidebar.tsx
@@ -35,8 +35,8 @@ import {
 
 // 파이프라인 플로우 기준 재구성:
 //   Overview → Strategy → Pipeline(Ideas→Contents→Variants)
-//     → Production(Media) → Carousel Studio → Video Studio
-//     → Distribution(Blog/Newsletter/Publications) → Intelligence(Analytics/Activity)
+//     → Production(Media) → Carousel → Video
+//     → Distribution(Blog/Newsletter/Publications) → Intelligence(Traffic/Activity)
 //
 // 기존 URL 경로는 모두 유지 — 그룹명과 순서만 재배치.
 


### PR DESCRIPTION
## 요약

사이드바를 파이프라인 논리 순서로 재구성. 기존 4개 그룹(CMS / Analytics / 영상 / 캐러셀) 을 8개 그룹으로 재배치.

## Before → After

\`\`\`
[Before]                          [After]
CMS                               Overview        : Dashboard
  Dashboard                       Strategy        : Topics
  Topics                          Pipeline        : Ideas → Contents → Variants
  Contents                        Production      : Media
  Ideas                           Carousel Studio : 캐러셀 / 레퍼런스 / 템플릿
  Publications                    Video Studio    : 프로젝트 / 레퍼런스 / 완료 영상
  Variants                        Distribution    : Blog / Newsletter / Publications
  Activity                        Intelligence    : Traffic / Activity
  Media
  Blog
  Newsletter
Analytics
  Traffic
영상 (Video)
  프로젝트 / 레퍼런스 / 완료 영상
캐러셀 (Carousel)
  캐러셀 / 레퍼런스 / 템플릿
\`\`\`

## 설계 원칙

1. **URL 변경 없음** — 모든 라우트 경로 유지. 북마크 / 문서 링크 보호.
2. **항목 title 보존** — 기존 e2e 테스트(analytics/blog-manage/newsletter/carousel/video/dashboard.spec.ts)가 특정 텍스트로 assert 하므로 항목 title 은 유지.
3. **그룹명만 변경** — 의미 단위로 묶어 논리 플로우 반영.
4. **신규 메뉴 추가 없음** — Brand Profile / Settings 등 아직 없는 메뉴는 추후 이슈.

## 영향 범위

- dashboard/src/components/layout/app-sidebar.tsx (1 file, +44 / -20)
- TypeScript 타입체크 통과
- e2e 테스트 영향 없음 (모든 assertion 대상 항목 title 유지)
- Next.js 라우팅/미들웨어/레이아웃 변경 없음

## 다음 단계

- Step 5: 페이지 간 "다음 단계" 액션 버튼 연결 (Ideas→Content 생성, Content→Variants, Variants→Studios, Studios→Publish)
- Step 6: 페이지 상단 파이프라인 stepper

Refs #23