### PR TITLE
fix(editor): Supabase CRUD 가 TABLE_PROJECTS env 무시하던 silent fail 버그

### DIFF
--- a/editor/src/db/supabase.py
+++ b/editor/src/db/supabase.py
@@ -1,6 +1,11 @@
-"""Supabase client initialization and CRUD helpers."""
+"""Supabase client initialization and CRUD helpers.
+
+프로젝트 테이블 이름은 TABLE_PROJECTS env 로 오버라이드 가능 (Phase 4 이후 권장: video_projects).
+table_config.py 의 상수를 그대로 사용해 agentic-cms 쪽 MCP/dashboard 와 같은 이름으로 맞춘다.
+"""
 import os
 from supabase import create_client, Client
+from src.server.table_config import TABLE_PROJECTS
 
 _client: Client | None = None
 
@@ -21,7 +26,7 @@ def get_client() -> Client:
 
 def list_projects(*, status: str | None = None, limit: int = 50, offset: int = 0):
     sb = get_client()
-    q = sb.table("projects").select(
+    q = sb.table(TABLE_PROJECTS).select(
         "id, name, orientation, status, thumbnail_url, duration, clip_count, "
         "source_files, created_by, created_at, updated_at, project_data"
     ).is_("deleted_at", "null").order("updated_at", desc=True)
@@ -35,7 +40,7 @@ def list_projects(*, status: str | None = None, limit: int = 50, offset: int = 0
 def get_project(project_id: str):
     sb = get_client()
     resp = (
-        sb.table("projects")
+        sb.table(TABLE_PROJECTS)
         .select("*")
         .eq("id", project_id)
         .is_("deleted_at", "null")
@@ -56,7 +61,7 @@ def create_project(data: dict):
         "clip_count": data.get("clipCount", 0),
         "source_files": data.get("sourceFiles"),
     }
-    resp = sb.table("projects").insert(row).execute()
+    resp = sb.table(TABLE_PROJECTS).insert(row).execute()
     return resp.data[0] if resp.data else None
 
 
@@ -89,7 +94,7 @@ def update_project(project_id: str, patch: dict):
     if not row:
         return get_project(project_id)
     resp = (
-        sb.table("projects")
+        sb.table(TABLE_PROJECTS)
         .update(row)
         .eq("id", project_id)
         .is_("deleted_at", "null")
@@ -102,7 +107,7 @@ def delete_project(project_id: str):
     """Soft delete."""
     from datetime import datetime, timezone
     sb = get_client()
-    sb.table("projects").update(
+    sb.table(TABLE_PROJECTS).update(
         {"deleted_at": datetime.now(timezone.utc).isoformat()}
     ).eq("id", project_id).execute()
     return True


### PR DESCRIPTION
## 배경

E2E 파이프라인 실행 중 발견된 **silent fail 버그**.

Phase 4 (PR #37) 에서 편집기의 projects 테이블을 agentic-cms 의 video_projects 로 통합하면서, 원본 projects 테이블은 projects_legacy_pre_phase4_20260418 로 rename 했다. 그 후 편집기 쪽에 `TABLE_PROJECTS=video_projects` env 를 추가했다.

하지만 **`editor/src/db/supabase.py` 가 이 env 를 무시하고 `sb.table(\"projects\")` 를 하드코딩** 중이었다. Phase 4 migration 이후엔 이 테이블이 rename 됐기 때문에 모든 CRUD 가 존재하지 않는 테이블을 건드리다 실패, `except Exception: pass` 로 에러 swallow, `dbId=null` 반환.

즉 2026-04-18 Phase 4 이후 **모든 editor save/update 가 DB 에는 안 들어가고 local JSON 파일만 생성** 돼 왔다. list/get 도 실패 중이었을 것 (editor /api/projects 가 로컬 파일만 열거했을 듯).

## 증거

E2E 테스트 중:
```json
// create_video_project 결과
{"status":"saved","id":"project_1776589399642","dbId":null}
```
→ Supabase video_projects 테이블엔 새 row 없음. 기존 4-18 데이터만 존재.

## 수정

`editor/src/db/supabase.py`:
- `from src.server.table_config import TABLE_PROJECTS` 추가
- `sb.table(\"projects\")` literal 5곳을 `sb.table(TABLE_PROJECTS)` 로 교체 (list_projects/get_project/create_project/update_project/delete_project)

`TABLE_PROJECTS` 는 `table_config.py` 에서 `os.environ.get(\"TABLE_PROJECTS\", \"projects\")` 로 정의돼 있어, env 없을 시 기존 \"projects\" default 유지 → backward compatible.

## 검증

수정 + editor 재기동 후 동일 호출:
```json
{"status":"saved","id":"project_1776589541422","dbId":"46784453-56c4-4a5a-9e87-e8bfa9d8d2ef"}
```
→ video_projects 테이블에 실제 row 생성, `link_video_project_to_variant` 정상 동작.

## 영향 범위

- Phase 4 merge (2026-04-18) ~ 이 PR merge 사이 editor 에서 저장된 video 프로젝트는 **Supabase 에 반영 안 됨**. 로컬 JSON 파일만 있음 (`editor/src/editor/_projects/*.json`).
- Dashboard /video/projects 페이지에서 편집기가 생성한 새 프로젝트가 안 보였을 가능성. 2 일간의 영향인데 실제 사용 빈도 낮아서 데이터 유실 거의 없음.
- 필요 시 로컬 JSON 을 읽어서 DB INSERT 로 역이관 가능 (follow-up).

## Test plan

- [x] 증거 재현: fix 전 create_video_project → dbId=null
- [x] fix 후 create_video_project → dbId 실제 UUID 반환
- [x] link_video_project_to_variant 성공
- [ ] editor list 엔드포인트도 정상 반환 (TABLE_PROJECTS 로 통일됐으므로 기대되는 결과)

## 연관

- Phase 4 migration: PR #37
- Phase 4 env 도입: PR #37
- 이 버그는 Phase 4 migration 시 code path 까지 확인 안 해서 발생한 regression.