### PR TITLE
fix(editor): silent-fail logging 도입 — Phase 4 드리프트 버그 재발 방지

### DIFF
--- a/editor/src/server/routes/finished.py
+++ b/editor/src/server/routes/finished.py
@@ -1,6 +1,7 @@
 """Finished videos routes — CRUD + upload + thumbnail.
 Files are uploaded to Supabase Storage (bucket: finished).
 """
+import logging
 import os
 import json
 import subprocess
@@ -15,6 +16,8 @@ from fastapi import APIRouter, Request, UploadFile, File, Form
 from fastapi.responses import FileResponse, JSONResponse
 from src.server.table_config import TABLE_FINISHED
 from src.server.storage import get_storage, STORAGE_MODE
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["finished"])
 
@@ -57,7 +60,9 @@ def _probe(path):
                 height = s.get("height", 0)
                 break
         return duration, size, width, height
-    except Exception:
+    except Exception as e:
+        # ffprobe 실패 — 기본값 (0) 반환해서 save 흐름 중단 안 함. probe 자체는 보조 기능.
+        logger.debug("ffprobe failed for %s: %s", path, e)
         return 0, 0, 0, 0
 
 
@@ -69,8 +74,9 @@ def _make_thumb(video_path, thumb_path):
              "-vf", "scale=240:-2", "-q:v", "6", str(thumb_path)],
             capture_output=True, timeout=10,
         )
-    except Exception:
-        pass
+    except Exception as e:
+        # 썸네일 실패는 본 영상 save 를 막지 않는다 (보조 기능).
+        logger.debug("ffmpeg thumbnail gen failed for %s: %s", video_path, e)
 
 
 @router.get("/api/finished")
@@ -101,7 +107,9 @@ async def stream_finished(video_id: str, request: Request):
     sb = _get_sb()
     try:
         resp = sb.table(TABLE_FINISHED).select("file_path,file_url,name").eq("id", video_id).maybe_single().execute()
-    except Exception:
+    except Exception as e:
+        # DB 실패 — "not found" 로 클라이언트엔 동일하게 응답하되, 서버 로그에는 남긴다.
+        logger.warning("stream_finished DB lookup failed for %s: %s", video_id, e)
         return JSONResponse({"error": "not found"}, status_code=404)
     if not resp or not resp.data:
         return JSONResponse({"error": "not found"}, status_code=404)
@@ -151,7 +159,8 @@ async def download_finished_named(video_id: str, filename: str):
     sb = _get_sb()
     try:
         resp = sb.table(TABLE_FINISHED).select("file_path,file_url").eq("id", video_id).maybe_single().execute()
-    except Exception:
+    except Exception as e:
+        logger.warning("download_finished DB lookup failed for %s: %s", video_id, e)
         return JSONResponse({"error": "not found"}, status_code=404)
     if not resp or not resp.data:
         return JSONResponse({"error": "not found"}, status_code=404)
@@ -262,14 +271,15 @@ async def upload_finished(
     }
     
     sb.table(TABLE_FINISHED).insert(row).execute()
-    
+
     # 로컬 임시 파일 정리 (Storage에 올렸으므로)
     try:
         dest.unlink(missing_ok=True)
         thumb_path.unlink(missing_ok=True)
-    except Exception:
-        pass
-    
+    except Exception as e:
+        # 정리 실패해도 이미 DB/Storage 에는 올라가 있어 영향 없음 — 디버그만.
+        logger.debug("Temp file cleanup failed for %s: %s", vid, e)
+
     return {"id": vid, "name": row["name"], "file_url": file_url}
 
 
@@ -333,8 +343,8 @@ async def save_from_render(request: Request):
         try:
             dest.unlink(missing_ok=True)
             thumb_path.unlink(missing_ok=True)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Temp file cleanup failed for %s: %s", vid, e)
     return {"id": vid, "name": name}
 
 
@@ -375,7 +385,7 @@ async def delete_finished(video_id: str):
                 if p and not p.startswith("http") and Path(p).exists():
                     try:
                         Path(p).unlink()
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug("Local file unlink failed for %s: %s", p, e)
         sb.table(TABLE_FINISHED).delete().eq("id", video_id).execute()
     return {"ok": True}

--- a/editor/src/server/routes/projects.py
+++ b/editor/src/server/routes/projects.py
@@ -1,5 +1,6 @@
 """Project CRUD routes — replaces both Next.js API and legacy local JSON."""
 import json
