### PR TITLE
chore(env): .env.example 3개 완전 동기화 — 코드 100% 커버

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ EDITOR_API_URL=http://127.0.0.1:8092
 # ── content-core CLI (Markdown → PlateJS 변환) ──────────────
 # create_blog_post_from_markdown 도구가 호출.
 CONTENT_CORE_CLI_PATH=/absolute/path/to/content-core/dist/cli.js
+# (선택) CLI 실행 timeout, 기본 30000 ms. 대용량 Markdown 변환 시 늘리기.
+# CONTENT_CORE_CLI_TIMEOUT_MS=30000
 
 # ── Tenant branding (multi-tenant 핵심 env) ─────────────────
 # Blog meta_title suffix — 예: META_TITLE_SUFFIX="YourBrand" → "{title} | YourBrand"

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -15,6 +15,13 @@ EDITOR_API_DIR=/absolute/path/to/agentic-cms/editor
 # (선택) editor 를 다른 포트에서 기동하고 싶으면
 # EDITOR_API_PORT=8092
 
+# ── Video 미디어 경로 (선택 — editor proxy 쓸 때 override) ────
+# 기본값 있음 — 지정 안 해도 정상 동작.
+# NEXT_PUBLIC_MEDIA_PROXY_PREFIX=/_proxy
+# NEXT_PUBLIC_MEDIA_ROOT=
+# NEXT_PUBLIC_MEDIA_FINISHED=
+# NEXT_PUBLIC_MEDIA_DEFAULT_SOURCE=
+
 # ── Tenant branding (multi-tenant 핵심 env — 고객마다 값 다름) ─────
 # 사이트 URL — 뉴스레터 발송 링크, 썸네일 prefix, GSC 등에 사용 (필수)
 NEXT_PUBLIC_SITE_URL=https://your-domain.com

--- a/editor/.env.example
+++ b/editor/.env.example
@@ -1,44 +1,94 @@
-# ─── Required ───
+# ============================================================
+# agentic-cms/editor — 영상 편집 Python FastAPI 서버 환경변수
+# ============================================================
+# 실제 값으로 채워서 `.env` 로 저장.
+# multi-tenant 배포: agentic-cms 의 dashboard/.env.local 와 SUPABASE_URL/KEY
+# 를 동일한 고객 프로젝트로 맞추는 것이 원칙.
+# ============================================================
 
-# Supabase (DB + Storage)
-# Create a project at https://supabase.com, run supabase/migrations/*.sql
+# ─── Required — Supabase (DB + Storage) ───────────────────
+# agentic-cms 의 dashboard/.env.local 과 동일한 project 를 가리켜야 함.
+# 2026-04-18 이후 editor 도 agentic-cms Supabase (video_projects 테이블) 사용.
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-key
 
-# ─── Server ───
+# video_projects 테이블 매핑 (agentic-cms 의 MCP/dashboard 와 공유)
+# 기본값은 brxce-editor 시절의 `projects` — 통합 이후 반드시 `video_projects`
+TABLE_PROJECTS=video_projects
+
+# ─── Required — Storage 모드 ──────────────────────────────
+# cloud  — 렌더 후 Supabase Storage 에 업로드 + 로컬 임시파일 정리 (multi-tenant 표준)
+# local  — 로컬 파일 그대로 유지 (개발 편의)
+STORAGE_MODE=cloud
+
+# ─── Server ────────────────────────────────────────────────
 PORT=8092
 
-# Media root directory (where video source files live)
-# Defaults to src/editor/ if not set
+# Media root directory — 영상 소스 파일이 있는 로컬 루트
+# 기본값: src/editor/
 MEDIA_ROOT=
 
-# Default source directory for auto-project creation
-# 팀 공용 SMB: smb://192.168.219.52/Media/ → macOS에서 /Volumes/Media
-DEFAULT_SOURCE_DIR=/Volumes/Media
+# Default source directory — 자동 프로젝트 생성 시 소스 경로
+# 예: 팀 NAS 마운트 (/Volumes/Media), 로컬 영상폴더 등
+DEFAULT_SOURCE_DIR=
 
-# Additional media search directories (comma-separated, for source resolution)
-# Server will search these paths when a video file is not found in src/editor/
-# 팀 공용 SMB가 기본 포함됨
-LEGACY_MEDIA_DIRS=/Volumes/Media
+# Additional media search directories — 쉼표로 구분, 소스 resolution 시 탐색
+LEGACY_MEDIA_DIRS=
 
 # Finished (rendered) video output directory
-# Defaults to src/editor/_finished/ if not set
+# 기본값: src/editor/_finished/
+# ⚠️ AWC 경험: `~/Desktop/_미디어/완료영상` 같은 절대 개인 경로 금지. 항상 프로젝트 내부 임시 디렉토리 + STORAGE_MODE=cloud 조합.
 FINISHED_DIR=
 
-# ─── Optional: AI Features ───
-
-# Gemini API Key (for reference auto-discovery + video analysis)
+# ─── Optional — AI Features ───────────────────────────────
+# Gemini API Key (reference auto-discovery + video analysis)
 # Get one at https://aistudio.google.com/apikey
 GEMINI_API_KEY=
 
-# OpenAI API Key (for Whisper auto-subtitles)
+# OpenAI API Key (Whisper auto-subtitles)
 OPENAI_API_KEY=
 
