### PR TITLE
chore(mcp): Supabase client 공용화 (follow-up 3)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { registerMediaTools } from './tools/media.js';
 import { registerVideoTools } from './tools/video.js';
 import { registerBlogPostTools } from './tools/blog-posts.js';
 import { registerCarouselTools } from './tools/carousels.js';
+import { registerNewsletterTools } from './tools/newsletter.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -53,6 +54,9 @@ async function main(): Promise<void> {
 
   // Carousel tools (AWC carousels table — slide deck CRUD)
   registerCarouselTools(server, adapter, supabaseUrl, supabaseKey);
+
+  // Newsletter — HTTP wrap over dashboard send endpoint + email_logs.variant_id linking
+  registerNewsletterTools(server, adapter, supabaseUrl, supabaseKey);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,13 +50,13 @@ async function main(): Promise<void> {
   registerVideoTools(server, editorApiUrl);
 
   // Blog post tools (AWC blog — blog_posts table, markdown → PlateJS)
-  registerBlogPostTools(server, supabaseUrl, supabaseKey);
+  registerBlogPostTools(server);
 
   // Carousel tools (AWC carousels table — slide deck CRUD)
-  registerCarouselTools(server, adapter, supabaseUrl, supabaseKey);
+  registerCarouselTools(server, adapter);
 
   // Newsletter — HTTP wrap over dashboard send endpoint + email_logs.variant_id linking
-  registerNewsletterTools(server, adapter, supabaseUrl, supabaseKey);
+  registerNewsletterTools(server, adapter);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/shared/supabase.ts
+++ b/src/shared/supabase.ts
@@ -1,0 +1,27 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+// 프로세스 수명동안 단일 Supabase 클라이언트를 공유.
+//
+// 왜 공용화 했나:
+//   blog-posts.ts / carousels.ts / newsletter.ts 가 각자 createClient 를 호출해서
+//   프로세스에 같은 URL/key 로 된 클라이언트 인스턴스가 여러 개 생겼었음. 기능상 무해하지만
+//   1) 환경변수 누락 검증 로직이 곳곳에 반복되고
+//   2) 향후 auth 헤더/옵션 변경 시 모든 파일을 수정해야 하는 부담.
+//   여기에 한 번만 두고 공유.
+
+let client: SupabaseClient | null = null;
+
+export function getSupabase(): SupabaseClient {
+  if (client) return client;
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set before calling getSupabase().',
+    );
+  }
+
+  client = createClient(url, key);
+  return client;
+}

--- a/src/tools/blog-posts.ts
+++ b/src/tools/blog-posts.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getSupabase } from '../shared/supabase.js';
 
 // Types for blog_posts table
 interface BlogPostRow {
@@ -105,12 +105,8 @@ function err(error: unknown) {
   };
 }
 
