### PR TITLE
chore(mcp): video-link 도구도 getSupabase() 로 통일

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
   registerNewsletterTools(server, adapter);
 
   // video_projects 는 brxce-editor 경유 생성이라 variant_id 를 post-link 로 채우는 전용 도구.
-  registerVideoLinkTools(server, adapter, supabaseUrl, supabaseKey);
+  registerVideoLinkTools(server, adapter);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/video-link.ts
+++ b/src/tools/video-link.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CMSAdapter } from '../adapters/interface.js';
+import { getSupabase } from '../shared/supabase.js';
 
 // video_projects 는 brxce-editor FastAPI(`/api/projects/save`) 경유로 만들어지므로
 // create 시점에 variant_id 를 바로 넣을 수 없다. 대신 기존 레코드의 variant_id 를
@@ -13,13 +13,8 @@ import type { CMSAdapter } from '../adapters/interface.js';
 //   3) link_video_project_to_variant(video_project_id=B, variant_id=A) → 연결
 //
 // 향후 brxce-editor 의 save 엔드포인트에 variant_id 가 추가되면 이 도구는 보조 유지.
-export function registerVideoLinkTools(
-  server: McpServer,
-  adapter: CMSAdapter,
-  supabaseUrl: string,
-  supabaseKey: string,
-): void {
-  const sb: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+export function registerVideoLinkTools(server: McpServer, adapter: CMSAdapter): void {
+  const sb = getSupabase();
 
   server.tool(
     'link_video_project_to_variant',


### PR DESCRIPTION
## 요약

#32(Supabase client 공용화) 에서 video-link 가 scope 밖이었던 탓에 혼자 4-인자 시그니처로 남아있던 inconsistency 정리.

## Before / After

\`\`\`
// Before
registerBlogPostTools(server);                    // 1-arg
registerCarouselTools(server, adapter);           // 2-arg
registerNewsletterTools(server, adapter);         // 2-arg
registerVideoLinkTools(server, adapter, url, key); // 4-arg ← 유일하게 다름

// After
registerVideoLinkTools(server, adapter);          // 2-arg ← 통일
\`\`\`

## 변경

- \`src/tools/video-link.ts\`: createClient import 제거, getSupabase() 사용, 시그니처 2-인자
- \`src/server.ts\`: registerVideoLinkTools 호출 인자 정리

## 영향 범위

- 기능 변화 없음 (순수 리팩토링)
- TypeScript 타입체크 통과
- 동일 Supabase client 싱글톤 사용 → 일관성 확보