### PR TITLE
feat(mcp): link_video_project_to_variant 도구 신설 (follow-up 1)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { registerVideoTools } from './tools/video.js';
 import { registerBlogPostTools } from './tools/blog-posts.js';
 import { registerCarouselTools } from './tools/carousels.js';
 import { registerNewsletterTools } from './tools/newsletter.js';
+import { registerVideoLinkTools } from './tools/video-link.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -57,6 +58,9 @@ async function main(): Promise<void> {
 
   // Newsletter — HTTP wrap over dashboard send endpoint + email_logs.variant_id linking
   registerNewsletterTools(server, adapter, supabaseUrl, supabaseKey);
+
+  // video_projects 는 brxce-editor 경유 생성이라 variant_id 를 post-link 로 채우는 전용 도구.
+  registerVideoLinkTools(server, adapter, supabaseUrl, supabaseKey);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/video-link.ts
+++ b/src/tools/video-link.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CMSAdapter } from '../adapters/interface.js';
+
+// video_projects 는 brxce-editor FastAPI(`/api/projects/save`) 경유로 만들어지므로
+// create 시점에 variant_id 를 바로 넣을 수 없다. 대신 기존 레코드의 variant_id 를
+// Supabase UPDATE 로 설정/해제하는 링크 전용 도구를 제공한다.
+//
+// 사용 시나리오:
+//   1) 에이전트가 create_variant(content_id, format=video 또는 reel/short) → variant A 확보
+//   2) 에이전트가 create_video_project(name, clips, ...) → video_project B (brxce-editor 경유)
+//   3) link_video_project_to_variant(video_project_id=B, variant_id=A) → 연결
+//
+// 향후 brxce-editor 의 save 엔드포인트에 variant_id 가 추가되면 이 도구는 보조 유지.
+export function registerVideoLinkTools(
+  server: McpServer,
+  adapter: CMSAdapter,
+  supabaseUrl: string,
+  supabaseKey: string,
+): void {
+  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+  server.tool(
+    'link_video_project_to_variant',
+    [
+      'Link (or unlink) an existing video_project to a variant (1:1).',
+      'video_projects is currently created via the brxce-editor API which does not accept variant_id,',
+      'so this tool fills the FK after creation.',
+      'Pass variant_id=null to explicitly unlink.',
+    ].join(' '),
+    {
+      video_project_id: z.string().uuid().describe('video_projects.id'),
+      variant_id: z
+        .string()
+        .uuid()
+        .nullable()
+        .describe('variants.id to link to, or null to unlink (1:1 constraint).'),
+    },
+    async (params) => {
+      try {
+        const { data, error } = await sb
+          .from('video_projects')
+          .update({ variant_id: params.variant_id })
+          .eq('id', params.video_project_id)
+          .select('id, name, variant_id')
+          .single();
+        if (error) {
+          if ((error as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another video_project (1:1 constraint).`,
+            );
+          }
+          throw new Error(error.message);
+        }
+
+        // Best-effort audit log — 링크 자체를 별도 액션으로 기록.
+        try {
+          await adapter.logActivity({
+            action: 'update',
+            collection: 'video_projects',
+            item_id: params.video_project_id,
+            actor_type: 'agent',
+            payload: { variant_id: params.variant_id },
+          });
+        } catch {
+          // 감사 실패는 tool 실행을 막지 않는다.
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  message: params.variant_id ? 'Video project linked to variant.' : 'Video project unlinked.',
+                  video_project: data,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/video-link.ts
+++ b/src/tools/video-link.ts
@@ -39,6 +39,19 @@ export function registerVideoLinkTools(
     },
     async (params) => {
       try {
+        // 사전 조회: 없는 video_project_id 가 넘어오면 .single() 이 "JSON object
+        // requested, multiple (or no) rows returned" 같은 불친절한 메시지를 뱉는다.
+        // id 존재 여부를 먼저 확인해 clear 메시지로 치환.
+        const { data: existing, error: existErr } = await sb
+          .from('video_projects')
+          .select('id')
+          .eq('id', params.video_project_id)
+          .maybeSingle();
+        if (existErr) throw new Error(existErr.message);
+        if (!existing) {
+          throw new Error(`video_project not found: ${params.video_project_id}`);
+        }
+
         const { data, error } = await sb
           .from('video_projects')
           .update({ variant_id: params.variant_id })


### PR DESCRIPTION
## 요약

Phase 1.5(#29) 에서 다루지 못한 video_project variant_id 연결을 보조 도구로 채움.

## 배경

`video_projects` 는 brxce-editor FastAPI `/api/projects/save` 경유로 생성 → create 시점에 variant_id 를 못 넣는 구조. blog_posts/carousels 처럼 create 파라미터에 끼워넣을 수 없음.

## 변경

신규 도구: `link_video_project_to_variant`

\`\`\`
link_video_project_to_variant({
  video_project_id: uuid,
  variant_id: uuid | null  // null 로 unlink
})
\`\`\`

내부 동작:
- video_projects.variant_id UPDATE
- 1:1 UNIQUE(uq_video_projects_variant_id) 위반(PG 23505) 친절 메시지
- activity_logs 감사 기록 (best-effort)

## 사용 시나리오

\`\`\`
create_variant(content_id, format=video) → variant A
create_video_project(name, clips) → video_project B (brxce-editor)
link_video_project_to_variant(video_project_id=B, variant_id=A)
\`\`\`

이후 Contents 상세 Variants & Derivatives 카드에서 비디오 파생물이 올바르게 표시.

## 범위 밖

- brxce-editor `/api/projects/save` 자체에 variant_id 파라미터 추가 (brxce-editor repo 수정)
- 이게 되면 이 도구는 "link 보조" 용도로 유지. 지금 당장 외부 repo 건드리는 부담을 피해 이쪽부터.

## Refs

- #27 (Phase 1 Step 6)
- #29 (Phase 1.5)