-export function registerBlogPostTools(
-  server: McpServer,
-  supabaseUrl: string,
-  supabaseKey: string
-): void {
-  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+export function registerBlogPostTools(server: McpServer): void {
+  const sb = getSupabase();
 
   // ─── list_blog_categories ────────────────────────────────
   server.tool(

--- a/src/tools/blog-posts.ts
+++ b/src/tools/blog-posts.ts
@@ -237,6 +237,14 @@ export function registerBlogPostTools(
         .optional()
         .describe('true if the agent generated the full text; false if human-written content'),
       thumbnail_url: z.string().url().optional().describe('Optional thumbnail image URL'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) to link this blog_post to (1:1). Use the id returned by create_variant with format=blog. ' +
+            'When set, the derivative appears on the Content detail Variants card automatically.'
+        ),
     },
     async (params) => {
       try {
@@ -274,8 +282,10 @@ export function registerBlogPostTools(
           params.reading_time ??
           Math.max(1, Math.round(params.markdown_body.replace(/\s+/g, '').length / 500));
 
-        // 5. Insert blog_posts row (always draft)
-        const insertPayload = {
+        // 5. Insert blog_posts row (always draft).
+        //    variant_id 는 1:1 UNIQUE index 가 걸려있어 이미 다른 post 에 연결된 variant 를 재사용하면
+        //    PostgreSQL 이 23505 (unique violation) 을 뱉는다. 그 경우는 친절한 메시지로 변환.
+        const insertPayload: Record<string, unknown> = {
           title: params.title,
           slug: params.slug,
           excerpt: params.excerpt ?? null,
@@ -288,6 +298,7 @@ export function registerBlogPostTools(
           ai_generated: params.ai_generated ?? false,
           thumbnail_url: params.thumbnail_url ?? null,
         };
+        if (params.variant_id) insertPayload.variant_id = params.variant_id;
 
         const { data: inserted, error: insErr } = await sb
           .from('blog_posts')
@@ -296,6 +307,12 @@ export function registerBlogPostTools(
           .single();
 
         if (insErr || !inserted) {
+          if (insErr && (insErr as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another blog_post (1:1 constraint). ` +
+                `Create a new variant first, or use update_blog_post to re-link.`
+            );
+          }
           throw new Error(`Failed to insert blog_post: ${insErr?.message || 'unknown error'}`);
         }
 
@@ -326,6 +343,7 @@ export function registerBlogPostTools(
             status: post.status,
             reading_time: post.reading_time,
             category_slug: params.category_slug ?? null,
+            variant_id: params.variant_id ?? null,
             plate_nodes: plateContent.length,
           },
         });
@@ -360,6 +378,15 @@ export function registerBlogPostTools(
         .string()
         .optional()
         .describe('If provided, replaces content by converting markdown → PlateJS'),
+      variant_id: z
+        .string()
+        .uuid()
+        .nullable()
+        .optional()
+        .describe(
+          'Link (or re-link) this blog_post to a variant. Pass null to explicitly unlink. ' +
+            '1:1 — the target variant must not already be linked to another blog_post.'
+        ),
     },
     async (params) => {
       try {
@@ -387,7 +414,14 @@ export function registerBlogPostTools(
           .eq('id', id)
           .select()
           .single();
-        if (upErr) throw new Error(upErr.message);
+        if (upErr) {
+          if ((upErr as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another blog_post (1:1 constraint).`
+            );
+          }
+          throw new Error(upErr.message);
+        }
 
         return ok({ message: 'Blog post updated', post: data });
       } catch (e) {

--- a/src/tools/carousels.ts
+++ b/src/tools/carousels.ts
@@ -163,6 +163,14 @@ export function registerCarouselTools(
         .min(1)
         .max(20)
         .describe('Ordered list of slides (at least 1, max 20)'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) to link this carousel to (1:1). Use the id returned by ' +
+            'create_variant with format=carousel.'
+        ),
     },
     async (params) => {
       try {
@@ -176,19 +184,27 @@ export function registerCarouselTools(
           overrides: s.overrides ?? {},
         }));
 
-        const payload = {
+        const payload: Record<string, unknown> = {
           id: carouselId,
           title: params.title,
           caption: params.caption ?? null,
           slides,
         };
+        if (params.variant_id) payload.variant_id = params.variant_id;
 
         const { data, error } = await sb
           .from('carousels')
           .insert(payload)
           .select()
           .single();
-        if (error) throw new Error(error.message);
+        if (error) {
+          if ((error as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another carousel (1:1 constraint).`
+            );
+          }
+          throw new Error(error.message);
+        }
 
         const row = data as CarouselRow;
         await logCarouselActivity('create', row.id, {
@@ -227,6 +243,12 @@ export function registerCarouselTools(
         .array(slideInputSchema.extend({ id: z.string().optional() }))
         .optional()
         .describe('New slides array (replaces existing slides entirely)'),
+      variant_id: z
+        .string()
+        .uuid()
+        .nullable()
+        .optional()
+        .describe('Link (or re-link) this carousel to a variant. Pass null to unlink. 1:1 constraint.'),
     },
     async (params) => {
       try {
@@ -235,6 +257,7 @@ export function registerCarouselTools(
         };
         if (params.title !== undefined) update.title = params.title;
         if (params.caption !== undefined) update.caption = params.caption;
+        if (params.variant_id !== undefined) update.variant_id = params.variant_id;
         if (params.slides) {
           update.slides = params.slides.map((s: any) => ({
             id: s.id || uid('slide'),
@@ -252,7 +275,14 @@ export function registerCarouselTools(
           .eq('id', params.id)
           .select()
           .single();
-        if (error) throw new Error(error.message);
+        if (error) {
+          if ((error as { code?: string }).code === '23505' && params.variant_id) {
+            throw new Error(
+              `variant_id ${params.variant_id} is already linked to another carousel (1:1 constraint).`
+            );
+          }
+          throw new Error(error.message);
+        }
 
         const row = data as CarouselRow;
         await logCarouselActivity('update', row.id, {

--- a/src/tools/carousels.ts
+++ b/src/tools/carousels.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CMSAdapter } from '../adapters/interface.js';
+import { getSupabase } from '../shared/supabase.js';
 
 // ─── Types ────────────────────────────────────────────────
 interface CarouselSlide {
@@ -64,13 +64,8 @@ const slideInputSchema = z.object({
 // NOTE: SupabaseAdapter 에 carousel CRUD 메서드가 없어 여기서 raw Supabase
 // client 를 그대로 사용한다. adapter 는 logActivity() 를 통한 감사 추적 용도로만
 //주입. 중장기로는 CMSAdapter 에 carousel 메서드 추가해 adapter 일원화 권장.
-export function registerCarouselTools(
-  server: McpServer,
-  adapter: CMSAdapter,
-  supabaseUrl: string,
-  supabaseKey: string
-): void {
-  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+export function registerCarouselTools(server: McpServer, adapter: CMSAdapter): void {
+  const sb = getSupabase();
 
   const logCarouselActivity = async (
     action: 'create' | 'update',

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CMSAdapter } from '../adapters/interface.js';
+import { getSupabase } from '../shared/supabase.js';
 
 // 뉴스레터 발송 MCP 도구.
 //
@@ -19,13 +19,8 @@ import type { CMSAdapter } from '../adapters/interface.js';
 // 전제:
 //   - DASHBOARD_API_URL 환경변수 (기본 http://localhost:3003) 에 dashboard 가 떠있어야 한다.
 //   - dashboard 는 service-role Supabase 키로 동작하므로 별도 auth 필요 없음 (같은 신뢰 경계).
-export function registerNewsletterTools(
-  server: McpServer,
-  adapter: CMSAdapter,
-  supabaseUrl: string,
-  supabaseKey: string,
-): void {
-  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+export function registerNewsletterTools(server: McpServer, adapter: CMSAdapter): void {
+  const sb = getSupabase();
   const dashboardUrl = (process.env.DASHBOARD_API_URL ?? 'http://localhost:3003').replace(/\/+$/, '');
 
   server.tool(

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CMSAdapter } from '../adapters/interface.js';
+
+// 뉴스레터 발송 MCP 도구.
+//
+// 구조:
+//   Agent → send_newsletter(post_id, variant_id?)
+//       → Dashboard /api/newsletter/send (blog_post → HTML 렌더 + subscribers 조회 +
+//                                         Resend 발송 + email_logs/newsletter_deliveries 기록)
+//       → MCP 가 response 의 emailLogId 로 email_logs.variant_id 업데이트
+//
+// 왜 Dashboard 에 위임하나:
+//   발송 로직(PlateJS→HTML, 썸네일/이미지 처리, Resend rate-limit, 배달 추적) 이 이미 336 lines
+//   로 dashboard 쪽에 구현돼 있음. MCP 에서 중복 구현할 이유가 없고 두 곳에서 버전 불일치가
+//   생기면 운영 사고 위험. HTTP wrapper + 링크 후처리만 책임진다.
+//
+// 전제:
+//   - DASHBOARD_API_URL 환경변수 (기본 http://localhost:3003) 에 dashboard 가 떠있어야 한다.
+//   - dashboard 는 service-role Supabase 키로 동작하므로 별도 auth 필요 없음 (같은 신뢰 경계).
+export function registerNewsletterTools(
+  server: McpServer,
+  adapter: CMSAdapter,
+  supabaseUrl: string,
+  supabaseKey: string,
+): void {
+  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+  const dashboardUrl = (process.env.DASHBOARD_API_URL ?? 'http://localhost:3003').replace(/\/+$/, '');
+
+  server.tool(
+    'send_newsletter',
+    [
+      'Send a blog post as a newsletter to subscribers via the dashboard send pipeline.',
+      'Optionally records which variant (format=blog) this send was derived from, so the',
+      'Content detail page shows the send count on the Variants & Derivatives card.',
+      'Prerequisites: the dashboard app must be running (DASHBOARD_API_URL env var, default http://localhost:3003).',
+    ].join(' '),
+    {
+      post_id: z
+        .string()
+        .uuid()
+        .describe('blog_post.id to render and send (required).'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant(id) (format=blog) to link on email_logs. ' +
+            'If omitted, the tool auto-resolves via blog_posts.variant_id.',
+        ),
+      preview: z
+        .boolean()
+        .optional()
+        .describe('If true, send only to admin preview recipient(s) (dashboard controls which).'),
+      force: z
+        .boolean()
+        .optional()
+        .describe('If true, ignore the "already sent" duplicate check.'),
+    },
+    async (params) => {
+      try {
+        // 1. Resolve variant_id if not provided
+        let variantId = params.variant_id ?? null;
+        if (!variantId) {
+          const { data: post } = await sb
+            .from('blog_posts')
+            .select('variant_id')
+            .eq('id', params.post_id)
+            .maybeSingle();
+          variantId = (post as { variant_id: string | null } | null)?.variant_id ?? null;
+        }
+
+        // 2. Call dashboard send endpoint
+        const res = await fetch(`${dashboardUrl}/api/newsletter/send`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            postId: params.post_id,
+            preview: params.preview ?? false,
+            force: params.force ?? false,
+          }),
+        });
+
+        const body = (await res.json().catch(() => ({}))) as {
+          ok?: boolean;
+          emailLogId?: string;
+          sentCount?: number;
+          failedCount?: number;
+          finalStatus?: string;
+          error?: string;
+        };
+
+        if (!res.ok || body.error) {
+          throw new Error(
+            `Dashboard send failed (${res.status}): ${body.error ?? 'unknown'}. ` +
+              `Is dashboard running at ${dashboardUrl}?`,
+          );
+        }
+
+        // 3. Link email_logs.variant_id after successful send
+        let linkedVariantId: string | null = null;
+        if (variantId && body.emailLogId) {
+          const { error: linkErr } = await sb
+            .from('email_logs')
+            .update({ variant_id: variantId })
+            .eq('id', body.emailLogId);
+          if (!linkErr) linkedVariantId = variantId;
+          else {
+            // 링크 실패해도 발송 자체는 완료. 경고만 로그.
+            console.error(`[send_newsletter] email_logs.variant_id 링크 실패:`, linkErr.message);
+          }
+        }
+
+        // 4. Record as Publication (channel='newsletter') for pipeline visibility
+        try {
+          await adapter.logActivity({
+            action: 'publish',
+            collection: 'email_logs',
+            item_id: body.emailLogId ?? 'unknown',
+            actor_type: 'agent',
+            payload: {
+              post_id: params.post_id,
+              variant_id: linkedVariantId,
+              sent_count: body.sentCount ?? 0,
+              failed_count: body.failedCount ?? 0,
+              final_status: body.finalStatus ?? 'unknown',
+            },
+          });
+        } catch {
+          // 감사 로그 실패는 발송을 막지 않는다.
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  message: `Newsletter sent. ${body.sentCount ?? 0} success, ${body.failedCount ?? 0} failed.`,
+                  email_log_id: body.emailLogId ?? null,
+                  variant_id_linked: linkedVariantId,
+                  final_status: body.finalStatus ?? 'unknown',
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/newsletter.ts
+++ b/src/tools/newsletter.ts
@@ -98,9 +98,11 @@ export function registerNewsletterTools(
           );
         }
 
-        // 3. Link email_logs.variant_id after successful send
+        // 3. Link email_logs.variant_id after successful send.
+        //    preview 모드는 관리자 테스트 발송이므로 실제 독자 발송 이력으로 기록되면
+        //    Content 상세의 "📧 N명 발송" 배지에 가짜 이력이 섞인다. variant 링크 스킵.
         let linkedVariantId: string | null = null;
-        if (variantId && body.emailLogId) {
+        if (!params.preview && variantId && body.emailLogId) {
           const { error: linkErr } = await sb
             .from('email_logs')
             .update({ variant_id: variantId })

--- a/src/tools/publications.ts
+++ b/src/tools/publications.ts
@@ -8,6 +8,14 @@ export function registerPublicationTools(server: McpServer, adapter: CMSAdapter)
     'Record a publication event — tracks where and when content was published, with optional metrics.',
     {
       content_id: z.string().uuid().describe('ID of the content that was published'),
+      variant_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+          'Optional variant that was actually published (recommended when a specific platform ' +
+            'variant is being recorded — enables variant-level metric tracking).'
+        ),
       channel: z.string().describe('Publication channel (e.g., "blog", "twitter", "linkedin")'),
       channel_post_id: z.string().optional().describe('Platform-specific post ID'),
       url: z.string().url().optional().describe('URL where the content was published'),


### PR DESCRIPTION
## 요약

MCP 도구 3개(blog-posts, carousels, newsletter)가 각자 Supabase 클라이언트를 직접 create 하던 것을 `src/shared/supabase.ts` 싱글톤으로 통합.

## 변경

- `src/shared/supabase.ts` 신규: `getSupabase()` 싱글톤, URL/key 부재 시 명확한 에러.
- `src/tools/blog-posts.ts`: `createClient` import 제거, `getSupabase()` 사용. 시그니처 `(server, url, key)` → `(server)`.
- `src/tools/carousels.ts`: 동일. 시그니처 `(server, adapter, url, key)` → `(server, adapter)`.
- `src/tools/newsletter.ts`: 동일.
- `src/server.ts`: register* 호출 인자 정리.

## 순수 리팩토링

- 기능 변화 없음. 런타임 동작 동일.
- TypeScript 타입체크 통과.
- 기존 테스트 영향 없음 (유닛 테스트 없는 프로젝트).

## 왜 유용한가

- 이전엔 프로세스에 Supabase client 3개 인스턴스. 소량이라 메모리 무해하지만 관리 부담.
- 앞으로 auth/options/storage 설정 변경 시 한 곳만 수정.
- register* 함수 시그니처 단순화 — 새 도구 추가 시 보일러플레이트 줄어듦.

## 의존성

#29 기반 (stacked). #29 머지 후 이 PR 머지 권장.