+import logging
 import os
 import re
 import subprocess
@@ -9,6 +10,8 @@ from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
 
@@ -57,7 +60,10 @@ def _try_supabase():
             "to_summary": row_to_summary,
             "to_project": row_to_project,
         }
-    except Exception:
+    except Exception as e:
+        # Import failure (e.g., supabase package missing) — legitimate skip,
+        # editor 는 local JSON 모드로 fallback. DEBUG 레벨로만 기록.
+        logger.debug("Supabase helpers unavailable: %s", e)
         return None
 
 
@@ -85,8 +91,11 @@ async def project_list(status: str | None = None, limit: int = 50, offset: int =
                     "locked": pd.get("locked", False) if isinstance(pd, dict) else False,
                 })
                 db_ids.add(row["id"])
-        except Exception:
-            pass
+        except Exception as e:
+            # DB list 실패 — 테이블 이름 오염, RLS, 네트워크 등 원인 가능.
+            # 2026-04-18 TABLE_PROJECTS 드리프트 버그가 silent fail 로 2일 숨겨졌던
+            # 이유이므로 이제는 반드시 WARNING 로 기록한다.
+            logger.warning("project_list DB lookup failed (falling back to local): %s", e)
 
     # Merge local-only projects
     PROJECTS_DIR.mkdir(exist_ok=True)
@@ -108,8 +117,9 @@ async def project_list(status: str | None = None, limit: int = 50, offset: int =
                 "sources": data.get("sources", []),
                 "source": "local",
             })
-        except Exception:
-            pass
+        except Exception as e:
+            # 개별 JSON 파일 parsing 실패 — 파일 1개 깨져도 목록 전체는 계속.
+            logger.warning("Failed to parse local project file %s: %s", f, e)
 
     return {"projects": projects}
 
@@ -129,8 +139,9 @@ async def project_create(request: Request):
             row = db["create"](body)
             if row:
                 return JSONResponse({"project": db["to_project"](row)}, status_code=201)
-        except Exception:
-            pass
+            logger.warning("project_create DB insert returned no row — falling back to local save")
+        except Exception as e:
+            logger.warning("project_create DB insert raised (falling back to local): %s", e)
 
     # Fallback: local save
     pid = f"project_{int(time.time() * 1000)}"
@@ -152,8 +163,8 @@ async def project_get(project_id: str):
             row = db["get"](project_id)
             if row:
                 return {"project": db["to_project"](row)}
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("project_get DB lookup failed for %s (trying local): %s", project_id, e)
 
     fpath = _safe_project_path(project_id)
     if fpath and fpath.exists():
@@ -173,8 +184,8 @@ def _is_locked(project_id: str) -> bool:
             if row:
                 pd = row.get("project_data") or {}
                 return pd.get("locked", False) if isinstance(pd, dict) else False
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("_is_locked DB lookup failed for %s: %s", project_id, e)
     return False
 
 
@@ -193,8 +204,9 @@ async def project_update(project_id: str, request: Request):
             row = db["update"](project_id, body)
             if row:
                 return {"project": db["to_project"](row)}
-        except Exception:
-            pass
+            logger.warning("project_update DB update returned no row for %s (falling back to local)", project_id)
+        except Exception as e:
+            logger.warning("project_update DB update failed for %s (falling back to local): %s", project_id, e)
 
     # Local fallback
     fpath = _safe_project_path(project_id)
@@ -217,8 +229,8 @@ async def project_delete(project_id: str):
     if db and _is_uuid(project_id):
         try:
             db["delete"](project_id)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("project_delete DB soft-delete failed for %s (continuing to local unlink): %s", project_id, e)
 
     fpath = _safe_project_path(project_id)
     if fpath and fpath.exists():
@@ -264,8 +276,9 @@ async def project_save(request: Request):
                         dur = float(probe.get("format", {}).get("duration", 0))
                         if dur > 0:
                             bgm["totalDuration"] = round(dur, 3)
-                except Exception:
-                    pass
+                except Exception as e:
+                    # ffprobe 실패 — duration 보조 계산만 놓치는 수준, save 자체는 계속.
+                    logger.debug("ffprobe failed for BGM %s: %s", bgm.get("source"), e)
 
     # DB save
     db = _try_supabase()
