### PR TITLE
feat(mcp): Postiz 연동 + Claude Code 사용 가이드

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,25 +64,37 @@ list_contents, get_content, create_content, update_content, list_ideas, promote_
 Claude Code 는 `.mcp.json` (repo 루트) 또는 사용자 설정으로 MCP 서버를 등록한다.
 
 ### 프로젝트 루트 `.mcp.json` 예시
+
+`<...>` 부분은 **본인 환경에 맞게** 교체.
+
 ```json
 {
   "mcpServers": {
     "agentic-cms": {
       "command": "node",
-      "args": ["/Users/jangdongjin/Projects/agentic-cms/dist/server.js"],
+      "args": ["<repo 절대 경로>/agentic-cms/dist/server.js"],
       "env": {
-        "SUPABASE_URL": "https://<project>.supabase.co",
+        "SUPABASE_URL": "https://<project-ref>.supabase.co",
         "SUPABASE_SERVICE_ROLE_KEY": "<service-role-key>",
         "DASHBOARD_API_URL": "http://localhost:3003",
-        "DASHBOARD_MCP_SECRET": "<선택: newsletter send auth>",
+        "DASHBOARD_MCP_SECRET": "<optional: newsletter send auth — dashboard env 와 동일 값>",
         "POSTIZ_API_URL": "https://postiz.agenticworkflows.club",
-        "POSTIZ_API_KEY": "<postiz workspace api key>",
-        "CONTENT_CORE_CLI_PATH": "<awc @awc/content-core cli 경로>"
+        "POSTIZ_API_KEY": "<Postiz Settings → API 에서 발급>",
+        "POSTIZ_AUTH_SCHEME": "raw",
+        "CONTENT_CORE_CLI_PATH": "<awc repo 절대 경로>/awc/packages/content-core/dist/cli.js"
       }
     }
   }
 }
 ```
+
+**env 설명**
+- `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`: **필수**. Supabase 프로젝트 접속.
+- `DASHBOARD_API_URL`: 뉴스레터 발송 시 dashboard `/api/newsletter/send` 호출에 사용. 기본 `http://localhost:3003`.
+- `DASHBOARD_MCP_SECRET`: 옵션. dashboard 쪽에도 동일 값 설정돼 있으면 외부 호출 검증용 secret.
+- `POSTIZ_API_URL` / `POSTIZ_API_KEY`: Postiz 소셜 발행에 **필수**. Postiz 사용 안 할 거면 생략 — send_to_postiz 도구만 기능 꺼짐.
+- `POSTIZ_AUTH_SCHEME`: `raw` (기본) / `bearer` / `x-api-key` 중 택 1. Postiz 배포 버전에 따라 다름. 400/401 나면 바꿔 시도.
+- `CONTENT_CORE_CLI_PATH`: AWC 의 `@awc/content-core` CLI 경로. create_blog_post_from_markdown 에서만 필요.
 
 ### 사전 빌드
 `npm install && npm run build` 로 `dist/server.js` 가 생성돼야 `node dist/server.js` 로 실행 가능. Claude Code 재시작하면 MCP 서버에 연결.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,82 @@ list_contents, get_content, create_content, update_content, list_ideas, promote_
 - URL: 환경변수 SUPABASE_URL (또는 NEXT_PUBLIC_SUPABASE_URL)
 - Key: 환경변수 SUPABASE_SERVICE_ROLE_KEY
 - .env.local (dashboard)에 설정됨
