### PR TITLE
fix(editor): silent-fail logging — 5 route 확장 (PR #41 follow-up)

### DIFF
--- a/editor/src/server/routes/bgm_analyze.py
+++ b/editor/src/server/routes/bgm_analyze.py
@@ -1,4 +1,5 @@
 """BGM auto-segment finder — analyzes audio to find best matching segments for video."""
+import logging
 import os
 import subprocess
 import tempfile
@@ -8,6 +9,8 @@ from pathlib import Path
 import numpy as np
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/bgm", tags=["bgm"])
 
@@ -315,10 +318,12 @@ def _get_chorus_starts(audio_path, total_dur):
                     if rounded not in seen:
                         chorus_starts.append(rounded)
                         seen.add(rounded)
-            except Exception:
-                pass
-    except (ImportError, Exception):
-        pass
+            except Exception as e:
+                # 특정 clip_length 분석 실패 — 다른 길이로 계속 시도. 보조 fallback.
+                logger.debug("chorus detection failed at clip_length=%s: %s", cl, e)
+    except (ImportError, Exception) as e:
+        # librosa / chroma 파이프라인 import 실패 또는 오류 — chorus 추출 전체 스킵.
+        logger.debug("chorus pipeline unavailable (skipping): %s", e)
     return chorus_starts
 
 
@@ -640,6 +645,7 @@ async def extract_beats(request: Request):
             "mode": mode,
         }
     except Exception as e:
+        logger.exception("bgm_analyze endpoint failed: %s", e)
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
@@ -677,6 +683,7 @@ async def detect_bgm_sections(request: Request):
             "noveltyCurve": novelty_data,
         }
     except Exception as e:
+        logger.exception("bgm_analyze endpoint failed: %s", e)
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
@@ -1058,4 +1065,5 @@ async def analyze_bgm(request: Request):
         }
 
     except Exception as e:
+        logger.exception("bgm_analyze endpoint failed: %s", e)
         return JSONResponse({"error": str(e)}, status_code=500)

--- a/editor/src/server/routes/carousel_render.py
+++ b/editor/src/server/routes/carousel_render.py
@@ -1,5 +1,6 @@
 """Server-side carousel rendering — PNG ZIP & PDF via Playwright."""
 import io
+import logging
 import os
 import zipfile
 from urllib.parse import quote
@@ -7,6 +8,8 @@ from urllib.parse import quote
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse, StreamingResponse
 from playwright.async_api import async_playwright
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/carousels", tags=["carousel-render"])
 
@@ -71,6 +74,7 @@ async def render_carousel_png(carousel_id: str):
             headers={"Content-Disposition": f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"},
         )
     except Exception as e:
+        logger.exception("render_carousel_png failed for %s", carousel_id)
         return JSONResponse({"error": f"렌더링 실패: {e}"}, status_code=500)
 
 
@@ -118,4 +122,5 @@ async def render_carousel_pdf(carousel_id: str):
             headers={"Content-Disposition": f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"},
         )
     except Exception as e:
+        logger.exception("render_carousel_pdf failed for %s", carousel_id)
         return JSONResponse({"error": f"PDF 렌더링 실패: {e}"}, status_code=500)

--- a/editor/src/server/routes/media.py
+++ b/editor/src/server/routes/media.py
@@ -1,5 +1,6 @@
 """Media serving routes — thumbnails, video list, upload, resolver, external upload."""
 import json
+import logging
 import os
 import subprocess
 import urllib.parse
@@ -7,6 +8,8 @@ from pathlib import Path
 
 from fastapi import APIRouter, Request, UploadFile, File
 from fastapi.responses import FileResponse, JSONResponse, Response
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["media"])
 
@@ -25,8 +28,8 @@ def _load_resolver_config():
     if _resolver_config_path.exists():
         try:
             return json.loads(_resolver_config_path.read_text())
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to read resolver config: %s", e)
     return {"sourceDirectories": [], "pathMappings": {}}
 
 
@@ -178,8 +181,8 @@ async def list_videos():
             for f in search_dir.iterdir():
                 if f.name not in all_files and f.exists():
                     all_files[f.name] = f
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Directory walk failed: %s", e)
     for f in sorted(all_files.values(), key=lambda x: x.name):
         stem = f.stem.split("_v")[0] if "_v" in f.stem else f.stem
         if (

--- a/editor/src/server/routes/references.py
+++ b/editor/src/server/routes/references.py
@@ -1,4 +1,5 @@
 """Reference videos API — replaces Next.js reference routes."""
+import logging
 import subprocess
 import tempfile
 import json
@@ -9,6 +10,8 @@ from fastapi.responses import JSONResponse, RedirectResponse, FileResponse
 from src.server.table_config import TABLE_VIDEOS, TABLE_ACCOUNTS
 from src.server.storage import get_storage, STORAGE_MODE
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/references", tags=["references"])
 
 
@@ -16,7 +19,8 @@ def _get_sb():
     try:
         from src.db.supabase import get_client
         return get_client()
-    except Exception:
+    except Exception as e:
+        logger.debug("Supabase client unavailable: %s", e)
         return None
 
 
@@ -119,8 +123,8 @@ async def delete_video(video_id: str):
                 storage = get_storage()
                 storage.delete_file("references", f"{prefix}/video.mp4")
                 storage.delete_file("references", f"{prefix}/thumbnail.jpg")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Reference storage cleanup failed: %s", e)
         # Delete from DB
         sb.table(TABLE_VIDEOS).delete().eq("id", video_id).execute()
         return {"ok": True}
@@ -203,8 +207,8 @@ def _recognize_music(video_path: str) -> dict | None:
     finally:
         try:
             os.remove(audio_tmp)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Temp audio file cleanup failed: %s", e)
 
 
 def _detect_platform(url: str) -> str:
@@ -240,8 +244,9 @@ def _do_import(sb, url: str, meta: dict, video_id: str) -> dict:
                 "display_name": uploader_name,
                 "platform": platform,
             }).execute()
