### PR TITLE
feat(mcp): Phase 1.5 — variant_id 지원 + send_newsletter 도구

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { registerMediaTools } from './tools/media.js';
 import { registerVideoTools } from './tools/video.js';
 import { registerBlogPostTools } from './tools/blog-posts.js';
 import { registerCarouselTools } from './tools/carousels.js';
+import { registerNewsletterTools } from './tools/newsletter.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -53,6 +54,9 @@ async function main(): Promise<void> {
 
   // Carousel tools (AWC carousels table — slide deck CRUD)
   registerCarouselTools(server, adapter, supabaseUrl, supabaseKey);
+
+  // Newsletter — HTTP wrap over dashboard send endpoint + email_logs.variant_id linking
+  registerNewsletterTools(server, adapter, supabaseUrl, supabaseKey);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/blog-posts.ts
+++ b/src/tools/blog-posts.ts
@@ -237,6 +237,14 @@ export function registerBlogPostTools(
         .optional()
         .describe('true if the agent generated the full text; false if human-written content'),
       thumbnail_url: z.string().url().optional().describe('Optional thumbnail image URL'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) to link this blog_post to (1:1). Use the id returned by create_variant with format=blog. ' +
+            'When set, the derivative appears on the Content detail Variants card automatically.'
+        ),
     },
     async (params) => {
       try {
@@ -274,8 +282,10 @@ export function registerBlogPostTools(
           params.reading_time ??
           Math.max(1, Math.round(params.markdown_body.replace(/\s+/g, '').length / 500));
 
-        // 5. Insert blog_posts row (always draft)
-        const insertPayload = {
+        // 5. Insert blog_posts row (always draft).
+        //    variant_id 는 1:1 UNIQUE index 가 걸려있어 이미 다른 post 에 연결된 variant 를 재사용하면
+        //    PostgreSQL 이 23505 (unique violation) 을 뱉는다. 그 경우는 친절한 메시지로 변환.
+        const insertPayload: Record<string, unknown> = {
           title: params.title,
           slug: params.slug,
           excerpt: params.excerpt ?? null,
@@ -288,6 +298,7 @@ export function registerBlogPostTools(
           ai_generated: params.ai_generated ?? false,
           thumbnail_url: params.thumbnail_url ?? null,
         };
+        if (params.variant_id) insertPayload.variant_id = params.variant_id;
 
         const { data: inserted, error: insErr } = await sb
           .from('blog_posts')
@@ -296,6 +307,12 @@ export function registerBlogPostTools(
           .single();
 
         if (insErr || !inserted) {
+          if (insErr && (insErr as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another blog_post (1:1 constraint). ` +
+                `Create a new variant first, or use update_blog_post to re-link.`
+            );
+          }
           throw new Error(`Failed to insert blog_post: ${insErr?.message || 'unknown error'}`);
         }
 
@@ -326,6 +343,7 @@ export function registerBlogPostTools(
             status: post.status,
             reading_time: post.reading_time,
             category_slug: params.category_slug ?? null,
+            variant_id: params.variant_id ?? null,
             plate_nodes: plateContent.length,
           },
         });
@@ -360,6 +378,15 @@ export function registerBlogPostTools(
         .string()
         .optional()
         .describe('If provided, replaces content by converting markdown → PlateJS'),
+      variant_id: z
+        .string()
+        .uuid()
+        .nullable()
+        .optional()
+        .describe(
+          'Link (or re-link) this blog_post to a variant. Pass null to explicitly unlink. ' +
+            '1:1 — the target variant must not already be linked to another blog_post.'
+        ),
     },
     async (params) => {
       try {
@@ -387,7 +414,14 @@ export function registerBlogPostTools(
           .eq('id', id)
           .select()
           .single();
-        if (upErr) throw new Error(upErr.message);
+        if (upErr) {
+          if ((upErr as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another blog_post (1:1 constraint).`
+            );
+          }
+          throw new Error(upErr.message);
+        }
 
         return ok({ message: 'Blog post updated', post: data });
       } catch (e) {

--- a/src/tools/carousels.ts
+++ b/src/tools/carousels.ts
@@ -163,6 +163,14 @@ export function registerCarouselTools(
         .min(1)
         .max(20)
         .describe('Ordered list of slides (at least 1, max 20)'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) to link this carousel to (1:1). Use the id returned by ' +
+            'create_variant with format=carousel.'
+        ),
     },
     async (params) => {
       try {
@@ -176,19 +184,27 @@ export function registerCarouselTools(
           overrides: s.overrides ?? {},
         }));
 
-        const payload = {
+        const payload: Record<string, unknown> = {
           id: carouselId,
           title: params.title,
           caption: params.caption ?? null,
           slides,
         };
+        if (params.variant_id) payload.variant_id = params.variant_id;
 
         const { data, error } = await sb
           .from('carousels')
           .insert(payload)
           .select()
           .single();
-        if (error) throw new Error(error.message);
+        if (error) {
+          if ((error as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another carousel (1:1 constraint).`
+            );
+          }
+          throw new Error(error.message);
+        }
 
         const row = data as CarouselRow;
         await logCarouselActivity('create', row.id, {
@@ -227,6 +243,12 @@ export function registerCarouselTools(
         .array(slideInputSchema.extend({ id: z.string().optional() }))
         .optional()
         .describe('New slides array (replaces existing slides entirely)'),
+      variant_id: z
+        .string()
+        .uuid()
+        .nullable()
+        .optional()
+        .describe('Link (or re-link) this carousel to a variant. Pass null to unlink. 1:1 constraint.'),
     },
     async (params) => {
       try {
@@ -235,6 +257,7 @@ export function registerCarouselTools(
         };
         if (params.title !== undefined) update.title = params.title;
         if (params.caption !== undefined) update.caption = params.caption;
+        if (params.variant_id !== undefined) update.variant_id = params.variant_id;
         if (params.slides) {
           update.slides = params.slides.map((s: any) => ({
             id: s.id || uid('slide'),
@@ -252,7 +275,14 @@ export function registerCarouselTools(
           .eq('id', params.id)
           .select()
           .single();
-        if (error) throw new Error(error.message);
+        if (error) {
+          if ((error as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another carousel (1:1 constraint).`
+            );
+          }
+          throw new Error(error.message);
+        }
 
         const row = data as CarouselRow;
         await logCarouselActivity('update', row.id, {

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CMSAdapter } from '../adapters/interface.js';
+
+// 뉴스레터 발송 MCP 도구.
+//
+// 구조:
+//   Agent → send_newsletter(post_id, variant_id?)
+//       → Dashboard /api/newsletter/send (blog_post → HTML 렌더 + subscribers 조회 +
+//                                         Resend 발송 + email_logs/newsletter_deliveries 기록)
+//       → MCP 가 response 의 emailLogId 로 email_logs.variant_id 업데이트
+//
+// 왜 Dashboard 에 위임하나:
+//   발송 로직(PlateJS→HTML, 썸네일/이미지 처리, Resend rate-limit, 배달 추적) 이 이미 336 lines
+//   로 dashboard 쪽에 구현돼 있음. MCP 에서 중복 구현할 이유가 없고 두 곳에서 버전 불일치가
+//   생기면 운영 사고 위험. HTTP wrapper + 링크 후처리만 책임진다.
+//
+// 전제:
+//   - DASHBOARD_API_URL 환경변수 (기본 http://localhost:3003) 에 dashboard 가 떠있어야 한다.
+//   - dashboard 는 service-role Supabase 키로 동작하므로 별도 auth 필요 없음 (같은 신뢰 경계).
+export function registerNewsletterTools(
+  server: McpServer,
+  adapter: CMSAdapter,
+  supabaseUrl: string,
+  supabaseKey: string,
+): void {
+  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+  const dashboardUrl = (process.env.DASHBOARD_API_URL ?? 'http://localhost:3003').replace(/\/+$/, '');
+
+  server.tool(
+    'send_newsletter',
+    [
+      'Send a blog post as a newsletter to subscribers via the dashboard send pipeline.',
+      'Optionally records which variant (format=blog) this send was derived from, so the',
+      'Content detail page shows the send count on the Variants & Derivatives card.',
+      'Prerequisites: the dashboard app must be running (DASHBOARD_API_URL env var, default http://localhost:3003).',
+    ].join(' '),
+    {
+      post_id: z
+        .string()
+        .uuid()
+        .describe('blog_post.id to render and send (required).'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) (format=blog) to link on email_logs. ' +
+            'If omitted, the tool auto-resolves via blog_posts.variant_id.',
+        ),
+      preview: z
+        .boolean()
+        .optional()
+        .describe('If true, send only to admin preview recipient(s) (dashboard controls which).'),
+      force: z
+        .boolean()
+        .optional()
+        .describe('If true, ignore the "already sent" duplicate check.'),
+    },
+    async (params) => {
+      try {
+        // 1. Resolve variant_id if not provided
+        let variantId = params.variant_id ?? null;
+        if (!variantId) {
+          const { data: post } = await sb
+            .from('blog_posts')
+            .select('variant_id')
+            .eq('id', params.post_id)
+            .maybeSingle();
+          variantId = (post as { variant_id: string | null } | null)?.variant_id ?? null;
+        }
+
+        // 2. Call dashboard send endpoint
+        const res = await fetch(`${dashboardUrl}/api/newsletter/send`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            postId: params.post_id,
+            preview: params.preview ?? false,
+            force: params.force ?? false,
+          }),
+        });
+
+        const body = (await res.json().catch(() => ({}))) as {
+          ok?: boolean;
+          emailLogId?: string;
+          sentCount?: number;
+          failedCount?: number;
+          finalStatus?: string;
+          error?: string;
+        };
+
+        if (!res.ok || body.error) {
+          throw new Error(
+            `Dashboard send failed (${res.status}): ${body.error ?? 'unknown'}. ` +
+              `Is dashboard running at ${dashboardUrl}?`,
+          );
+        }
+
+        // 3. Link email_logs.variant_id after successful send
+        let linkedVariantId: string | null = null;
+        if (variantId && body.emailLogId) {
+          const { error: linkErr } = await sb
+            .from('email_logs')
+            .update({ variant_id: variantId })
+            .eq('id', body.emailLogId);
+          if (!linkErr) linkedVariantId = variantId;
+          else {
+            // 링크 실패해도 발송 자체는 완료. 경고만 로그.
+            console.error(`[send_newsletter] email_logs.variant_id 링크 실패:`, linkErr.message);
+          }
+        }
+
+        // 4. Record as Publication (channel='newsletter') for pipeline visibility
+        try {
+          await adapter.logActivity({
+            action: 'publish',
+            collection: 'email_logs',
+            item_id: body.emailLogId ?? 'unknown',
+            actor_type: 'agent',
+            payload: {
+              post_id: params.post_id,
+              variant_id: linkedVariantId,
+              sent_count: body.sentCount ?? 0,
+              failed_count: body.failedCount ?? 0,
+              final_status: body.finalStatus ?? 'unknown',
+            },
+          });
+        } catch {
+          // 감사 로그 실패는 발송을 막지 않는다.
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  message: `Newsletter sent. ${body.sentCount ?? 0} success, ${body.failedCount ?? 0} failed.`,
+                  email_log_id: body.emailLogId ?? null,
+                  variant_id_linked: linkedVariantId,
+                  final_status: body.finalStatus ?? 'unknown',
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -98,9 +98,11 @@ export function registerNewsletterTools(
           );
         }
 
-        // 3. Link email_logs.variant_id after successful send
+        // 3. Link email_logs.variant_id after successful send.
+        //    preview 모드는 관리자 테스트 발송이므로 실제 독자 발송 이력으로 기록되면
+        //    Content 상세의 "📧 N명 발송" 배지에 가짜 이력이 섞인다. variant 링크 스킵.
         let linkedVariantId: string | null = null;
-        if (variantId && body.emailLogId) {
+        if (!params.preview && variantId && body.emailLogId) {
           const { error: linkErr } = await sb
             .from('email_logs')
             .update({ variant_id: variantId })

--- a/src/tools/publications.ts
+++ b/src/tools/publications.ts
@@ -8,6 +8,14 @@ export function registerPublicationTools(server: McpServer, adapter: CMSAdapter)
     'Record a publication event — tracks where and when content was published, with optional metrics.',
     {
       content_id: z.string().uuid().describe('ID of the content that was published'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant that was actually published (recommended when a specific platform ' +
+            'variant is being recorded — enables variant-level metric tracking).'
+        ),
       channel: z.string().describe('Publication channel (e.g., "blog", "twitter", "linkedin")'),
       channel_post_id: z.string().optional().describe('Platform-specific post ID'),
       url: z.string().url().optional().describe('URL where the content was published'),


### PR DESCRIPTION
## 요약

**Phase 1.5 — 에이전트가 DB 모델의 variant_id FK (#17) 를 실제로 채울 수 있게 하는 도구 업데이트.**

Phase 1(Step 1-6)에서 DB/UI 를 구축했지만, MCP 도구가 variant_id 파라미터를 받지 않아 에이전트가 variant ↔ 파생 레코드 연결을 못 하는 상태였음. 이 PR 로 에이전트가 end-to-end 파이프라인(Idea → Content → Variant → Blog/Carousel → Newsletter → Publication)을 한 세션에서 완결 가능.

## 변경

### Step 1 — 기존 도구에 variant_id 옵션 추가
- `create_blog_post_from_markdown`: `variant_id?`
- `update_blog_post`: `variant_id?` (null 로 unlink 가능)
- `create_carousel`: `variant_id?`
- `update_carousel`: `variant_id?`
- `create_publication`: `variant_id?`

공통 처리:
- 1:1 UNIQUE index 위반 시 (PG 23505) "variant_id X is already linked to another {table}" 친절한 에러로 변환
- optional 파라미터이므로 기존 호출 호환

### Step 2 — send_newsletter 도구 신설 (`src/tools/newsletter.ts`)
에이전트가 블로그를 뉴스레터로 발송하고 variant 에 연결까지 자동으로 처리:

\`\`\`
send_newsletter(post_id, variant_id?, preview?, force?)
\`\`\`

플로우:
1. variant_id 미지정 시 blog_posts.variant_id 로 자동 resolve
2. Dashboard `/api/newsletter/send` 에 HTTP 위임 (PlateJS→HTML, Resend, 배달 기록)
3. 성공 response 의 emailLogId 로 email_logs.variant_id 업데이트
4. activity_logs 에 publish 액션 기록

### 왜 Dashboard 에 HTTP 위임했나
발송 로직 이미 336 lines 로 dashboard 에 있음 (PlateJS 렌더, 썸네일 처리, Resend rate-limit, 배달 추적). MCP 에 중복 구현하면 버전 불일치 리스크. MCP 는 "input 정리 + variant 링크 + 감사" 만 책임.

## 범위 밖

- `create_video_project` — brxce-editor FastAPI 경유라 별도 작업 필요. 향후 `link_video_project_to_variant` 별도 도구 추가 제안.
- 기존 orphan 레코드 backfill (variant_id=null 인 blog_posts 17 rows 등) — 이 PR 은 신규 생성만 커버. backfill 은 별도 이슈.

## 영향 범위

- TypeScript 타입체크 통과
- 기존 MCP 도구 호출 호환 (variant_id 모두 optional)
- Dashboard 변경 없음 (send 엔드포인트 재사용)
- DASHBOARD_API_URL env 신규 (기본값 http://localhost:3003 — 기존 dev 설정에 맞춤)

## 테스트 계획

- [ ] MCP 서버 재시작 후 Claude Desktop 등에서 도구 목록에 send_newsletter 노출 확인
- [ ] create_variant + create_blog_post_from_markdown(variant_id=...) → Contents 상세에서 Blog 파생물 표시
- [ ] 같은 variant_id 로 재차 create → 친절한 에러 메시지
- [ ] send_newsletter(post_id) → dashboard 실발송 성공 + email_logs.variant_id 세팅
- [ ] Dashboard 중단 상태에서 send_newsletter → "Is dashboard running at X?" 메시지

## 다음 단계

Phase 1.5 완료 후:
- Phase 2 (멀티 사용자 대응): 하드코딩 env화, AWC 테이블 migration 이식, README, editor 옵션화
- 또는 Phase 1 보류 follow-up (Promote 버튼 활성화, Variants 생성 form 등)