+
+## Claude Code 에서 MCP 사용법
+
+Claude Code 는 `.mcp.json` (repo 루트) 또는 사용자 설정으로 MCP 서버를 등록한다.
+
+### 프로젝트 루트 `.mcp.json` 예시
+```json
+{
+  "mcpServers": {
+    "agentic-cms": {
+      "command": "node",
+      "args": ["/Users/jangdongjin/Projects/agentic-cms/dist/server.js"],
+      "env": {
+        "SUPABASE_URL": "https://<project>.supabase.co",
+        "SUPABASE_SERVICE_ROLE_KEY": "<service-role-key>",
+        "DASHBOARD_API_URL": "http://localhost:3003",
+        "DASHBOARD_MCP_SECRET": "<선택: newsletter send auth>",
+        "POSTIZ_API_URL": "https://postiz.agenticworkflows.club",
+        "POSTIZ_API_KEY": "<postiz workspace api key>",
+        "CONTENT_CORE_CLI_PATH": "<awc @awc/content-core cli 경로>"
+      }
+    }
+  }
+}
+```
+
+### 사전 빌드
+`npm install && npm run build` 로 `dist/server.js` 가 생성돼야 `node dist/server.js` 로 실행 가능. Claude Code 재시작하면 MCP 서버에 연결.
+
+### 연결 검증
+Claude Code 에서 새 세션 시작 후: "agentic-cms 의 MCP 도구 목록 알려줘" → `list_topics` / `create_idea` / ... 등 도구 이름이 보이면 성공.
+
+## Postiz 연동
+
+소셜 채널 실제 발행은 Postiz 를 통한다.
+
+### 사전 설정 (Postiz 쪽)
+1. https://postiz.agenticworkflows.club 또는 자가 호스팅 Postiz 인스턴스
+2. Settings → API → API Key 생성
+3. 각 소셜 채널(Instagram/LinkedIn/Threads/X/YouTube) 을 Integrations 에서 OAuth 연결
+
+### 에이전트 사용 흐름
+```
+1. list_postiz_integrations()             → 연결된 채널 id 확인
+2. send_to_postiz({
+     variant_id,                          → 발행할 variant
+     integration_id,                      → 위에서 확보한 id
+     scheduled_at?                        → 즉시 발행이면 생략
+   })
+→ variant.status = 'sent_to_postiz'
+→ variant.platform_settings.postiz_post_id 기록
+→ publications 테이블에 자동 기록 (content_id + variant_id + channel)
+```
+
+### 발행 실패 시
+- DTO 형식 불일치가 Postiz 버전에 따라 발생 가능. 기본 DTO 가 안 맞으면 `raw_payload` 파라미터로 에이전트가 직접 body 구성 후 전달.
+- `dry_run: true` 로 실 호출 없이 payload 만 미리 확인 가능.
+
+## 에이전트 e2e 파이프라인 (Postiz 포함)
+
+**시나리오**: "AX 전환 토픽으로 블로그 + LinkedIn + 뉴스레터 + Instagram 발행"
+
+```
+1. list_topics()                                    → AX 전환 id
+2. create_idea({topic_id, raw_text, angle})         → idea.id
+3. promote_idea({idea_id, title, slug, hook, cta})  → content (draft)
+4. update_content({id, body_md, core_message})      → 본문
+5. create_variant(blog) → variant_blog
+6. create_blog_post_from_markdown(variant_id=blog.id) → blog_post
+7. send_newsletter(post_id, variant_id=blog.id)     → 뉴스레터 발송
+8. create_variant(linkedin thread) → variant_linkedin
+9. create_variant(instagram carousel) → variant_ig
+10. create_carousel(variant_id=ig.id, slides)       → carousel 레코드
+11. list_postiz_integrations()                      → linkedin_id, ig_id
+12. send_to_postiz(variant_id=linkedin.id, integration_id=linkedin_id) → LinkedIn 발행
+13. send_to_postiz(variant_id=ig.id, integration_id=ig_id)              → Instagram 발행
+```
+
+→ Contents 상세에 blog/carousel/newsletter/publications 전부 variant 트리로 연결 표시.

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { registerBlogPostTools } from './tools/blog-posts.js';
 import { registerCarouselTools } from './tools/carousels.js';
 import { registerNewsletterTools } from './tools/newsletter.js';
 import { registerVideoLinkTools } from './tools/video-link.js';
+import { registerPostizTools } from './tools/postiz.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -61,6 +62,9 @@ async function main(): Promise<void> {
 
   // video_projects 는 brxce-editor 경유 생성이라 variant_id 를 post-link 로 채우는 전용 도구.
   registerVideoLinkTools(server, adapter);