-# Anthropic API Key (for AI subtitle generation)
+# Anthropic API Key (AI subtitle generation)
 ANTHROPIC_API_KEY=
 
-# ─── Optional: Reference Discovery ───
-
-# Instagram credentials (for reference auto-discovery)
+# ─── Optional — Instagram Reference Discovery ──────────────
+# Instagram credentials (reference auto-discovery)
 IG_USERNAME=
 IG_PASSWORD=
+
+# ─── Optional — Tenant Branding (editor standalone UI) ─────
+# editor 를 독립 Next.js 앱으로 빌드/실행할 때만 의미 있음.
+# agentic-cms dashboard 에서 proxy 로 쓰는 경우엔 dashboard/.env.local 의 같은 값이 적용됨.
+# 자세한 의미는 ../dashboard/.env.example 참고.
+# NEXT_PUBLIC_BRAND_NAME=
+# NEXT_PUBLIC_BRAND_HANDLE=
+# NEXT_PUBLIC_BRAND_EMOJI=
+# NEXT_PUBLIC_BRAND_AVATAR_URL=
+# NEXT_PUBLIC_CONTACT_DOMAIN=
+
+# ─── Optional — Supabase 테이블명 override ─────────────────
+# 모든 기본값은 코드(table_config.py)의 default 사용. 기본 이름이 충돌할 때만 override.
+# TABLE_PROJECTS=video_projects           # Phase 4 이후 권장값
+# TABLE_VIDEOS=reference_videos           # legacy reference 영상
+# TABLE_ACCOUNTS=reference_accounts       # legacy reference 계정
+# TABLE_CAROUSELS=carousels
+# TABLE_FINISHED=finished_videos
+# TABLE_PRESETS=presets
+# TABLE_RENDER_JOBS=render_jobs
+# TABLE_REF_POSTS=ref_posts               # 통합 reference 시스템
+# TABLE_REF_ACCOUNTS=ref_accounts
+# TABLE_REF_SLIDES=ref_slides
+# TABLE_STORYBOARDS=storyboards
+# TABLE_SUBTITLES=subtitles
+# TABLE_COLLECTIONS=reference_collections
+# TABLE_COLLECTION_ITEMS=reference_collection_items
+# TABLE_PLANS=plans
+
+# ─── Optional — Carousel Remotion 렌더링 ──────────────────
+# editor 의 Python 이 슬라이드를 렌더할 때 호출하는 Next.js URL.
+# editor standalone 일 때 기본 3100, agentic-cms 와 통합 시 dashboard(3003) 또는 editor 자체.
+# NEXT_URL=http://localhost:3100
+
+# ─── Optional — CLI/Remote Editor URL ───────────────────────
+# studio_cli 에서 원격 editor 서버 가리킬 때 (로컬 개발에선 기본값 OK)
+# BRXCE_EDITOR_URL=http://localhost:8092


### PR DESCRIPTION
## 배경

Phase 2 multi-tenant 작업 (PR #38) 이후 **일부 env 변수가 `.env.example` 에 누락된 상태**. 코드에서 실제 쓰이는데 템플릿에 없으면 새 tenant onboarding 시 \"왜 안 되지?\" 상황 발생.

자동 교차 체크 스크립트로 MCP/Dashboard/Editor 3군데 코드 grep vs `.env.example` 비교 → 누락분 전부 추가.

## 변경사항

### `agentic-cms/.env.example` (MCP)
- `CONTENT_CORE_CLI_TIMEOUT_MS` (선택, default 30000ms) 추가 — 대용량 Markdown 변환 시 override 필요

### `agentic-cms/dashboard/.env.example`
- `NEXT_PUBLIC_MEDIA_PROXY_PREFIX`, `MEDIA_ROOT`, `MEDIA_FINISHED`, `MEDIA_DEFAULT_SOURCE` (선택) 추가 — editor-config.ts 에서 video proxy 경로 override

### `agentic-cms/editor/.env.example`
- **\`TABLE_PROJECTS=video_projects\`** (⚠️ Phase 4 이후 사실상 필수) 추가
- **\`STORAGE_MODE=cloud\`** (⚠️ Phase 6.5 이후 권장 default) 추가
- `TABLE_*` 전체 15개 (선택 override) 추가
- `NEXT_URL` (선택, carousel Remotion 렌더용) 추가
- `BRXCE_EDITOR_URL` (선택, CLI) 추가
- `NEXT_PUBLIC_BRAND_*` (editor standalone 빌드 시 참조 — 보통 dashboard env 가 해줌) 주석 추가
- `DEFAULT_SOURCE_DIR`, `LEGACY_MEDIA_DIRS`, `FINISHED_DIR` 예시값을 AWC SMB 전용 → generic 으로 중립화

## 검증

교차 체크 결과 — 3개 파일 **모두 missing 0건**:
```
MCP:       code 11  env.example 11  missing=[]
Dashboard: code 22  env.example 23  missing=[]
Editor:    code 28  env.example 35  missing=[]
```

## Test plan

- [ ] 새 tenant onboarding 시 `.env.example` 복사 → 필수값만 채워도 기본 기능 돌아야 함
- [ ] 선택 값 미설정 시 코드가 graceful default/degrade 로 동작

## 연관

Follow-up to PR #38 (Phase 2 multi-tenant).