-    except Exception:
-        pass  # account may already exist
+    except Exception as e:
+        # account may already exist (unique violation) — insert 실패여도 link 된 이전 row 사용.
+        logger.debug("account upsert (ignored if duplicate): %s", e)
 
     storage_prefix = f"{uploader}/{video_id}"
     thumbnail_url = None
@@ -262,8 +267,8 @@ def _do_import(sb, url: str, meta: dict, video_id: str) -> dict:
                 buf = Path(thumb_tmp).read_bytes()
                 storage_path = f"{storage_prefix}/thumbnail.jpg"
                 thumbnail_url = storage.upload_file("references", storage_path, buf, "image/jpeg")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Thumbnail upload failed (ref post continues w/o thumbnail): %s", e)
 
     # Video download
     video_tmp = os.path.join(tmp_dir, f"{video_id}.mp4")
@@ -276,8 +281,9 @@ def _do_import(sb, url: str, meta: dict, video_id: str) -> dict:
             buf = Path(video_tmp).read_bytes()
             storage_path = f"{storage_prefix}/video.mp4"
             video_url = storage.upload_file("references", storage_path, buf, "video/mp4")
-    except Exception:
-        pass  # video download failed, thumbnail-only
+    except Exception as e:
+        # video download failed — thumbnail-only fallback. 이게 자주 일어나면 Instagram block/proxy 문제일 수 있음.
+        logger.warning("Reference video download/upload failed (thumbnail-only fallback): %s", e)
 
     # Post date
     upload_date = meta.get("upload_date", "")  # YYYYMMDD
@@ -330,8 +336,8 @@ def _do_import(sb, url: str, meta: dict, video_id: str) -> dict:
     for f in [os.path.join(tmp_dir, f"{video_id}.jpg"), video_tmp]:
         try:
             os.remove(f)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Temp file cleanup failed: %s", e)
 
     return {"id": video_id, "message": "임포트 완료"}
 

--- a/editor/src/server/routes/video_analyze.py
+++ b/editor/src/server/routes/video_analyze.py
@@ -1,8 +1,11 @@
 """Video source analysis — orientation, scene detection, motion, best clip selection."""
+import logging
 import os
 import subprocess
 import json
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 import numpy as np
 import cv2
@@ -150,7 +153,9 @@ async def find_best_clips(request: Request):
             if not scenes:
                 # Whole video as one scene
                 scenes = [(video.base_timecode, video.base_timecode + dur)]
-        except Exception:
+        except Exception as e:
+            # PySceneDetect 실패 — 전체 영상을 한 scene 으로 fallback. 알고리즘 정확도만 떨어짐.
+            logger.debug("PySceneDetect failed for %s (using whole-video fallback): %s", fname, e)
             scenes = [(0, dur)]
 
         # 2. Motion + brightness analysis with OpenCV (sample frames)


### PR DESCRIPTION
## 배경

PR #41 에서 `projects.py` + `finished.py` 의 silent fail 을 정리했고, 이번 PR 은 나머지 5개 route 에 동일 원칙 적용.

## 변경

- **bgm_analyze.py**: chorus detect / tempo / section endpoint 들의 silent fallback + 500 response logger.exception
- **carousel_render.py**: Playwright PNG/PDF 렌더 실패 500 에 logger.exception
- **references.py**: 7곳 silent pass 를 로깅으로 (DB client, storage cleanup, thumbnail/video upload 실패, temp file cleanup)
  - **thumbnail/video upload 실패는 WARNING** — Instagram block 등 자주 일어날 수 있는 문제 신호
  - account upsert duplicate, temp file cleanup 은 DEBUG
- **video_analyze.py**: PySceneDetect 실패 fallback logger.debug
- **media.py**: resolver config 읽기 실패, directory walk 실패 logger.debug

## 원칙 (PR #41 과 동일)

| 실패 종류 | 레벨 |
|---|---|
| DB / Storage / Network | WARNING |
| 보조 기능 (ffprobe, cleanup, optional import) | DEBUG |

## 검증

- 5개 파일 `.venv/bin/python` 직접 import OK
- 외부 API 응답 status/JSON 동일
- fallback 흐름 그대로 유지

## 잔여 work (scope out)

references.py / media.py 에 남아있는 `except Exception:` 중 `pass` 가 아니라 `return None/0/False/''` 로 기본값 반환하는 것들은 silent 이지만 의도적 fallback (예: get_video_fps → 30 기본값). 이것들까지 로그 추가하면 noise 가 커져 의도 훼손. 현재 상태로 유지.

## 연관

- 원인 분석: PR #40 (TABLE_PROJECTS 드리프트 버그)
- 1차 대응: PR #41 (projects.py + finished.py)
- 본 PR: 나머지 5 route 확장