+
+  // Postiz — 소셜 채널 실제 발행 (POSTIZ_API_URL + POSTIZ_API_KEY 필요).
+  registerPostizTools(server, adapter);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/postiz.ts
+++ b/src/tools/postiz.ts
@@ -25,8 +25,27 @@ import { getSupabase } from '../shared/supabase.js';
 export function registerPostizTools(server: McpServer, adapter: CMSAdapter): void {
   const postizUrl = (process.env.POSTIZ_API_URL ?? '').replace(/\/+$/, '');
   const postizKey = process.env.POSTIZ_API_KEY ?? '';
+  // Postiz 배포 버전에 따라 인증 헤더 형식이 다르다:
+  //   - 'raw'        : Authorization: <key>            (기본, 대부분의 Postiz)
+  //   - 'bearer'     : Authorization: Bearer <key>
+  //   - 'x-api-key'  : x-api-key: <key>                (몇몇 커스텀 배포)
+  // env POSTIZ_AUTH_SCHEME 으로 명시. 미설정 시 raw.
+  const authScheme = (process.env.POSTIZ_AUTH_SCHEME ?? 'raw').toLowerCase();
 
   const postizConfigured = Boolean(postizUrl && postizKey);
+
+  // 소셜 채널 whitelist — variant.platform 이 아래 중 하나여야 Postiz 로 보낼 수 있다.
+  // blog / email / self 같은 자사 채널 variant 를 실수로 소셜에 발행하는 것 방지.
+  const POSTIZ_ALLOWED_PLATFORMS = new Set([
+    'instagram',
+    'linkedin',
+    'threads',
+    'tiktok',
+    'youtube',
+    'x',
+    'twitter',
+    'facebook',
+  ]);
 
   const postizFetch = async (path: string, init?: RequestInit): Promise<Response> => {
     if (!postizConfigured) {
@@ -34,11 +53,15 @@ export function registerPostizTools(server: McpServer, adapter: CMSAdapter): voi
         'Postiz not configured. Set POSTIZ_API_URL and POSTIZ_API_KEY env vars before using Postiz tools.',
       );
     }
+    const authHeaders: Record<string, string> =
+      authScheme === 'bearer'
+        ? { Authorization: `Bearer ${postizKey}` }
+        : authScheme === 'x-api-key'
+          ? { 'x-api-key': postizKey }
+          : { Authorization: postizKey };
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      Authorization: postizKey,
-      // 일부 Postiz 버전은 x-api-key 를 기대함 — 둘 다 보내 호환성 확보.
-      'x-api-key': postizKey,
+      ...authHeaders,
       ...(init?.headers as Record<string, string> | undefined),
     };
     return fetch(`${postizUrl}${path}`, { ...init, headers });
@@ -101,6 +124,12 @@ export function registerPostizTools(server: McpServer, adapter: CMSAdapter): voi
         .boolean()
         .optional()
         .describe('If true, builds the payload but does NOT call Postiz — useful for agent debugging.'),