@@ -289,8 +302,18 @@ async def project_save(request: Request):
                 row = db["create"](db_payload)
             if row:
                 body["dbId"] = row["id"]
-        except Exception:
-            pass
+            else:
+                # 이게 바로 TABLE_PROJECTS 드리프트 버그가 숨어 있던 지점 —
+                # row 가 None 이면 save 실패한 것이므로 경고 로그 필수.
+                logger.warning(
+                    "project_save DB %s returned no row (pid=%s, dbId=%s) — saved to local only",
+                    "update" if db_id else "insert", pid, db_id,
+                )
+        except Exception as e:
+            logger.warning(
+                "project_save DB operation raised (pid=%s, dbId=%s) — falling back to local only: %s",
+                pid, db_id, e,
+            )
 
     fpath.parent.mkdir(exist_ok=True)
     fpath.write_text(json.dumps(body, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## 배경

PR #40 에서 고친 TABLE_PROJECTS 드리프트 버그가 2일간 숨어 있었던 이유:
`editor/src/server/routes/projects.py` 의 모든 DB 호출이 `except Exception: pass` 패턴으로 silent 하게 에러를 삼키고 있었음. logger.warning 한 줄만 있었어도 즉시 발견됐을 것.

이번 PR 은 **관련 route 들의 silent fail 을 전수 audit** 하고 적절한 로깅을 추가해 같은 패턴의 회귀가 다시 2일씩 숨지 않도록 하는 방어 작업.

## 변경 파일 (2)

### `editor/src/server/routes/projects.py`
- `logging.getLogger(__name__)` 추가
- DB 실패 모든 지점에 경고/디버그 로그:
  - `_try_supabase()` import 실패 → DEBUG (정상 fallback)
  - `project_list` DB 실패 → WARNING (⚠️ Phase 4 버그가 숨어있던 지점)
  - 로컬 JSON parse 실패 → WARNING (파일 깨짐 가시화)
  - `project_create` / `project_update` / `project_save` DB insert/update 실패 또는 row=None → WARNING
  - `project_get` / `_is_locked` DB 조회 실패 → DEBUG/WARNING (조회 실패는 fallback 정상)
  - `project_delete` DB soft-delete 실패 → WARNING
  - ffprobe BGM duration 추출 실패 → DEBUG (보조 기능)

### `editor/src/server/routes/finished.py`
- `logging.getLogger(__name__)` 추가
- DB 실패 지점:
  - `stream_finished` / `download_finished` DB lookup 실패 → WARNING (클라이언트엔 404 응답 유지, 로그만 추가)
- 보조 기능 실패:
  - `_probe` (ffprobe) 실패 → DEBUG
  - `_make_thumb` (ffmpeg 썸네일) 실패 → DEBUG
  - 임시 파일 unlink 실패 → DEBUG

## 원칙 적용

| 실패 종류 | 로그 레벨 | 이유 |
|---|---|---|
| DB / 네트워크 실패 | WARNING | 운영상 반드시 인지해야 함 |
| 파일 정리 / ffprobe 등 보조 | DEBUG | 주 기능에 영향 없음, 디버깅 시만 |
| import 실패 (fallback 모드) | DEBUG | 정상 동작 — noise 방지 |

`except Exception: pass` 자체를 `raise` 로 바꾸지는 않았음 — 기존 fallback 흐름 (DB 실패 시 local JSON) 은 유지, 로그만 추가해서 **silent** 만 해결.

## Test plan

- [x] editor 재기동 후 /api/projects 정상 응답 (73 projects 반환)
- [x] Python syntax / import error 없음
- [ ] 일부러 TABLE_PROJECTS 를 잘못된 값으로 설정 → 로그에 "project_list DB lookup failed ..." WARNING 나오는지 확인
- [ ] 동일 시나리오에서 API 응답은 여전히 성공 (local fallback 정상)

## 외부 영향

- API 응답 변경 없음 (에러 응답, status code 동일)
- Silent fallback 동작 유지 (DB 실패 → local JSON 로 처리)
- 서버 로그에만 경고 추가

## 연관

- 원인 분석: PR #40 (TABLE_PROJECTS 드리프트 버그 fix)
- 같은 방향의 후속 작업 가능 (scope out — 다른 route 의 silent fail audit):
  - `bgm_analyze.py`, `carousel_render.py`, `references.py`, `video_analyze.py`, `media.py` 의 silent fail 들 — 별도 이슈로 추적