### PR TITLE
feat: 파이프라인 페이지에 다음 단계 액션 버튼 연결

### DIFF
--- a/dashboard/src/app/(dashboard)/ideas/ideas-list.tsx
+++ b/dashboard/src/app/(dashboard)/ideas/ideas-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ArrowUpCircleIcon, CheckCircleIcon, SearchIcon } from "lucide-react";
 import type { Idea, Topic } from "@/lib/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -35,14 +35,27 @@ function getIntentVariant(intent: string | null | undefined) {
 
 export function IdeasList({ ideas, topics }: IdeasListProps) {
   // 사이드바의 Topics → "이 토픽의 아이디어" 링크가 `?topic_id=<id>` 로 넘어오므로
-  // 첫 렌더에 URL 파라미터로 topic 필터를 초기화한다.
+  // 첫 렌더에 URL 파라미터로 topic 필터를 초기화한다. 다만 존재하지 않는 topic_id 는
+  // 무시 — 유효하지 않은 값으로 들어오면 "전체 없음" 처럼 보여 혼란스럽기 때문.
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const initialTopicId = searchParams.get("topic_id");
+  const topicsById = new Map(topics.map((topic) => [topic.id, topic]));
+  const rawTopicId = searchParams.get("topic_id");
+  const initialTopicId = rawTopicId && topicsById.has(rawTopicId) ? rawTopicId : null;
 
   const [search, setSearch] = useState("");
   const [selectedTopicId, setSelectedTopicId] = useState<string | null>(initialTopicId);
 
-  const topicsById = new Map(topics.map((topic) => [topic.id, topic]));
+  // topic 선택 시 state 와 URL 을 같이 업데이트해 공유 가능한 필터 URL 을 유지한다.
+  const selectTopic = (topicId: string | null) => {
+    setSelectedTopicId(topicId);
+    const params = new URLSearchParams(searchParams.toString());
+    if (topicId) params.set("topic_id", topicId);
+    else params.delete("topic_id");
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
 
   const filtered = ideas.filter((idea) => {
     const topic = idea.topic_id ? topicsById.get(idea.topic_id) : undefined;
@@ -74,7 +87,7 @@ export function IdeasList({ ideas, topics }: IdeasListProps) {
           type="button"
           size="sm"
           variant={selectedTopicId === null ? "secondary" : "outline"}
-          onClick={() => setSelectedTopicId(null)}
+          onClick={() => selectTopic(null)}
         >
           All Topics
         </Button>
@@ -84,7 +97,7 @@ export function IdeasList({ ideas, topics }: IdeasListProps) {
             type="button"
             size="sm"
             variant={selectedTopicId === topic.id ? "secondary" : "outline"}
-            onClick={() => setSelectedTopicId(topic.id)}
+            onClick={() => selectTopic(topic.id)}
           >
             {topic.name}
           </Button>

--- a/dashboard/src/app/(dashboard)/ideas/ideas-list.tsx
+++ b/dashboard/src/app/(dashboard)/ideas/ideas-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { ArrowUpCircleIcon, CheckCircleIcon, SearchIcon } from "lucide-react";
 import type { Idea, Topic } from "@/lib/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -33,8 +34,13 @@ function getIntentVariant(intent: string | null | undefined) {
 }
 
 export function IdeasList({ ideas, topics }: IdeasListProps) {
+  // 사이드바의 Topics → "이 토픽의 아이디어" 링크가 `?topic_id=<id>` 로 넘어오므로
+  // 첫 렌더에 URL 파라미터로 topic 필터를 초기화한다.
+  const searchParams = useSearchParams();
+  const initialTopicId = searchParams.get("topic_id");
+
   const [search, setSearch] = useState("");
-  const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
+  const [selectedTopicId, setSelectedTopicId] = useState<string | null>(initialTopicId);
 
   const topicsById = new Map(topics.map((topic) => [topic.id, topic]));
 

--- a/dashboard/src/app/(dashboard)/publications/publications-table.tsx
+++ b/dashboard/src/app/(dashboard)/publications/publications-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { type ColumnDef } from "@tanstack/react-table";
 import { ExternalLinkIcon } from "lucide-react";
 import type { Publication } from "@/lib/types";
@@ -21,10 +22,17 @@ const columns: ColumnDef<Publication, unknown>[] = [
     header: ({ column }) => <DataTableColumnHeader column={column} title="Content" />,
     cell: ({ row }) => {
       const contents = row.original.contents;
+      const contentId = row.original.content_id;
+      if (!contents?.title) {
+        return <span className="font-medium text-muted-foreground">Unknown</span>;
+      }
       return (
-        <span className="font-medium">
-          {contents?.title ?? "Unknown"}
-        </span>
+        <Link
+          href={`/contents/${contentId}`}
+          className="font-medium transition-colors hover:text-info hover:underline"
+        >
+          {contents.title}
+        </Link>
       );
     },
     enableSorting: false,

--- a/dashboard/src/app/(dashboard)/topics/page.tsx
+++ b/dashboard/src/app/(dashboard)/topics/page.tsx
@@ -70,8 +70,8 @@ async function TopicsData() {
             </p>
             <Button asChild variant="outline" size="sm" className="w-full">
               <Link href={`/ideas?topic_id=${topic.id}`}>
-                <LightbulbIcon className="mr-1.5 h-3.5 w-3.5" />이 토픽의 아이디어
-                <ArrowRightIcon className="ml-auto h-3.5 w-3.5" />
+                <LightbulbIcon aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />이 토픽의 아이디어
+                <ArrowRightIcon aria-hidden="true" className="ml-auto h-3.5 w-3.5" />
               </Link>
             </Button>
           </CardContent>

--- a/dashboard/src/app/(dashboard)/topics/page.tsx
+++ b/dashboard/src/app/(dashboard)/topics/page.tsx
@@ -1,8 +1,11 @@
 export const dynamic = "force-dynamic";
 
+import Link from "next/link";
 import { Suspense } from "react";
+import { ArrowRightIcon, LightbulbIcon } from "lucide-react";
 import { Main } from "@/components/layout/main";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getTopics } from "@/lib/queries";
@@ -61,10 +64,16 @@ async function TopicsData() {
               ))}
             </div>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <p className="text-sm text-muted-foreground">
               {topic.description ?? "No description provided."}
             </p>
+            <Button asChild variant="outline" size="sm" className="w-full">
+              <Link href={`/ideas?topic_id=${topic.id}`}>
+                <LightbulbIcon className="mr-1.5 h-3.5 w-3.5" />이 토픽의 아이디어
+                <ArrowRightIcon className="ml-auto h-3.5 w-3.5" />
+              </Link>
+            </Button>
           </CardContent>
         </Card>
       ))}

--- a/dashboard/src/app/(dashboard)/variants/page.tsx
+++ b/dashboard/src/app/(dashboard)/variants/page.tsx
@@ -2,11 +2,21 @@ export const dynamic = "force-dynamic";
 
 import Link from "next/link";
 import { Suspense } from "react";
+import {
+  ArrowRightIcon,
+  PenSquareIcon,
+  LayersIcon,
+  VideoIcon,
+  MailIcon,
+  SplitIcon,
+} from "lucide-react";
 import { Main } from "@/components/layout/main";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getAllVariants } from "@/lib/queries";
+import type { Variant } from "@/lib/types";
 
 function formatLabel(value: string) {
   return value
@@ -40,6 +50,26 @@ function getStatusVariant(status: string) {
   return "secondary" as const;
 }
 
+// format 기반 스튜디오 링크. 실제 파생 레코드(blog_posts/carousels/...)와 variant_id 로
+// 연결된 항목은 Contents 상세의 Derivatives 카드에서 우선 보이므로, 여기 list 화면에서는
+// "이 format 을 다루는 스튜디오의 진입점"만 간단히 연결한다.
+const studioByFormat: Record<string, { icon: typeof PenSquareIcon; label: string; href: string }> = {
+  blog: { icon: PenSquareIcon, label: "Blog 스튜디오", href: "/blog-manage" },
+  carousel: { icon: LayersIcon, label: "Carousel 스튜디오", href: "/carousel" },
+  video: { icon: VideoIcon, label: "Video 스튜디오", href: "/video/projects" },
+  reel: { icon: VideoIcon, label: "Video 스튜디오", href: "/video/projects" },
+  short: { icon: VideoIcon, label: "Video 스튜디오", href: "/video/projects" },
+};
+function getStudioLink(variant: Variant) {
+  const format = studioByFormat[variant.format];
+  if (format) return format;
+  if (variant.platform === "email") {
+    return { icon: MailIcon, label: "Newsletter", href: "/newsletter" };
+  }
+  // 소셜 variant(single_post/article/thread/story) 는 Publications 쪽에서 추적.
+  return { icon: SplitIcon, label: "원본 Content 열기", href: null as string | null };
+}
+
 async function VariantsData() {
   const variants = await getAllVariants();
 
@@ -53,37 +83,49 @@ async function VariantsData() {
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {variants.map((variant) => (
-        <Card key={variant.id}>
-          <CardHeader className="gap-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="outline">{formatLabel(variant.platform)}</Badge>
-              <Badge variant="outline">{formatLabel(variant.format)}</Badge>
-            </div>
-            <div className="flex items-start justify-between gap-3">
-              <CardTitle className="text-base leading-6">
-                {truncateText(variant.body_text, 100)}
-              </CardTitle>
-              <Badge variant={getStatusVariant(variant.status)}>{formatLabel(variant.status)}</Badge>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">
-              {variant.character_count?.toLocaleString() ?? 0} characters
-            </p>
-            {variant.contents?.title ? (
-              <Link
-                href={`/contents/${variant.content_id}`}
-                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-              >
-                {variant.contents.title}
-              </Link>
-            ) : (
-              <p className="text-sm text-muted-foreground">No linked content</p>
-            )}
-          </CardContent>
-        </Card>
-      ))}
+      {variants.map((variant) => {
+        const studio = getStudioLink(variant);
+        const StudioIcon = studio.icon;
+        const studioHref = studio.href ?? `/contents/${variant.content_id}`;
+        return (
+          <Card key={variant.id}>
+            <CardHeader className="gap-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">{formatLabel(variant.platform)}</Badge>
+                <Badge variant="outline">{formatLabel(variant.format)}</Badge>
+              </div>
+              <div className="flex items-start justify-between gap-3">
+                <CardTitle className="text-base leading-6">
+                  {truncateText(variant.body_text, 100)}
+                </CardTitle>
+                <Badge variant={getStatusVariant(variant.status)}>{formatLabel(variant.status)}</Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                {variant.character_count?.toLocaleString() ?? 0} characters
+              </p>
+              {variant.contents?.title ? (
+                <Link
+                  href={`/contents/${variant.content_id}`}
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {variant.contents.title}
+                </Link>
+              ) : (
+                <p className="text-sm text-muted-foreground">No linked content</p>
+              )}
+              <Button asChild variant="outline" size="sm" className="w-full">
+                <Link href={studioHref}>
+                  <StudioIcon className="mr-1.5 h-3.5 w-3.5" />
+                  {studio.label}
+                  <ArrowRightIcon className="ml-auto h-3.5 w-3.5" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/dashboard/src/app/(dashboard)/variants/page.tsx
+++ b/dashboard/src/app/(dashboard)/variants/page.tsx
@@ -117,9 +117,9 @@ async function VariantsData() {
               )}
               <Button asChild variant="outline" size="sm" className="w-full">
                 <Link href={studioHref}>
-                  <StudioIcon className="mr-1.5 h-3.5 w-3.5" />
+                  <StudioIcon aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
                   {studio.label}
-                  <ArrowRightIcon className="ml-auto h-3.5 w-3.5" />
+                  <ArrowRightIcon aria-hidden="true" className="ml-auto h-3.5 w-3.5" />
                 </Link>
               </Button>
             </CardContent>


### PR DESCRIPTION
## 요약

사이드바는 파이프라인 순으로 재구성(#24)됐지만, 각 페이지에서 "다음 단계로 가는 액션"이 흩어져 있었다. 각 단계 페이지에 클릭 한 번으로 다음 단계로 넘어가는 버튼/링크를 추가.

## 변경

### Topics → Ideas
각 토픽 카드 안에 "이 토픽의 아이디어" 버튼. `/ideas?topic_id=<id>` 로 이동.

### Ideas 필터 URL 동기화
`ideas-list.tsx` 에 `useSearchParams` 로 `?topic_id=<id>` 를 읽어 **초기 topic 필터로 자동 적용**. 기존엔 URL 파라미터 무시됐음.

### Variants → Studio
각 variant 카드에 format 기반 스튜디오 진입 버튼:
- `blog` → Blog 스튜디오 (`/blog-manage`)
- `carousel` → Carousel 스튜디오 (`/carousel`)
- `video` / `reel` / `short` → Video 스튜디오 (`/video/projects`)
- `platform=email` → Newsletter (`/newsletter`)
- 그 외 소셜 포맷 → 원본 Content 상세로 fallback

### Publications → Content 상세
테이블의 Content 컬럼을 `/contents/<content_id>` Link 로 변경. 기존엔 클릭 불가.

## 구현 노트

shadcn `card.tsx` 가 `CardFooter` 를 export 하지 않아 처음엔 런타임에서 `Element type is invalid` 에러가 났었음. `CardContent` 의 마지막 버튼으로 배치하는 방식으로 해결.

## 범위 밖 (별도 이슈 권장)

- **Ideas Promote 버튼 활성화** — 현재는 disabled 스텁. 실제 idea→content 생성은 server action + content 초안 생성 로직 필요. scope 큼.
- **Contents → Variants 자동 생성 폼** — 현재 "Manage Variants" 는 list로만 이동. 자동 생성 UI는 별도 작업.
- **Step 6: 페이지 상단 파이프라인 stepper** — 별도 PR.

## 테스트

- [x] TypeScript 타입체크 통과
- [x] dev server 에서 /topics /variants /ideas?topic_id=... /publications 전부 HTTP 200
- [x] Topics 카드에 "이 토픽의 아이디어" 문자열 렌더링 확인
- [ ] 실제 브라우저에서 Topics → 버튼 클릭 → Ideas 페이지에서 topic 필터가 자동 선택되는지
- [ ] Variants 카드의 스튜디오 버튼이 올바른 페이지로 이동하는지

Refs #25