+      force: z
+        .boolean()
+        .optional()
+        .describe(
+          'If true, send even when variant.status is already "sent_to_postiz". Default false — prevents accidental double-post.',
+        ),
     },
     async (params) => {
       try {
@@ -113,6 +142,23 @@ export function registerPostizTools(server: McpServer, adapter: CMSAdapter): voi
           .eq('id', params.variant_id)
           .single();
         if (varErr || !variant) throw new Error(`Variant not found: ${params.variant_id}`);
+
+        // 1a. 소셜 채널 whitelist 검증 — blog/email/self variant 를 Postiz 로 보내는 실수 방지.
+        const platform = (variant.platform as string | null)?.toLowerCase() ?? '';
+        if (!POSTIZ_ALLOWED_PLATFORMS.has(platform)) {
+          throw new Error(
+            `variant.platform='${platform}' is not a Postiz-supported social channel. ` +
+              `Allowed: ${Array.from(POSTIZ_ALLOWED_PLATFORMS).join(', ')}. ` +
+              `For blog use send_newsletter, for email use send_newsletter, for self/other use create_publication manually.`,
+          );
+        }
+
+        // 1b. 중복 발행 방지 — 이미 보낸 variant 는 force=true 없이는 재발행 차단.
+        if (variant.status === 'sent_to_postiz' && !params.force) {
+          throw new Error(
+            `Variant already sent to Postiz (variant.status='sent_to_postiz'). Pass force=true to override (e.g. re-send after failure).`,
+          );
+        }
 
         // 2. Postiz payload 구성 (raw_payload 없으면 기본 DTO)
         //    기본 DTO 는 Postiz public API 공통 형식 — 배포 버전 차이 있을 수 있으니

--- a/src/tools/postiz.ts
+++ b/src/tools/postiz.ts
@@ -1,0 +1,225 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CMSAdapter } from '../adapters/interface.js';
+import { getSupabase } from '../shared/supabase.js';
+
+// Postiz 연동 MCP 도구.
+//
+// Postiz 는 오픈소스 소셜 스케줄러. Instagram / LinkedIn / Threads / X(twitter) /
+// YouTube / TikTok 등을 통합 관리. Public API v1 을 통해 MCP 에이전트가 직접 발행 가능.
+//
+// 구조:
+//   Agent → list_postiz_integrations() → 연결된 채널 id 확인
+//   Agent → send_to_postiz(variant_id, integration_id, scheduled_at?)
+//       → Postiz API POST /posts (variant.body_text + hashtags 로 DTO 구성)
+//       → 성공 시: variant.status = 'sent_to_postiz' 업데이트
+//                 variant.platform_settings.postiz_post_id 기록
+//                 create_publication(channel, postiz_post_id) 자동 호출
+//
+// 전제:
+//   - POSTIZ_API_URL 환경변수 (예: https://postiz.agenticworkflows.club)
+//   - POSTIZ_API_KEY 환경변수 (Postiz 워크스페이스 설정에서 발급)
+//
+// Postiz API 호출 형식은 배포 버전마다 다를 수 있어 raw_payload override 를 지원.
+// 기본 DTO 가 안 맞으면 에이전트가 raw_payload 로 직접 body 전달.
+export function registerPostizTools(server: McpServer, adapter: CMSAdapter): void {
+  const postizUrl = (process.env.POSTIZ_API_URL ?? '').replace(/\/+$/, '');
+  const postizKey = process.env.POSTIZ_API_KEY ?? '';
+
+  const postizConfigured = Boolean(postizUrl && postizKey);
+
+  const postizFetch = async (path: string, init?: RequestInit): Promise<Response> => {
+    if (!postizConfigured) {
+      throw new Error(
+        'Postiz not configured. Set POSTIZ_API_URL and POSTIZ_API_KEY env vars before using Postiz tools.',
+      );
+    }
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: postizKey,
+      // 일부 Postiz 버전은 x-api-key 를 기대함 — 둘 다 보내 호환성 확보.
+      'x-api-key': postizKey,
+      ...(init?.headers as Record<string, string> | undefined),
+    };
+    return fetch(`${postizUrl}${path}`, { ...init, headers });
+  };
+
+  server.tool(
+    'list_postiz_integrations',
+    '[Pipeline step 6 — Publish] List connected social integrations in Postiz (returns id + platform + display name per channel). Use this first to get the integration_id before calling send_to_postiz.',
+    {},
+    async () => {
+      try {
+        const res = await postizFetch('/public/v1/integrations');
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(`Postiz /integrations failed (${res.status}): ${JSON.stringify(body)}`);
+        }
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ integrations: body }, null, 2) }],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'send_to_postiz',
+    [
+      '[Pipeline step 6 — Publish] Send a variant to Postiz for immediate or scheduled publication to the connected social channel.',
+      'Typical flow: create_variant (step 4) → update_variant to fill body_text & hashtags → list_postiz_integrations → send_to_postiz.',
+      'On success: variant.status becomes "sent_to_postiz", postiz_post_id is stored in platform_settings, and a publications row is automatically created.',
+      'Use raw_payload to bypass the default DTO builder when a specific Postiz feature (media, thread, poll, etc.) is needed.',
+    ].join(' '),
+    {
+      variant_id: z.string().uuid().describe('Variant id to publish. variant.body_text will be used as the post content.'),
+      integration_id: z
+        .string()
+        .describe('Postiz integration id (channel). Get from list_postiz_integrations.'),
+      channel: z
+        .string()
+        .optional()
+        .describe(
+          'Channel label for the publication record (e.g. "linkedin", "instagram"). If omitted, tries to infer from variant.platform.',
+        ),
+      scheduled_at: z
+        .string()
+        .optional()
+        .describe('ISO 8601 timestamp to schedule the post. Omit for immediate publish.'),
+      raw_payload: z
+        .record(z.unknown())
+        .optional()
+        .describe(
+          'Advanced: fully override the Postiz POST /posts body. If set, the tool sends this payload as-is (still records variant link + publication on 2xx).',
+        ),
+      dry_run: z
+        .boolean()
+        .optional()
+        .describe('If true, builds the payload but does NOT call Postiz — useful for agent debugging.'),
+    },
+    async (params) => {
+      try {
+        const sb = getSupabase();
+
+        // 1. variant 조회
+        const { data: variant, error: varErr } = await sb
+          .from('variants')
+          .select('id, content_id, platform, format, body_text, hashtags, platform_settings, status')
+          .eq('id', params.variant_id)
+          .single();
+        if (varErr || !variant) throw new Error(`Variant not found: ${params.variant_id}`);
+
+        // 2. Postiz payload 구성 (raw_payload 없으면 기본 DTO)
+        //    기본 DTO 는 Postiz public API 공통 형식 — 배포 버전 차이 있을 수 있으니
+        //    안 맞으면 raw_payload 로 바이패스.
+        const hashtagLine = (variant.hashtags as string[] | null)?.length
+          ? '\n\n' + (variant.hashtags as string[]).join(' ')
+          : '';
+        const content = `${variant.body_text ?? ''}${hashtagLine}`.trim();
+        const defaultPayload = {
+          type: params.scheduled_at ? 'schedule' : 'now',
+          date: params.scheduled_at ?? new Date().toISOString(),
+          posts: [
+            {
+              integration: { id: params.integration_id },
+              value: [{ content, media: [] }],
+              settings: variant.platform_settings ?? {},
+            },
+          ],
+        };
+        const payload = params.raw_payload ?? defaultPayload;
+
+        if (params.dry_run) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(
+                  { message: 'dry_run — payload built but not sent', payload },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+
+        // 3. Postiz 호출
+        const res = await postizFetch('/public/v1/posts', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+        const respBody = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+        if (!res.ok) {
+          throw new Error(
+            `Postiz /posts failed (${res.status}): ${JSON.stringify(respBody)}. Payload shape mismatch? Try raw_payload.`,
+          );
+        }
+
+        // Postiz 응답에서 post id 추출 (필드명은 버전마다 조금씩 다름 — 보수적으로 탐색)
+        const postizPostId =
+          (respBody.id as string | undefined) ??
+          (Array.isArray(respBody.posts) ? (respBody.posts[0] as { id?: string } | undefined)?.id : undefined) ??
+          null;
+
+        // 4. variant status / platform_settings 업데이트
+        const newSettings = {
+          ...((variant.platform_settings as Record<string, unknown> | null) ?? {}),
+          postiz_post_id: postizPostId,
+          postiz_integration_id: params.integration_id,
+          postiz_sent_at: new Date().toISOString(),
+        };
+        await sb
+          .from('variants')
+          .update({ status: 'sent_to_postiz', platform_settings: newSettings })
+          .eq('id', params.variant_id);
+
+        // 5. publication 기록 (실제 발행 시각은 Postiz 가 스케줄 처리 후 webhook 으로
+        //    알려주는 것이 이상적이지만, 현재는 '예약/즉시 발행 요청 시점' 을 기록).
+        const channel = params.channel ?? variant.platform ?? 'postiz';
+        try {
+          await adapter.createPublication({
+            content_id: variant.content_id as string,
+            variant_id: variant.id as string,
+            channel,
+            postiz_post_id: postizPostId ?? undefined,
+          });
+        } catch (err) {
+          // publication 기록 실패가 Postiz 발행을 되돌리지는 않는다 — 경고만.
+          console.error('[send_to_postiz] publication record failed:', err);
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  message: params.scheduled_at
+                    ? `Scheduled via Postiz at ${params.scheduled_at}.`
+                    : 'Sent to Postiz for immediate publish.',
+                  variant_id: variant.id,
+                  postiz_post_id: postizPostId,
+                  channel,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
## 요약

**에이전트 e2e 파이프라인의 마지막 조각** — 소셜 채널 실제 발행.

지금까지: 에이전트가 Topic → Idea → Content → Variant → 파생 레코드(blog/carousel/video) → 뉴스레터까지 가능. 소셜 채널(IG/LinkedIn/X/Threads/YouTube) 발행은 "기록(create_publication)" 만 있고 **실제 업로드는 없었음**. 이 PR 이 그 공백을 채움.

## 신규 MCP 도구 (src/tools/postiz.ts)

### `list_postiz_integrations`
연결된 소셜 채널 조회. 각 채널의 integration id 확보.

### `send_to_postiz(variant_id, integration_id, ...)`
variant 를 Postiz 로 발행.

- variant.body_text + hashtags 로 기본 DTO 구성
- Postiz `POST /public/v1/posts` 호출
- 즉시 발행(`type: 'now'`) 또는 예약(`scheduled_at` 지정)
- 성공 시 자동으로:
  - `variant.status = 'sent_to_postiz'`
  - `variant.platform_settings.postiz_post_id` 저장
  - `publications` 테이블에 기록 (content_id / variant_id / channel / postiz_post_id)
- `raw_payload` 로 Postiz DTO 완전 오버라이드 가능 (버전 호환)
- `dry_run: true` 로 payload 미리보기

## 필요 env

```
POSTIZ_API_URL=https://postiz.agenticworkflows.club
POSTIZ_API_KEY=<Postiz Settings → API 에서 발급>
```

미설정 시 첫 호출에서 명확한 에러 메시지.

## AGENTS.md — Claude Code 가이드 추가

1. **`.mcp.json` 설정 예시** (필요한 env 전체 포함)
2. **Postiz 사전 설정** (채널 OAuth 연결 + API Key 발급 절차)
3. **Postiz 포함 e2e 파이프라인 시나리오**
   - 토픽 → 아이디어 → 컨텐츠 → variant → blog + newsletter + LinkedIn + IG 동시 배포
   - 13-step 호출 시퀀스

## 이후 가능해진 것

사용자가 Claude Code 에 한 줄 지시:
```
"AX 전환 토픽의 '하드웨어 스타트업 AI 도입' 사례를 블로그+LinkedIn thread+IG carousel+뉴스레터로 배포해줘"
```

에이전트가 자율 실행:
- 토픽/아이디어 설정 → content 초안 → variants 파생
- blog_post / carousel / email_log 생성 + variant_id 자동 연결
- Postiz 로 LinkedIn/IG 실제 발행
- 모든 publications 기록

사람은 대시보드에서 draft 검토 후 published 승인만. 완전한 에이전트 주도 파이프라인.

## 영향 범위

- 3 파일 / +308 / -0
- 기존 도구 호환성 영향 없음
- Postiz env 미설정이어도 다른 MCP 도구는 정상 작동 (Postiz 도구만 사용 시점에 에러)
- TypeScript 타입체크 통과

## 범위 밖 (별도)

- Postiz 발행 후 metrics 콜백 수신 (webhook 수신 endpoint) — dashboard 에 webhook handler 필요, 별도
- Resend 뉴스레터 webhook (delivery / open / click) — 위와 동일 패턴
- Phase 2 (멀티 사용자 대응): 하드코딩 env화, AWC 테이블 migration 이식 등