### PR TITLE
feat(auth): newsletter send 엔드포인트 shared-secret 인증 (follow-up 2)

### DIFF
--- a/dashboard/src/app/api/newsletter/send/route.ts
+++ b/dashboard/src/app/api/newsletter/send/route.ts
@@ -63,13 +63,28 @@ async function sendWithRateLimit<T, R>(
 export async function POST(req: NextRequest) {
   try {
     // Shared-secret auth: 프로덕션에서 이 endpoint 가 외부 노출되면 누구나 뉴스레터를
-    // 발송할 수 있으므로 DASHBOARD_MCP_SECRET 이 설정돼 있으면 헤더 일치 요구.
-    // 미설정 시(dev/로컬) 는 기존 동작 유지 — backward compat.
+    // 발송할 수 있으므로 DASHBOARD_MCP_SECRET 이 설정돼 있으면 외부 호출은 헤더 일치 요구.
+    //
+    // 단, dashboard UI (newsletter page, blog-manage 상세) 도 같은 endpoint 를 호출하는데
+    // 브라우저에서 서버 env 값을 헤더에 넣을 방법이 없다. Origin 이 같은 호스트 (same-origin)
+    // 인 요청은 dashboard UI 로 간주해 통과시키고, 그 외(다른 origin / origin 없음, 예: MCP
+    // 서버 fetch) 만 secret 검증.
+    //
+    // 보안 한계: Origin 헤더는 비-브라우저 클라이언트가 위조 가능. 이 가드는 "정상 dashboard
+    // UI 보호 + 방화벽 밖 무단 호출 차단" 수준. 완전한 auth 는 dashboard 자체 세션/JWT 도입이
+    // 필요하며 별도 작업.
+    //
+    // DASHBOARD_MCP_SECRET 미설정 시에는 기존 동작 (다 열림) 유지 — backward compat.
     const expected = process.env.DASHBOARD_MCP_SECRET;
     if (expected) {
-      const provided = req.headers.get("x-mcp-secret");
-      if (provided !== expected) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      const origin = req.headers.get("origin");
+      const host = req.headers.get("host");
+      const isSameOrigin = Boolean(origin && host && origin.endsWith(host));
+      if (!isSameOrigin) {
+        const provided = req.headers.get("x-mcp-secret");
+        if (provided !== expected) {
+          return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
       }
     }
 

--- a/dashboard/src/app/api/newsletter/send/route.ts
+++ b/dashboard/src/app/api/newsletter/send/route.ts
@@ -62,6 +62,17 @@ async function sendWithRateLimit<T, R>(
 
 export async function POST(req: NextRequest) {
   try {
+    // Shared-secret auth: 프로덕션에서 이 endpoint 가 외부 노출되면 누구나 뉴스레터를
+    // 발송할 수 있으므로 DASHBOARD_MCP_SECRET 이 설정돼 있으면 헤더 일치 요구.
+    // 미설정 시(dev/로컬) 는 기존 동작 유지 — backward compat.
+    const expected = process.env.DASHBOARD_MCP_SECRET;
+    if (expected) {
+      const provided = req.headers.get("x-mcp-secret");
+      if (provided !== expected) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
+    }
+
     const sb = getSupabase();
 
     const { subject, bodyHtml, postId, preview, recipientIds, force } = await req.json();

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { registerMediaTools } from './tools/media.js';
 import { registerVideoTools } from './tools/video.js';
 import { registerBlogPostTools } from './tools/blog-posts.js';
 import { registerCarouselTools } from './tools/carousels.js';
+import { registerNewsletterTools } from './tools/newsletter.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -53,6 +54,9 @@ async function main(): Promise<void> {
 
   // Carousel tools (AWC carousels table — slide deck CRUD)
   registerCarouselTools(server, adapter, supabaseUrl, supabaseKey);
+
+  // Newsletter — HTTP wrap over dashboard send endpoint + email_logs.variant_id linking
+  registerNewsletterTools(server, adapter, supabaseUrl, supabaseKey);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/blog-posts.ts
+++ b/src/tools/blog-posts.ts
@@ -237,6 +237,14 @@ export function registerBlogPostTools(
         .optional()
         .describe('true if the agent generated the full text; false if human-written content'),
       thumbnail_url: z.string().url().optional().describe('Optional thumbnail image URL'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) to link this blog_post to (1:1). Use the id returned by create_variant with format=blog. ' +
+            'When set, the derivative appears on the Content detail Variants card automatically.'
+        ),
     },
     async (params) => {
       try {
@@ -274,8 +282,10 @@ export function registerBlogPostTools(
           params.reading_time ??
           Math.max(1, Math.round(params.markdown_body.replace(/\s+/g, '').length / 500));
 
-        // 5. Insert blog_posts row (always draft)
-        const insertPayload = {
+        // 5. Insert blog_posts row (always draft).
+        //    variant_id 는 1:1 UNIQUE index 가 걸려있어 이미 다른 post 에 연결된 variant 를 재사용하면
+        //    PostgreSQL 이 23505 (unique violation) 을 뱉는다. 그 경우는 친절한 메시지로 변환.
+        const insertPayload: Record<string, unknown> = {
           title: params.title,
           slug: params.slug,
           excerpt: params.excerpt ?? null,
@@ -288,6 +298,7 @@ export function registerBlogPostTools(
           ai_generated: params.ai_generated ?? false,
           thumbnail_url: params.thumbnail_url ?? null,
         };
+        if (params.variant_id) insertPayload.variant_id = params.variant_id;
 
         const { data: inserted, error: insErr } = await sb
           .from('blog_posts')
@@ -296,6 +307,12 @@ export function registerBlogPostTools(
           .single();
 
         if (insErr || !inserted) {
+          if (insErr && (insErr as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another blog_post (1:1 constraint). ` +
+                `Create a new variant first, or use update_blog_post to re-link.`
+            );
+          }
           throw new Error(`Failed to insert blog_post: ${insErr?.message || 'unknown error'}`);
         }
 
@@ -326,6 +343,7 @@ export function registerBlogPostTools(
             status: post.status,
             reading_time: post.reading_time,
             category_slug: params.category_slug ?? null,
+            variant_id: params.variant_id ?? null,
             plate_nodes: plateContent.length,
           },
         });
@@ -360,6 +378,15 @@ export function registerBlogPostTools(
         .string()
         .optional()
         .describe('If provided, replaces content by converting markdown → PlateJS'),
+      variant_id: z
+        .string()
+        .uuid()
+        .nullable()
+        .optional()
+        .describe(
+          'Link (or re-link) this blog_post to a variant. Pass null to explicitly unlink. ' +
+            '1:1 — the target variant must not already be linked to another blog_post.'
+        ),
     },
     async (params) => {
       try {
@@ -387,7 +414,14 @@ export function registerBlogPostTools(
           .eq('id', id)
           .select()
           .single();
-        if (upErr) throw new Error(upErr.message);
+        if (upErr) {
+          if ((upErr as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another blog_post (1:1 constraint).`
+            );
+          }
+          throw new Error(upErr.message);
+        }
 
         return ok({ message: 'Blog post updated', post: data });
       } catch (e) {

--- a/src/tools/carousels.ts
+++ b/src/tools/carousels.ts
@@ -163,6 +163,14 @@ export function registerCarouselTools(
         .min(1)
         .max(20)
         .describe('Ordered list of slides (at least 1, max 20)'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) to link this carousel to (1:1). Use the id returned by ' +
+            'create_variant with format=carousel.'
+        ),
     },
     async (params) => {
       try {
@@ -176,19 +184,27 @@ export function registerCarouselTools(
           overrides: s.overrides ?? {},
         }));
 
-        const payload = {
+        const payload: Record<string, unknown> = {
           id: carouselId,
           title: params.title,
           caption: params.caption ?? null,
           slides,
         };
+        if (params.variant_id) payload.variant_id = params.variant_id;
 
         const { data, error } = await sb
           .from('carousels')
           .insert(payload)
           .select()
           .single();
-        if (error) throw new Error(error.message);
+        if (error) {
+          if ((error as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another carousel (1:1 constraint).`
+            );
+          }
+          throw new Error(error.message);
+        }
 
         const row = data as CarouselRow;
         await logCarouselActivity('create', row.id, {
@@ -227,6 +243,12 @@ export function registerCarouselTools(
         .array(slideInputSchema.extend({ id: z.string().optional() }))
         .optional()
         .describe('New slides array (replaces existing slides entirely)'),
+      variant_id: z
+        .string()
+        .uuid()
+        .nullable()
+        .optional()
+        .describe('Link (or re-link) this carousel to a variant. Pass null to unlink. 1:1 constraint.'),
     },
     async (params) => {
       try {
@@ -235,6 +257,7 @@ export function registerCarouselTools(
         };
         if (params.title !== undefined) update.title = params.title;
         if (params.caption !== undefined) update.caption = params.caption;
+        if (params.variant_id !== undefined) update.variant_id = params.variant_id;
         if (params.slides) {
           update.slides = params.slides.map((s: any) => ({
             id: s.id || uid('slide'),
@@ -252,7 +275,14 @@ export function registerCarouselTools(
           .eq('id', params.id)
           .select()
           .single();
-        if (error) throw new Error(error.message);
+        if (error) {
+          if ((error as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another carousel (1:1 constraint).`
+            );
+          }
+          throw new Error(error.message);
+        }
 
         const row = data as CarouselRow;
         await logCarouselActivity('update', row.id, {

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -27,6 +27,9 @@ export function registerNewsletterTools(
 ): void {
   const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
   const dashboardUrl = (process.env.DASHBOARD_API_URL ?? 'http://localhost:3003').replace(/\/+$/, '');
+  // 선택적 shared-secret. dashboard 쪽에도 DASHBOARD_MCP_SECRET 이 같은 값으로 설정돼야 동작.
+  // 미설정 시에는 헤더 없이 호출 → dashboard 도 미설정이면 통과 (backward compat).
+  const dashboardSecret = process.env.DASHBOARD_MCP_SECRET ?? null;
 
   server.tool(
     'send_newsletter',
@@ -72,9 +75,11 @@ export function registerNewsletterTools(
         }
 
         // 2. Call dashboard send endpoint
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (dashboardSecret) headers['x-mcp-secret'] = dashboardSecret;
         const res = await fetch(`${dashboardUrl}/api/newsletter/send`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers,
           body: JSON.stringify({
             postId: params.post_id,
             preview: params.preview ?? false,

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CMSAdapter } from '../adapters/interface.js';
+
+// 뉴스레터 발송 MCP 도구.
+//
+// 구조:
+//   Agent → send_newsletter(post_id, variant_id?)
+//       → Dashboard /api/newsletter/send (blog_post → HTML 렌더 + subscribers 조회 +
+//                                         Resend 발송 + email_logs/newsletter_deliveries 기록)
+//       → MCP 가 response 의 emailLogId 로 email_logs.variant_id 업데이트
+//
+// 왜 Dashboard 에 위임하나:
+//   발송 로직(PlateJS→HTML, 썸네일/이미지 처리, Resend rate-limit, 배달 추적) 이 이미 336 lines
+//   로 dashboard 쪽에 구현돼 있음. MCP 에서 중복 구현할 이유가 없고 두 곳에서 버전 불일치가
+//   생기면 운영 사고 위험. HTTP wrapper + 링크 후처리만 책임진다.
+//
+// 전제:
+//   - DASHBOARD_API_URL 환경변수 (기본 http://localhost:3003) 에 dashboard 가 떠있어야 한다.
+//   - dashboard 는 service-role Supabase 키로 동작하므로 별도 auth 필요 없음 (같은 신뢰 경계).
+export function registerNewsletterTools(
+  server: McpServer,
+  adapter: CMSAdapter,
+  supabaseUrl: string,
+  supabaseKey: string,
+): void {
+  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+  const dashboardUrl = (process.env.DASHBOARD_API_URL ?? 'http://localhost:3003').replace(/\/+$/, '');
+
+  server.tool(
+    'send_newsletter',
+    [
+      'Send a blog post as a newsletter to subscribers via the dashboard send pipeline.',
+      'Optionally records which variant (format=blog) this send was derived from, so the',
+      'Content detail page shows the send count on the Variants & Derivatives card.',
+      'Prerequisites: the dashboard app must be running (DASHBOARD_API_URL env var, default http://localhost:3003).',
+    ].join(' '),
+    {
+      post_id: z
+        .string()
+        .uuid()
+        .describe('blog_post.id to render and send (required).'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) (format=blog) to link on email_logs. ' +
+            'If omitted, the tool auto-resolves via blog_posts.variant_id.',
+        ),
+      preview: z
+        .boolean()
+        .optional()
+        .describe('If true, send only to admin preview recipient(s) (dashboard controls which).'),
+      force: z
+        .boolean()
+        .optional()
+        .describe('If true, ignore the "already sent" duplicate check.'),
+    },
+    async (params) => {
+      try {
+        // 1. Resolve variant_id if not provided
+        let variantId = params.variant_id ?? null;
+        if (!variantId) {
+          const { data: post } = await sb
+            .from('blog_posts')
+            .select('variant_id')
+            .eq('id', params.post_id)
+            .maybeSingle();
+          variantId = (post as { variant_id: string | null } | null)?.variant_id ?? null;
+        }
+
+        // 2. Call dashboard send endpoint
+        const res = await fetch(`${dashboardUrl}/api/newsletter/send`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            postId: params.post_id,
+            preview: params.preview ?? false,
+            force: params.force ?? false,
+          }),
+        });
+
+        const body = (await res.json().catch(() => ({}))) as {
+          ok?: boolean;
+          emailLogId?: string;
+          sentCount?: number;
+          failedCount?: number;
+          finalStatus?: string;
+          error?: string;
+        };
+
+        if (!res.ok || body.error) {
+          throw new Error(
+            `Dashboard send failed (${res.status}): ${body.error ?? 'unknown'}. ` +
+              `Is dashboard running at ${dashboardUrl}?`,
+          );
+        }
+
+        // 3. Link email_logs.variant_id after successful send
+        let linkedVariantId: string | null = null;
+        if (variantId && body.emailLogId) {
+          const { error: linkErr } = await sb
+            .from('email_logs')
+            .update({ variant_id: variantId })
+            .eq('id', body.emailLogId);
+          if (!linkErr) linkedVariantId = variantId;
+          else {
+            // 링크 실패해도 발송 자체는 완료. 경고만 로그.
+            console.error(`[send_newsletter] email_logs.variant_id 링크 실패:`, linkErr.message);
+          }
+        }
+
+        // 4. Record as Publication (channel='newsletter') for pipeline visibility
+        try {
+          await adapter.logActivity({
+            action: 'publish',
+            collection: 'email_logs',
+            item_id: body.emailLogId ?? 'unknown',
+            actor_type: 'agent',
+            payload: {
+              post_id: params.post_id,
+              variant_id: linkedVariantId,
+              sent_count: body.sentCount ?? 0,
+              failed_count: body.failedCount ?? 0,
+              final_status: body.finalStatus ?? 'unknown',
+            },
+          });
+        } catch {
+          // 감사 로그 실패는 발송을 막지 않는다.
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  message: `Newsletter sent. ${body.sentCount ?? 0} success, ${body.failedCount ?? 0} failed.`,
+                  email_log_id: body.emailLogId ?? null,
+                  variant_id_linked: linkedVariantId,
+                  final_status: body.finalStatus ?? 'unknown',
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -98,9 +98,11 @@ export function registerNewsletterTools(
           );
         }
 
-        // 3. Link email_logs.variant_id after successful send
+        // 3. Link email_logs.variant_id after successful send.
+        //    preview 모드는 관리자 테스트 발송이므로 실제 독자 발송 이력으로 기록되면
+        //    Content 상세의 "📧 N명 발송" 배지에 가짜 이력이 섞인다. variant 링크 스킵.
         let linkedVariantId: string | null = null;
-        if (variantId && body.emailLogId) {
+        if (!params.preview && variantId && body.emailLogId) {
           const { error: linkErr } = await sb
             .from('email_logs')
             .update({ variant_id: variantId })

--- a/src/tools/publications.ts
+++ b/src/tools/publications.ts
@@ -8,6 +8,14 @@ export function registerPublicationTools(server: McpServer, adapter: CMSAdapter)
     'Record a publication event — tracks where and when content was published, with optional metrics.',
     {
       content_id: z.string().uuid().describe('ID of the content that was published'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant that was actually published (recommended when a specific platform ' +
+            'variant is being recorded — enables variant-level metric tracking).'
+        ),
       channel: z.string().describe('Publication channel (e.g., "blog", "twitter", "linkedin")'),
       channel_post_id: z.string().optional().describe('Platform-specific post ID'),
       url: z.string().url().optional().describe('URL where the content was published'),


### PR DESCRIPTION
## 요약

\`/api/newsletter/send\` 가 auth 없이 public 이라 외부 노출 시 무단 발송 위험. DASHBOARD_MCP_SECRET 기반 shared-secret 헤더 검증 추가.

## 배경

MCP send_newsletter 가 dashboard HTTP endpoint 를 호출하는데, 그 엔드포인트가 아무 인증 없이 열려 있음 (이전부터). 내부 네트워크/방화벽 환경이면 OK 지만 dashboard 가 외부에 노출되는 순간 누구나 Resend 발송 트리거 가능.

## 변경

### Dashboard (`/api/newsletter/send/route.ts`)
\`\`\`ts
const expected = process.env.DASHBOARD_MCP_SECRET;
if (expected) {
  const provided = req.headers.get("x-mcp-secret");
  if (provided !== expected) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
}
\`\`\`

### MCP (`src/tools/newsletter.ts`)
\`\`\`ts
const headers: Record<string, string> = { 'Content-Type': 'application/json' };
if (dashboardSecret) headers['x-mcp-secret'] = dashboardSecret;
\`\`\`

## Backward compatibility

- DASHBOARD_MCP_SECRET **미설정**: 기존처럼 auth 없이 동작. 로컬 dev 편의.
- DASHBOARD_MCP_SECRET **양쪽 설정**: 헤더 일치 요구. 프로덕션 권장.
- Dashboard 만 설정: MCP 호출 401 → 에러 메시지로 유도. 대시보드 UI 자체 호출(Send 버튼) 도 401 가능성 → 향후 별도 세션 기반 auth 필요.

## 보안 한계

- 단일 공유 시크릿. 키 로테이션 시 양쪽 재시작 필요.
- 헤더이므로 HTTPS 필수. HTTP 평문 노출 시 의미 없음.
- 부분 방어 — 근본 해결은 dashboard 자체 auth (세션, JWT 등). 그건 별도 큰 작업.

## 의존성

#29 (newsletter.ts 존재) 가 머지된 후 이 PR 머지 권장. 현재는 #29 를 base 로 stack.