### PR TITLE
feat(gallery): admin 콘텐츠 업로드·큐레이션 dashboard UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ editor/coverage/
 # Phase 2 multi-tenant — editor 개인/런타임 데이터
 editor/src/editor/_resolver_config.json
 editor/src/editor/_projects/
+
+# Playwright MCP fixtures + ad-hoc E2E artifacts
+.playwright-mcp/
+e2e-*.png

--- a/dashboard/src/app/(dashboard)/gallery/[id]/danger-zone.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/danger-zone.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2Icon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { deleteGalleryItem } from "../actions";
+
+export function GalleryDangerZone({
+  itemId,
+  title,
+}: {
+  itemId: string;
+  title: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function onDelete() {
+    if (
+      !confirm(
+        `정말 삭제할까요?\n"${title}"\n\ngallery_items + gallery_item_media link만 삭제됩니다. media row와 storage 파일은 보존.`
+      )
+    )
+      return;
+    setError(null);
+    startTransition(async () => {
+      try {
+        await deleteGalleryItem(itemId);
+        router.push("/gallery");
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="text-xs text-destructive/90">
+          <p className="font-medium">갤러리 아이템 삭제</p>
+          <p className="mt-1 text-destructive/70">
+            gallery_items 행 + gallery_item_media 링크만 제거 (cascade). 업로드된
+            media row와 storage 파일은 보존되어 다른 곳에서 재사용 가능.
+          </p>
+        </div>
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={pending}
+          onClick={onDelete}
+          className="shrink-0 gap-2"
+        >
+          <Trash2Icon className="h-4 w-4" />
+          {pending ? "삭제 중…" : "삭제"}
+        </Button>
+      </div>
+      {error && (
+        <div className="mt-3 text-xs text-destructive">{error}</div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/gallery/[id]/media-panel.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/media-panel.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  PlayCircleIcon,
+  Trash2Icon,
+  UploadIcon,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  GalleryItemMediaLink,
+  GalleryMediaRole,
+} from "@/lib/types";
+import { GALLERY_IMAGE_MAX, GALLERY_VIDEO_MAX } from "@/lib/gallery-constants";
+import {
+  removeGalleryMedia,
+  reorderGalleryMedia,
+} from "../actions";
+
+const ROLE_OPTIONS: GalleryMediaRole[] = ["cover", "gallery", "detail", "hero_video"];
+
+function roleVariant(role: GalleryMediaRole) {
+  if (role === "cover") return "warning" as const;
+  if (role === "hero_video") return "destructive" as const;
+  if (role === "detail") return "info" as const;
+  return "secondary" as const;
+}
+
+export function GalleryMediaPanel({
+  itemId,
+  links,
+}: {
+  itemId: string;
+  links: GalleryItemMediaLink[];
+}) {
+  const router = useRouter();
+  const replaceCoverInput = useRef<HTMLInputElement>(null);
+  const attachInput = useRef<HTMLInputElement>(null);
+  const [attachRole, setAttachRole] = useState<GalleryMediaRole>("gallery");
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  // role별 그룹 + sort_order 정렬
+  const grouped: Record<GalleryMediaRole, GalleryItemMediaLink[]> = {
+    cover: [],
+    gallery: [],
+    detail: [],
+    hero_video: [],
+  };
+  for (const l of links) grouped[l.role]?.push(l);
+  for (const k of Object.keys(grouped) as GalleryMediaRole[]) {
+    grouped[k].sort((a, b) => a.sort_order - b.sort_order);
+  }
+
+  function uploadFile(
+    file: File,
+    mode: "attach" | "replace_cover",
+    role?: GalleryMediaRole
+  ) {
+    setError(null);
+    const isVideo = file.type.startsWith("video/");
+    const cap = isVideo ? GALLERY_VIDEO_MAX : GALLERY_IMAGE_MAX;
+    if (file.size > cap) {
+      setError(`파일이 너무 큽니다. (max ${(cap / 1024 / 1024).toFixed(0)}MB)`);
+      return;
+    }
+
+    const fd = new FormData();
+    fd.set("file", file);
+    fd.set("mode", mode);
+    fd.set("item_id", itemId);
+    if (mode === "attach" && role) fd.set("role", role);
+
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/gallery/upload", { method: "POST", body: fd });
+        const json = await res.json();
+        if (!res.ok || !json.ok) {
+          throw new Error(json.error ?? `HTTP ${res.status}`);
+        }
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  function onDelete(linkId: string) {
+    if (!confirm("이 미디어 link를 삭제할까요? (media row는 보존됩니다)")) return;
+    startTransition(async () => {
+      try {
+        await removeGalleryMedia(linkId, itemId);
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  function onMove(role: GalleryMediaRole, index: number, dir: -1 | 1) {
+    const list = grouped[role];
+    const j = index + dir;
+    if (j < 0 || j >= list.length) return;
+    const a = list[index];
+    const b = list[j];
+    startTransition(async () => {
+      try {
+        await reorderGalleryMedia(itemId, [
+          { id: a.id, sort_order: b.sort_order },
+          { id: b.id, sort_order: a.sort_order },
+        ]);
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 액션 바 */}
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-muted/10 p-3">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={pending}
+          onClick={() => replaceCoverInput.current?.click()}
+          className="gap-2"
+        >
+          <UploadIcon className="h-3.5 w-3.5" />
+          Cover 교체
+        </Button>
+        <input
+          ref={replaceCoverInput}
+          type="file"
+          accept="image/*,video/*"
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) uploadFile(f, "replace_cover");
+            e.target.value = "";
+          }}
+        />
+
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Role</span>
+          <Select value={attachRole} onValueChange={(v) => setAttachRole(v as GalleryMediaRole)}>
+            <SelectTrigger className="h-8 w-[130px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ROLE_OPTIONS.map((r) => (
+                <SelectItem key={r} value={r}>
+                  {r}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            size="sm"
+            disabled={pending}
+            onClick={() => attachInput.current?.click()}
+            className="gap-2"
+          >
+            <UploadIcon className="h-3.5 w-3.5" />
+            미디어 추가
+          </Button>
+          <input
+            ref={attachInput}
+            type="file"
+            accept="image/*,video/*"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) uploadFile(f, "attach", attachRole);
+              e.target.value = "";
+            }}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* role별 그룹 */}
+      {(Object.keys(grouped) as GalleryMediaRole[]).map((role) => {
+        const list = grouped[role];
+        if (list.length === 0) return null;
+        return (
+          <div key={role}>
+            <div className="mb-2 flex items-center gap-2">
+              <Badge variant={roleVariant(role)}>{role}</Badge>
+              <span className="text-xs text-muted-foreground">{list.length}건</span>
+            </div>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+              {list.map((link, i) => (
+                <MediaCard
+                  key={link.id}
+                  link={link}
+                  canMoveUp={i > 0}
+                  canMoveDown={i < list.length - 1}
+                  pending={pending}
+                  onUp={() => onMove(role, i, -1)}
+                  onDown={() => onMove(role, i, 1)}
+                  onDelete={() => onDelete(link.id)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      {links.length === 0 && (
+        <div className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+          연결된 미디어가 없습니다. 위 "미디어 추가" 또는 "Cover 교체"로 등록.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MediaCard({
+  link,
+  canMoveUp,
+  canMoveDown,
+  pending,
+  onUp,
+  onDown,
+  onDelete,
+}: {
+  link: GalleryItemMediaLink;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  pending: boolean;
+  onUp: () => void;
+  onDown: () => void;
+  onDelete: () => void;
+}) {
+  const isVideo = link.media_mime?.startsWith("video/");
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="relative aspect-video bg-black/80">
+        {link.media_url ? (
+          isVideo ? (
+            <>
+              <video src={link.media_url} className="h-full w-full object-cover" muted />
+              <PlayCircleIcon className="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 text-white/80" />
+            </>
+          ) : (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={link.media_url}
+              alt={link.media_filename ?? "media"}
+              className="h-full w-full object-cover"
+            />
+          )
+        ) : (
+          <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+            no preview
+          </div>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-1 px-2 py-1.5">
+        <div className="truncate text-[10px] text-muted-foreground" title={link.media_filename ?? ""}>
+          {link.media_filename ?? link.media_id.slice(0, 8)}
+        </div>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            disabled={!canMoveUp || pending}
+            onClick={onUp}
+          >
+            <ChevronUpIcon className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            disabled={!canMoveDown || pending}
+            onClick={onDown}
+          >
+            <ChevronDownIcon className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+            disabled={pending}
+            onClick={onDelete}
+          >
+            <Trash2Icon className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  GalleryItemWithCover,
+  GalleryCoverAspect,
+} from "@/lib/types";
+import { updateGalleryMeta } from "../actions";
+
+const ASPECT_OPTIONS: GalleryCoverAspect[] = ["1:1", "16:9", "9:16", "4:5", "3:4"];
+
+export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
+  const [pending, startTransition] = useTransition();
+  const [title, setTitle] = useState(item.title);
+  const [subtitle, setSubtitle] = useState(item.subtitle ?? "");
+  const [summary, setSummary] = useState(item.summary ?? "");
+  const [author, setAuthor] = useState(item.author ?? "");
+  const [duration, setDuration] = useState(
+    item.duration_minutes?.toString() ?? ""
+  );
+  const [aspect, setAspect] = useState<GalleryCoverAspect>(item.cover_aspect);
+  const [tagsInput, setTagsInput] = useState(item.tags.join(", "));
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const save = () => {
+    startTransition(async () => {
+      await updateGalleryMeta(item.id, {
+        title,
+        subtitle: subtitle || null,
+        summary: summary || null,
+        author: author || null,
+        duration_minutes: duration ? Number.parseInt(duration, 10) : null,
+        cover_aspect: aspect,
+        tags: tagsInput
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+      });
+      setSavedAt(new Date().toLocaleTimeString("ko-KR"));
+    });
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]">
+      {/* 편집 영역 */}
+      <div className="space-y-4">
+        <Field label="Title">
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+        </Field>
+        <Field label="Subtitle (1줄)">
+          <Input value={subtitle} onChange={(e) => setSubtitle(e.target.value)} />
+        </Field>
+        <Field label="Summary">
+          <Textarea
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            rows={3}
+          />
+        </Field>
+        <div className="grid grid-cols-3 gap-4">
+          <Field label="Author">
+            <Input value={author} onChange={(e) => setAuthor(e.target.value)} />
+          </Field>
+          <Field label="Duration (min)">
+            <Input
+              type="number"
+              value={duration}
+              onChange={(e) => setDuration(e.target.value)}
+            />
+          </Field>
+          <Field label="Cover Aspect">
+            <Select value={aspect} onValueChange={(v) => setAspect(v as GalleryCoverAspect)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ASPECT_OPTIONS.map((a) => (
+                  <SelectItem key={a} value={a}>
+                    {a}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+        </div>
+        <Field label="Tags (쉼표 구분)">
+          <Input
+            value={tagsInput}
+            onChange={(e) => setTagsInput(e.target.value)}
+            placeholder="landing, ad, beauty"
+          />
+        </Field>
+
+        <div className="flex items-center gap-3">
+          <Button onClick={save} disabled={pending}>
+            {pending ? "저장 중…" : "저장"}
+          </Button>
+          {savedAt && (
+            <span className="text-xs text-muted-foreground">
+              저장됨 · {savedAt}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* 미리보기 */}
+      <aside className="rounded-lg border border-border bg-muted/10 p-4">
+        <div className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Cover Preview
+        </div>
+        {item.cover_url ? (
+          item.cover_mime?.startsWith("video/") ? (
+            <video
+              src={item.cover_url}
+              controls
+              muted
+              className="w-full rounded-md"
+            />
+          ) : (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={item.cover_url} alt={item.title} className="w-full rounded-md" />
+          )
+        ) : (
+          <div className="flex h-40 items-center justify-center rounded-md bg-muted text-xs text-muted-foreground">
+            cover 없음
+          </div>
+        )}
+
+        <dl className="mt-4 space-y-2 text-xs">
+          <MetaRow label="ID" value={item.id} />
+          <MetaRow label="Kind" value={item.kind} />
+          <MetaRow label="Status" value={item.status} />
+          <MetaRow label="Visibility" value={item.visibility} />
+          <MetaRow label="Featured" value={item.is_featured ? `rank ${item.featured_rank ?? "—"}` : "no"} />
+          <MetaRow label="Published" value={item.published_at?.slice(0, 10) ?? "—"} />
+          <MetaRow label="Updated" value={item.updated_at.slice(0, 10)} />
+        </dl>
+      </aside>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-3">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="truncate font-mono text-right">{value}</dd>
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/gallery/[id]/page.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/page.tsx
@@ -1,0 +1,59 @@
+export const dynamic = "force-dynamic";
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeftIcon } from "lucide-react";
+import { Main } from "@/components/layout/main";
+import { Button } from "@/components/ui/button";
+import { getGalleryItemDetail } from "@/lib/queries";
+import { GalleryMetaForm } from "./meta-form";
+import { GalleryMediaPanel } from "./media-panel";
+import { GalleryDangerZone } from "./danger-zone";
+
+export default async function GalleryItemEditPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const item = await getGalleryItemDetail(id);
+  if (!item) notFound();
+
+  return (
+    <Main>
+      <div className="mb-6 flex items-center gap-3">
+        <Link href="/gallery">
+          <Button variant="ghost" size="sm" className="gap-2">
+            <ArrowLeftIcon className="h-4 w-4" />
+            목록으로
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{item.title}</h1>
+          <p className="text-muted-foreground">/{item.slug} · {item.kind}</p>
+        </div>
+      </div>
+
+      <section className="mb-10">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Meta
+        </h2>
+        <GalleryMetaForm item={item} />
+      </section>
+
+      <section className="mb-10">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Media ({item.media_links.length})
+        </h2>
+        <GalleryMediaPanel itemId={item.id} links={item.media_links} />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-destructive">
+          Danger Zone
+        </h2>
+        <GalleryDangerZone itemId={item.id} title={item.title} />
+      </section>
+    </Main>
+  );
+}

--- a/dashboard/src/app/(dashboard)/gallery/actions.ts
+++ b/dashboard/src/app/(dashboard)/gallery/actions.ts
@@ -1,0 +1,143 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import type {
+  GalleryItemStatus,
+  GalleryCoverAspect,
+  GalleryVisibility,
+} from "@/lib/types";
+
+// ── status 변경 ─────────────────────────────────────────
+export async function updateGalleryStatus(id: string, status: GalleryItemStatus) {
+  const patch: Record<string, unknown> = { status };
+  if (status === "published") patch.published_at = new Date().toISOString();
+
+  const { error } = await getSupabase()
+    .from("gallery_items")
+    .update(patch)
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/gallery");
+  revalidatePath(`/gallery/${id}`);
+}
+
+// ── featured 토글 ───────────────────────────────────────
+export async function setGalleryFeatured(
+  id: string,
+  is_featured: boolean,
+  featured_rank?: number | null
+) {
+  const patch: Record<string, unknown> = {
+    is_featured,
+    featured_rank: is_featured ? featured_rank ?? null : null,
+    featured_at: is_featured ? new Date().toISOString() : null,
+  };
+  const { error } = await getSupabase()
+    .from("gallery_items")
+    .update(patch)
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/gallery");
+}
+
+// ── featured_rank inline 수정 ────────────────────────────
+export async function updateGalleryRank(id: string, featured_rank: number | null) {
+  const { error } = await getSupabase()
+    .from("gallery_items")
+    .update({ featured_rank })
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/gallery");
+}
+
+// ── visibility 변경 ──────────────────────────────────────
+export async function updateGalleryVisibility(id: string, visibility: GalleryVisibility) {
+  const { error } = await getSupabase()
+    .from("gallery_items")
+    .update({ visibility })
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/gallery");
+}
+
+// ── 메타 편집 (title / subtitle / summary / tags / duration / cover_aspect) ─────────
+export interface GalleryMetaPatch {
+  title?: string;
+  subtitle?: string | null;
+  summary?: string | null;
+  tags?: string[];
+  duration_minutes?: number | null;
+  cover_aspect?: GalleryCoverAspect;
+  author?: string | null;
+}
+
+export async function updateGalleryMeta(id: string, patch: GalleryMetaPatch) {
+  const { error } = await getSupabase()
+    .from("gallery_items")
+    .update(patch)
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/gallery");
+  revalidatePath(`/gallery/${id}`);
+}
+
+// ── 미디어 link 삭제 (gallery_item_media row만, media row는 보존) ─────
+export async function removeGalleryMedia(linkId: string, itemId: string) {
+  const { error } = await getSupabase()
+    .from("gallery_item_media")
+    .delete()
+    .eq("id", linkId);
+  if (error) throw new Error(error.message);
+  revalidatePath(`/gallery/${itemId}`);
+}
+
+// ── 미디어 sort_order 일괄 변경 ─────────────────────────────
+export async function reorderGalleryMedia(
+  itemId: string,
+  updates: { id: string; sort_order: number }[]
+) {
+  const sb = getSupabase();
+  const results = await Promise.all(
+    updates.map((u) =>
+      sb
+        .from("gallery_item_media")
+        .update({ sort_order: u.sort_order })
+        .eq("id", u.id)
+    )
+  );
+  const failed = results.find((r) => r.error);
+  if (failed?.error) throw new Error(failed.error.message);
+  revalidatePath(`/gallery/${itemId}`);
+}
+
+// ── 갤러리 아이템 자체 삭제 (gallery_item_media는 cascade) ─────
+// underlying media row + storage 파일은 보존 (다른 item이 참조 가능)
+export async function deleteGalleryItem(id: string) {
+  const { error } = await getSupabase()
+    .from("gallery_items")
+    .delete()
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/gallery");
+}
+
+// ── AWC Web 랜딩 갱신 (수동 트리거) ─────────────────────────
+// 대시보드는 agentic-cms 별도 배포라 AWC Web의 revalidateTag 직접 불가 — HTTP 경유.
+export async function pingAwcWebRevalidate() {
+  const endpoint = process.env.AWC_WEB_REVALIDATE_URL;
+  const secret = process.env.AWC_WEB_REVALIDATE_SECRET;
+  if (!endpoint || !secret) {
+    return { ok: false, reason: "AWC_WEB_REVALIDATE_URL or SECRET not configured" };
+  }
+  try {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "x-admin-secret": secret, "content-type": "application/json" },
+      body: JSON.stringify({ tag: "acms-gallery" }),
+    });
+    return { ok: res.ok, status: res.status };
+  } catch (e) {
+    return { ok: false, reason: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { PlayCircleIcon, ExternalLinkIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  GalleryItemWithCover,
+  GalleryItemStatus,
+  GalleryKind,
+  GalleryVisibility,
+} from "@/lib/types";
+import {
+  setGalleryFeatured,
+  updateGalleryRank,
+  updateGalleryStatus,
+  updateGalleryVisibility,
+  pingAwcWebRevalidate,
+} from "./actions";
+
+const STATUS_OPTIONS: GalleryItemStatus[] = ["draft", "published", "archived"];
+const KIND_FILTER: (GalleryKind | "all")[] = [
+  "all",
+  "landing",
+  "video",
+  "ad",
+  "image",
+  "carousel",
+  "case_study",
+  "other",
+];
+const VISIBILITY_OPTIONS: GalleryVisibility[] = ["public", "member", "internal"];
+
+function kindVariant(kind: GalleryKind) {
+  if (kind === "video") return "destructive" as const;
+  if (kind === "landing") return "warning" as const;
+  if (kind === "ad") return "success" as const;
+  if (kind === "case_study") return "info" as const;
+  return "secondary" as const;
+}
+
+function statusVariant(status: GalleryItemStatus) {
+  if (status === "published") return "success" as const;
+  if (status === "draft") return "warning" as const;
+  return "secondary" as const;
+}
+
+export function GalleryTable({ items }: { items: GalleryItemWithCover[] }) {
+  const [kindFilter, setKindFilter] = useState<(typeof KIND_FILTER)[number]>("all");
+  const [statusFilter, setStatusFilter] = useState<"all" | GalleryItemStatus>("all");
+  const [featuredOnly, setFeaturedOnly] = useState(false);
+
+  const filtered = items.filter((i) => {
+    if (kindFilter !== "all" && i.kind !== kindFilter) return false;
+    if (statusFilter !== "all" && i.status !== statusFilter) return false;
+    if (featuredOnly && !i.is_featured) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* 필터 바 */}
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-muted/10 p-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-muted-foreground">Kind</span>
+          <Select value={kindFilter} onValueChange={(v) => setKindFilter(v as any)}>
+            <SelectTrigger className="h-8 w-[140px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {KIND_FILTER.map((k) => (
+                <SelectItem key={k} value={k}>
+                  {k}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-muted-foreground">Status</span>
+          <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as any)}>
+            <SelectTrigger className="h-8 w-[140px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">all</SelectItem>
+              {STATUS_OPTIONS.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {s}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <label className="flex cursor-pointer items-center gap-2 text-xs">
+          <Switch
+            checked={featuredOnly}
+            onCheckedChange={(v: boolean) => setFeaturedOnly(v)}
+          />
+          <span>Featured only</span>
+        </label>
+        <div className="ml-auto">
+          <RevalidateButton />
+        </div>
+      </div>
+
+      {/* 테이블 */}
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/30 text-left text-xs uppercase tracking-wider text-muted-foreground">
+            <tr>
+              <th className="w-[88px] px-3 py-3">Cover</th>
+              <th className="px-3 py-3">Title</th>
+              <th className="w-[110px] px-3 py-3">Kind</th>
+              <th className="w-[130px] px-3 py-3">Status</th>
+              <th className="w-[130px] px-3 py-3">Visibility</th>
+              <th className="w-[80px] px-3 py-3">Featured</th>
+              <th className="w-[90px] px-3 py-3">Rank</th>
+              <th className="w-[100px] px-3 py-3">Updated</th>
+              <th className="w-[70px] px-3 py-3"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-3 py-12 text-center text-muted-foreground">
+                  조건에 맞는 항목이 없습니다.
+                </td>
+              </tr>
+            )}
+            {filtered.map((item) => (
+              <GalleryRow key={item.id} item={item} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function GalleryRow({ item }: { item: GalleryItemWithCover }) {
+  const [isPending, startTransition] = useTransition();
+  const [rank, setRank] = useState<string>(
+    item.featured_rank?.toString() ?? ""
+  );
+  const isVideo = item.cover_mime?.startsWith("video/");
+
+  const commitRank = () => {
+    const parsed = rank.trim() === "" ? null : Number.parseInt(rank, 10);
+    if (parsed !== null && Number.isNaN(parsed)) return;
+    startTransition(() => {
+      updateGalleryRank(item.id, parsed).catch(console.error);
+    });
+  };
+
+  return (
+    <tr className="border-t border-border/60 hover:bg-muted/10">
+      <td className="px-3 py-3">
+        {item.cover_url ? (
+          isVideo ? (
+            <div className="relative h-12 w-20 overflow-hidden rounded-md bg-black">
+              <video src={item.cover_url} className="h-full w-full object-cover" muted />
+              <PlayCircleIcon className="absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 text-white/90" />
+            </div>
+          ) : (
+            <div className="relative h-12 w-20 overflow-hidden rounded-md bg-muted">
+              <Image
+                src={item.cover_url}
+                alt={item.title}
+                fill
+                sizes="80px"
+                className="object-cover"
+                unoptimized
+              />
+            </div>
+          )
+        ) : (
+          <div className="flex h-12 w-20 items-center justify-center rounded-md bg-muted text-xs text-muted-foreground">
+            —
+          </div>
+        )}
+      </td>
+
+      <td className="px-3 py-3">
+        <div className="font-medium">{item.title}</div>
+        {item.subtitle && (
+          <div className="text-xs text-muted-foreground">{item.subtitle}</div>
+        )}
+        <div className="mt-1 flex flex-wrap gap-1">
+          <span className="text-[10px] text-muted-foreground">/{item.slug}</span>
+          {item.tags.slice(0, 3).map((t) => (
+            <span key={t} className="text-[10px] text-muted-foreground">
+              #{t}
+            </span>
+          ))}
+        </div>
+      </td>
+
+      <td className="px-3 py-3">
+        <Badge variant={kindVariant(item.kind)}>{item.kind}</Badge>
+      </td>
+
+      <td className="px-3 py-3">
+        <Select
+          value={item.status}
+          onValueChange={(v) => {
+            startTransition(() => {
+              updateGalleryStatus(item.id, v as GalleryItemStatus).catch(console.error);
+            });
+          }}
+        >
+          <SelectTrigger className="h-8">
+            <SelectValue>
+              <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((s) => (
+              <SelectItem key={s} value={s}>
+                {s}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </td>
+
+      <td className="px-3 py-3">
+        <Select
+          value={item.visibility}
+          onValueChange={(v) => {
+            startTransition(() => {
+              updateGalleryVisibility(item.id, v as GalleryVisibility).catch(console.error);
+            });
+          }}
+        >
+          <SelectTrigger className="h-8">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {VISIBILITY_OPTIONS.map((v) => (
+              <SelectItem key={v} value={v}>
+                {v}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </td>
+
+      <td className="px-3 py-3">
+        <Switch
+          checked={item.is_featured}
+          disabled={isPending}
+          onCheckedChange={(v: boolean) => {
+            startTransition(() => {
+              setGalleryFeatured(
+                item.id,
+                v,
+                v ? item.featured_rank ?? 100 : null
+              ).catch(console.error);
+            });
+          }}
+        />
+      </td>
+
+      <td className="px-3 py-3">
+        <Input
+          type="number"
+          className="h-8 w-20"
+          value={rank}
+          placeholder="—"
+          disabled={!item.is_featured || isPending}
+          onChange={(e) => setRank(e.target.value)}
+          onBlur={commitRank}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+          }}
+        />
+      </td>
+
+      <td className="px-3 py-3 text-xs text-muted-foreground">
+        {new Date(item.updated_at).toLocaleDateString("ko-KR", {
+          month: "2-digit",
+          day: "2-digit",
+        })}
+      </td>
+
+      <td className="px-3 py-3">
+        <Link href={`/gallery/${item.id}`}>
+          <Button variant="ghost" size="sm" className="gap-1">
+            Edit
+            <ExternalLinkIcon className="h-3 w-3" />
+          </Button>
+        </Link>
+      </td>
+    </tr>
+  );
+}
+
+function RevalidateButton() {
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      onClick={() => {
+        setStatus(null);
+        startTransition(async () => {
+          const r = await pingAwcWebRevalidate();
+          setStatus(r.ok ? "AWC Web 갱신 요청 OK" : `실패: ${r.reason ?? r.status}`);
+          setTimeout(() => setStatus(null), 4000);
+        });
+      }}
+    >
+      {pending ? "요청 중…" : status ?? "AWC Web 랜딩 갱신"}
+    </Button>
+  );
+}

--- a/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -67,6 +67,12 @@ export function NewGalleryForm() {
   const isVideo = file?.type.startsWith("video/") ?? false;
   const sizeCap = isVideo ? GALLERY_VIDEO_MAX : GALLERY_IMAGE_MAX;
   const sizeOver = file ? file.size > sizeCap : false;
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
 
   // title 입력 시 slug 자동 생성 (사용자가 수동 편집한 적 없을 때만)
   const autoSlug = useMemo(() => toKebab(title), [title]);

--- a/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useMemo, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  GalleryKind,
+  GalleryCoverAspect,
+  GalleryItemStatus,
+  GalleryVisibility,
+} from "@/lib/types";
+import { GALLERY_IMAGE_MAX, GALLERY_VIDEO_MAX } from "@/lib/gallery-constants";
+
+const KIND_OPTIONS: GalleryKind[] = [
+  "landing",
+  "video",
+  "ad",
+  "image",
+  "carousel",
+  "case_study",
+  "other",
+];
+const ASPECT_OPTIONS: GalleryCoverAspect[] = ["1:1", "16:9", "9:16", "4:5", "3:4"];
+const STATUS_OPTIONS: GalleryItemStatus[] = ["draft", "published", "archived"];
+const VISIBILITY_OPTIONS: GalleryVisibility[] = ["public", "member", "internal"];
+
+function toKebab(s: string): string {
+  return s
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function NewGalleryForm() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [kind, setKind] = useState<GalleryKind>("image");
+  const [coverAspect, setCoverAspect] = useState<GalleryCoverAspect>("16:9");
+  const [subtitle, setSubtitle] = useState("");
+  const [summary, setSummary] = useState("");
+  const [author, setAuthor] = useState("");
+  const [tags, setTags] = useState("");
+  const [duration, setDuration] = useState("");
+  const [status, setStatus] = useState<GalleryItemStatus>("draft");
+  const [visibility, setVisibility] = useState<GalleryVisibility>("public");
+
+  const isVideo = file?.type.startsWith("video/") ?? false;
+  const sizeCap = isVideo ? GALLERY_VIDEO_MAX : GALLERY_IMAGE_MAX;
+  const sizeOver = file ? file.size > sizeCap : false;
+
+  // title 입력 시 slug 자동 생성 (사용자가 수동 편집한 적 없을 때만)
+  const autoSlug = useMemo(() => toKebab(title), [title]);
+
+  const onTitle = (v: string) => {
+    setTitle(v);
+    if (!slugTouched) setSlug(toKebab(v));
+  };
+
+  const onFile = (f: File | null) => {
+    setFile(f);
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(f ? URL.createObjectURL(f) : null);
+    if (f?.type.startsWith("video/")) {
+      setKind((k) => (k === "image" ? "video" : k));
+    }
+  };
+
+  const canSubmit = !!file && !sizeOver && title.trim() && slug.trim() && !pending;
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit || !file) return;
+    setError(null);
+
+    const fd = new FormData();
+    fd.set("file", file);
+    fd.set("mode", "new");
+    fd.set("slug", slug.trim());
+    fd.set("title", title.trim());
+    fd.set("kind", kind);
+    fd.set("cover_aspect", coverAspect);
+    fd.set("status", status);
+    fd.set("visibility", visibility);
+    if (subtitle.trim()) fd.set("subtitle", subtitle.trim());
+    if (summary.trim()) fd.set("summary", summary.trim());
+    if (author.trim()) fd.set("author", author.trim());
+    if (tags.trim()) fd.set("tags", tags.trim());
+    if (duration.trim()) fd.set("duration_minutes", duration.trim());
+
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/gallery/upload", { method: "POST", body: fd });
+        const json = await res.json();
+        if (!res.ok || !json.ok) {
+          throw new Error(json.error ?? `HTTP ${res.status}`);
+        }
+        router.push(`/gallery/${json.item_id}`);
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]"
+    >
+      <div className="space-y-4">
+        <Field label="File (이미지 ≤10MB / 비디오 ≤100MB)">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*,video/*"
+            onChange={(e) => onFile(e.target.files?.[0] ?? null)}
+            className="block w-full text-sm file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+          />
+          {file && (
+            <div className="mt-2 text-xs text-muted-foreground">
+              {file.name} · {(file.size / 1024 / 1024).toFixed(1)}MB · {file.type}
+            </div>
+          )}
+          {sizeOver && (
+            <div className="mt-1 text-xs text-destructive">
+              파일이 너무 큽니다. ({isVideo ? "비디오 ≤100MB" : "이미지 ≤10MB"})
+            </div>
+          )}
+        </Field>
+
+        <Field label="Title">
+          <Input
+            value={title}
+            onChange={(e) => onTitle(e.target.value)}
+            placeholder="예: AWC · Member Dashboard"
+            required
+          />
+        </Field>
+
+        <Field label="Slug">
+          <Input
+            value={slug}
+            onChange={(e) => {
+              setSlugTouched(true);
+              setSlug(toKebab(e.target.value));
+            }}
+            placeholder={autoSlug || "auto-from-title"}
+            required
+          />
+          <div className="mt-1 text-[10px] text-muted-foreground">
+            /gallery/item/{slug || "—"} (lowercase + kebab만)
+          </div>
+        </Field>
+
+        <div className="grid grid-cols-3 gap-4">
+          <Field label="Kind">
+            <Select value={kind} onValueChange={(v) => setKind(v as GalleryKind)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {KIND_OPTIONS.map((k) => (
+                  <SelectItem key={k} value={k}>
+                    {k}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field label="Cover Aspect">
+            <Select value={coverAspect} onValueChange={(v) => setCoverAspect(v as GalleryCoverAspect)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ASPECT_OPTIONS.map((a) => (
+                  <SelectItem key={a} value={a}>
+                    {a}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field label="Duration (min)">
+            <Input
+              type="number"
+              value={duration}
+              onChange={(e) => setDuration(e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+        </div>
+
+        <Field label="Subtitle (1줄)">
+          <Input
+            value={subtitle}
+            onChange={(e) => setSubtitle(e.target.value)}
+            placeholder="예: 게이미피케이션 멤버십 시안"
+          />
+        </Field>
+
+        <Field label="Summary">
+          <Textarea
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            rows={3}
+          />
+        </Field>
+
+        <div className="grid grid-cols-3 gap-4">
+          <Field label="Author">
+            <Input value={author} onChange={(e) => setAuthor(e.target.value)} />
+          </Field>
+          <Field label="Status">
+            <Select value={status} onValueChange={(v) => setStatus(v as GalleryItemStatus)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field label="Visibility">
+            <Select
+              value={visibility}
+              onValueChange={(v) => setVisibility(v as GalleryVisibility)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {VISIBILITY_OPTIONS.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+        </div>
+
+        <Field label="Tags (쉼표 구분)">
+          <Input
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="landing, ad, beauty"
+          />
+        </Field>
+
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <Button type="submit" disabled={!canSubmit}>
+            {pending ? "업로드 중…" : "등록"}
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            등록 후 상세 페이지로 이동 — 추가 미디어 업로드 가능
+          </span>
+        </div>
+      </div>
+
+      <aside className="rounded-lg border border-border bg-muted/10 p-4">
+        <div className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Cover Preview
+        </div>
+        {previewUrl ? (
+          isVideo ? (
+            <video src={previewUrl} controls muted className="w-full rounded-md" />
+          ) : (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={previewUrl} alt="preview" className="w-full rounded-md" />
+          )
+        ) : (
+          <div className="flex h-48 items-center justify-center rounded-md bg-muted text-xs text-muted-foreground">
+            파일 선택 시 미리보기
+          </div>
+        )}
+      </aside>
+    </form>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/dashboard/src/app/(dashboard)/gallery/new/page.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/new/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { ArrowLeftIcon } from "lucide-react";
+import { Main } from "@/components/layout/main";
+import { Button } from "@/components/ui/button";
+import { NewGalleryForm } from "./new-form";
+
+export default function NewGalleryItemPage() {
+  return (
+    <Main>
+      <div className="mb-6 flex items-center gap-3">
+        <Link href="/gallery">
+          <Button variant="ghost" size="sm" className="gap-2">
+            <ArrowLeftIcon className="h-4 w-4" />
+            목록으로
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">New Gallery Item</h1>
+          <p className="text-muted-foreground">
+            커버 1장 업로드 + 메타 입력 → 즉시 등록. 추가 미디어는 등록 후 상세 화면에서.
+          </p>
+        </div>
+      </div>
+
+      <NewGalleryForm />
+    </Main>
+  );
+}

--- a/dashboard/src/app/(dashboard)/gallery/page.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/page.tsx
@@ -1,0 +1,51 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+import { PlusIcon } from "lucide-react";
+import { Main } from "@/components/layout/main";
+import { Button } from "@/components/ui/button";
+import { getGalleryItems } from "@/lib/queries";
+import { GalleryTable } from "./gallery-table";
+
+export default async function GalleryAdminPage() {
+  const items = await getGalleryItems();
+
+  const counts = {
+    total: items.length,
+    published: items.filter((i) => i.status === "published").length,
+    draft: items.filter((i) => i.status === "draft").length,
+    featured: items.filter((i) => i.is_featured).length,
+  };
+
+  return (
+    <Main>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Gallery</h1>
+          <p className="text-muted-foreground">
+            AWC Web(랜딩+/my) · APP Gallery 공용 전시물. Featured 토글 = 랜딩 노출.
+          </p>
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="text-right text-xs text-muted-foreground">
+            <div>전체 {counts.total} · 공개 {counts.published} · 드래프트 {counts.draft}</div>
+            <div>Featured {counts.featured} / 권장 9</div>
+          </div>
+          <Link href="/gallery/new">
+            <Button size="sm" className="gap-1.5">
+              <PlusIcon className="h-4 w-4" />
+              New
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      <p className="mb-4 text-xs text-muted-foreground">
+        <strong>Tip.</strong> <code>featured_rank</code>가 낮을수록 랜딩에서 먼저 노출.
+        커버 교체·추가 미디어는 각 항목 Edit 화면에서.
+      </p>
+
+      <GalleryTable items={items} />
+    </Main>
+  );
+}

--- a/dashboard/src/app/api/gallery/upload/route.ts
+++ b/dashboard/src/app/api/gallery/upload/route.ts
@@ -78,6 +78,12 @@ export async function POST(req: Request) {
       const kind = (fd.get("kind") as string | null) ?? "image";
 
       if (!slug) return NextResponse.json({ error: "slug required" }, { status: 400 });
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+        return NextResponse.json(
+          { error: "invalid slug (lowercase kebab-case only, no slashes / dots / traversal)" },
+          { status: 400 }
+        );
+      }
       if (!title) return NextResponse.json({ error: "title required" }, { status: 400 });
       if (!ALLOWED_KINDS.has(kind)) {
         return NextResponse.json({ error: `invalid kind: ${kind}` }, { status: 400 });

--- a/dashboard/src/app/api/gallery/upload/route.ts
+++ b/dashboard/src/app/api/gallery/upload/route.ts
@@ -1,0 +1,304 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { GALLERY_IMAGE_MAX, GALLERY_VIDEO_MAX } from "@/lib/gallery-constants";
+
+const BUCKET = "content-media";
+
+type Mode = "new" | "attach" | "replace_cover";
+type Role = "cover" | "gallery" | "detail" | "hero_video";
+
+const ALLOWED_KINDS = new Set([
+  "landing",
+  "video",
+  "ad",
+  "image",
+  "carousel",
+  "case_study",
+  "other",
+]);
+const ALLOWED_ASPECTS = new Set(["1:1", "16:9", "9:16", "4:5", "3:4"]);
+const ALLOWED_ROLES = new Set<Role>(["cover", "gallery", "detail", "hero_video"]);
+
+function safeName(name: string): string {
+  return name
+    .normalize("NFKD")
+    .replace(/[^\w.\-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+function publicUrlFor(path: string): string {
+  return `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${BUCKET}/${path}`;
+}
+
+export async function POST(req: Request) {
+  let storageCleanup: string | null = null;
+  let mediaCleanup: string | null = null;
+
+  try {
+    const fd = await req.formData();
+    const file = fd.get("file") as File | null;
+    const mode = (fd.get("mode") as Mode | null) ?? "new";
+
+    if (!file) {
+      return NextResponse.json({ error: "file is required" }, { status: 400 });
+    }
+    if (!["new", "attach", "replace_cover"].includes(mode)) {
+      return NextResponse.json({ error: `invalid mode: ${mode}` }, { status: 400 });
+    }
+
+    const isImage = file.type.startsWith("image/");
+    const isVideo = file.type.startsWith("video/");
+    if (!isImage && !isVideo) {
+      return NextResponse.json(
+        { error: "이미지 또는 비디오 파일만 업로드 가능합니다." },
+        { status: 400 }
+      );
+    }
+    const sizeCap = isImage ? GALLERY_IMAGE_MAX : GALLERY_VIDEO_MAX;
+    if (file.size > sizeCap) {
+      return NextResponse.json(
+        { error: `파일이 너무 큽니다. (max ${(sizeCap / 1024 / 1024).toFixed(0)}MB)` },
+        { status: 400 }
+      );
+    }
+
+    const sb = getSupabase();
+
+    // ── mode별 사전 파라미터 검증 ──
+    let itemId: string | null = null;
+    let slugForPath: string;
+    let role: Role;
+
+    if (mode === "new") {
+      const slug = (fd.get("slug") as string | null)?.trim();
+      const title = (fd.get("title") as string | null)?.trim();
+      const kind = (fd.get("kind") as string | null) ?? "image";
+
+      if (!slug) return NextResponse.json({ error: "slug required" }, { status: 400 });
+      if (!title) return NextResponse.json({ error: "title required" }, { status: 400 });
+      if (!ALLOWED_KINDS.has(kind)) {
+        return NextResponse.json({ error: `invalid kind: ${kind}` }, { status: 400 });
+      }
+      slugForPath = slug;
+      role = "cover";
+
+      // slug 중복 사전 체크
+      const { data: dup } = await sb
+        .from("gallery_items")
+        .select("id")
+        .eq("slug", slug)
+        .maybeSingle();
+      if (dup?.id) {
+        return NextResponse.json(
+          { error: `slug already exists: ${slug}` },
+          { status: 409 }
+        );
+      }
+    } else {
+      itemId = (fd.get("item_id") as string | null)?.trim() ?? null;
+      if (!itemId) {
+        return NextResponse.json({ error: "item_id required" }, { status: 400 });
+      }
+      const { data: item } = await sb
+        .from("gallery_items")
+        .select("id, slug, cover_media_id")
+        .eq("id", itemId)
+        .maybeSingle();
+      if (!item) {
+        return NextResponse.json({ error: "item not found" }, { status: 404 });
+      }
+      slugForPath = item.slug;
+
+      if (mode === "replace_cover") {
+        role = "cover";
+      } else {
+        const requested = (fd.get("role") as Role | null) ?? "gallery";
+        if (!ALLOWED_ROLES.has(requested)) {
+          return NextResponse.json({ error: `invalid role: ${requested}` }, { status: 400 });
+        }
+        role = requested;
+      }
+    }
+
+    // ── Storage 업로드 ──
+    const ext = file.name.split(".").pop()?.toLowerCase() ?? "bin";
+    const stem = safeName(file.name.replace(/\.[^.]+$/, "")) || "file";
+    const storagePath = `gallery/${slugForPath}/${Date.now()}-${stem}.${ext}`;
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const { error: uploadErr } = await sb.storage
+      .from(BUCKET)
+      .upload(storagePath, buffer, {
+        cacheControl: "3600",
+        contentType: file.type,
+        upsert: false,
+      });
+    if (uploadErr) {
+      return NextResponse.json(
+        { error: `storage: ${uploadErr.message}` },
+        { status: 500 }
+      );
+    }
+    storageCleanup = storagePath;
+
+    // ── media row insert ──
+    const url = publicUrlFor(storagePath);
+    const { data: mediaRow, error: mediaErr } = await sb
+      .from("media")
+      .insert({
+        filename: file.name,
+        mime_type: file.type,
+        file_size: file.size,
+        url,
+        storage_path: storagePath,
+        alt_text: (fd.get("alt_text") as string | null) ?? null,
+        caption: (fd.get("caption") as string | null) ?? null,
+        created_by: "dashboard:gallery-upload",
+      })
+      .select("id")
+      .single();
+    if (mediaErr) {
+      throw new Error(`media insert: ${mediaErr.message}`);
+    }
+    mediaCleanup = mediaRow.id;
+    const mediaId = mediaRow.id;
+
+    // ── mode 분기 처리 ──
+    if (mode === "new") {
+      const slug = fd.get("slug") as string;
+      const title = fd.get("title") as string;
+      const kind = (fd.get("kind") as string) ?? "image";
+      const subtitle = (fd.get("subtitle") as string | null) || null;
+      const summary = (fd.get("summary") as string | null) || null;
+      const author = (fd.get("author") as string | null) || null;
+      const cover_aspect = (fd.get("cover_aspect") as string | null) ?? "16:9";
+      const status = (fd.get("status") as string | null) ?? "draft";
+      const visibility = (fd.get("visibility") as string | null) ?? "public";
+      const durationStr = fd.get("duration_minutes") as string | null;
+      const duration_minutes = durationStr ? Number.parseInt(durationStr, 10) : null;
+      const tagsStr = fd.get("tags") as string | null;
+      const tags = tagsStr
+        ? tagsStr
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : [];
+
+      if (!ALLOWED_ASPECTS.has(cover_aspect)) {
+        throw new Error(`invalid cover_aspect: ${cover_aspect}`);
+      }
+
+      const { data: itemRow, error: itemErr } = await sb
+        .from("gallery_items")
+        .insert({
+          slug,
+          title,
+          subtitle,
+          summary,
+          kind,
+          cover_media_id: mediaId,
+          cover_aspect,
+          status,
+          visibility,
+          tags,
+          author,
+          duration_minutes,
+          brand: "awc",
+          source_label: "Agentic CMS",
+          published_at: status === "published" ? new Date().toISOString() : null,
+        })
+        .select("id, slug")
+        .single();
+      if (itemErr) throw new Error(`gallery_items insert: ${itemErr.message}`);
+
+      // gallery_item_media link (role=cover)
+      const { error: linkErr } = await sb.from("gallery_item_media").insert({
+        item_id: itemRow.id,
+        media_id: mediaId,
+        role: "cover",
+        sort_order: 0,
+      });
+      if (linkErr) throw new Error(`gallery_item_media insert: ${linkErr.message}`);
+
+      revalidatePath("/gallery");
+      return NextResponse.json({
+        ok: true,
+        mode,
+        item_id: itemRow.id,
+        slug: itemRow.slug,
+        media_id: mediaId,
+        url,
+      });
+    }
+
+    if (mode === "replace_cover") {
+      // 이전 cover link 삭제 (있으면)
+      await sb
+        .from("gallery_item_media")
+        .delete()
+        .eq("item_id", itemId!)
+        .eq("role", "cover");
+
+      // 신규 link + cover_media_id 갱신
+      const { error: linkErr } = await sb.from("gallery_item_media").insert({
+        item_id: itemId,
+        media_id: mediaId,
+        role: "cover",
+        sort_order: 0,
+      });
+      if (linkErr) throw new Error(`gallery_item_media insert: ${linkErr.message}`);
+
+      const { error: updErr } = await sb
+        .from("gallery_items")
+        .update({ cover_media_id: mediaId })
+        .eq("id", itemId!);
+      if (updErr) throw new Error(`gallery_items update cover: ${updErr.message}`);
+
+      revalidatePath("/gallery");
+      revalidatePath(`/gallery/${itemId}`);
+      return NextResponse.json({ ok: true, mode, item_id: itemId, media_id: mediaId, url });
+    }
+
+    // mode === "attach"
+    // 다음 sort_order 계산 (같은 role 안에서 max + 1, 없으면 0)
+    const { data: maxRow } = await sb
+      .from("gallery_item_media")
+      .select("sort_order")
+      .eq("item_id", itemId!)
+      .eq("role", role)
+      .order("sort_order", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const nextSort = (maxRow?.sort_order ?? -1) + 1;
+
+    const { error: linkErr } = await sb.from("gallery_item_media").insert({
+      item_id: itemId,
+      media_id: mediaId,
+      role,
+      sort_order: nextSort,
+    });
+    if (linkErr) throw new Error(`gallery_item_media insert: ${linkErr.message}`);
+
+    revalidatePath(`/gallery/${itemId}`);
+    return NextResponse.json({
+      ok: true,
+      mode,
+      item_id: itemId,
+      media_id: mediaId,
+      role,
+      sort_order: nextSort,
+      url,
+    });
+  } catch (e) {
+    const sb = getSupabase();
+    await Promise.all([
+      mediaCleanup ? sb.from("media").delete().eq("id", mediaCleanup) : null,
+      storageCleanup ? sb.storage.from(BUCKET).remove([storageCleanup]) : null,
+    ]);
+    const message = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/dashboard/src/components/layout/app-sidebar.tsx
+++ b/dashboard/src/components/layout/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   LayersIcon,
   TrendingUpIcon,
   PenSquareIcon,
+  GalleryHorizontalIcon,
 } from "lucide-react";
 import {
   Sidebar,
@@ -58,6 +59,7 @@ const pipelineNavItems: NavItem[] = [
 
 const productionNavItems: NavItem[] = [
   { title: "Media", url: "/media", icon: ImageIcon },
+  { title: "Gallery", url: "/gallery", icon: GalleryHorizontalIcon },
 ];
 
 const carouselNavItems: NavItem[] = [

--- a/dashboard/src/lib/gallery-constants.ts
+++ b/dashboard/src/lib/gallery-constants.ts
@@ -1,0 +1,2 @@
+export const GALLERY_IMAGE_MAX = 10 * 1024 * 1024;
+export const GALLERY_VIDEO_MAX = 100 * 1024 * 1024;

--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -16,6 +16,12 @@ import type {
   ActivityAction,
   ActorType,
   Revision,
+  GalleryItem,
+  GalleryItemWithCover,
+  GalleryItemStatus,
+  GalleryKind,
+  GalleryItemDetail,
+  GalleryItemMediaLink,
 } from "./types";
 
 export async function getContents(): Promise<Content[]> {
@@ -260,4 +266,96 @@ export async function getRevisions(contentId: string): Promise<Revision[]> {
     .order("version_number", { ascending: false });
   if (error) throw error;
   return (data ?? []) as Revision[];
+}
+
+// ─── Gallery (AWC Web + APP 페어링) ─────────────────────────
+// 대시보드는 service_role 로 전체 조회 (RLS bypass). cover_url 은 media join 으로 채움.
+
+interface GalleryListOptions {
+  status?: GalleryItemStatus;
+  kind?: GalleryKind;
+  is_featured?: boolean;
+}
+
+export async function getGalleryItems(
+  opts: GalleryListOptions = {}
+): Promise<GalleryItemWithCover[]> {
+  let q = getSupabase()
+    .from("gallery_items")
+    .select("*, media:cover_media_id(url, mime_type)");
+
+  if (opts.status) q = q.eq("status", opts.status);
+  if (opts.kind) q = q.eq("kind", opts.kind);
+  if (typeof opts.is_featured === "boolean") q = q.eq("is_featured", opts.is_featured);
+
+  const { data, error } = await q
+    .order("is_featured", { ascending: false })
+    .order("featured_rank", { ascending: true, nullsFirst: false })
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("updated_at", { ascending: false });
+
+  if (error) throw error;
+
+  return (data ?? []).map((row: any) => {
+    const { media, ...rest } = row;
+    return {
+      ...rest,
+      cover_url: media?.url ?? null,
+      cover_mime: media?.mime_type ?? null,
+    } as GalleryItemWithCover;
+  });
+}
+
+export async function getGalleryItemById(
+  id: string
+): Promise<GalleryItemWithCover | null> {
+  const { data, error } = await getSupabase()
+    .from("gallery_items")
+    .select("*, media:cover_media_id(url, mime_type)")
+    .eq("id", id)
+    .maybeSingle();
+  if (error || !data) return null;
+  const { media, ...rest } = data as any;
+  return {
+    ...rest,
+    cover_url: media?.url ?? null,
+    cover_mime: media?.mime_type ?? null,
+  } as GalleryItemWithCover;
+}
+
+export async function getGalleryItemDetail(
+  id: string
+): Promise<GalleryItemDetail | null> {
+  const { data, error } = await getSupabase()
+    .from("gallery_items")
+    .select(
+      "*, cover:cover_media_id(url, mime_type), gallery_item_media(id, item_id, media_id, role, sort_order, created_at, media:media_id(url, mime_type, filename))"
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  const { cover, gallery_item_media, ...rest } = data as any;
+
+  const media_links: GalleryItemMediaLink[] = (gallery_item_media ?? [])
+    .map((row: any) => {
+      const { media, ...linkRest } = row;
+      return {
+        ...linkRest,
+        media_url: media?.url ?? null,
+        media_mime: media?.mime_type ?? null,
+        media_filename: media?.filename ?? null,
+      } as GalleryItemMediaLink;
+    })
+    .sort((a: GalleryItemMediaLink, b: GalleryItemMediaLink) =>
+      a.role === b.role ? a.sort_order - b.sort_order : a.role.localeCompare(b.role)
+    );
+
+  return {
+    ...rest,
+    cover_url: cover?.url ?? null,
+    cover_mime: cover?.mime_type ?? null,
+    media_links,
+  };
 }

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -199,3 +199,69 @@ export interface FinishedVideo {
   notes?: string;
   created_at?: string;
 }
+
+// ── Gallery ──────────────────────────────────────────────
+export type GalleryKind =
+  | 'landing'
+  | 'video'
+  | 'ad'
+  | 'image'
+  | 'carousel'
+  | 'case_study'
+  | 'other';
+
+export type GalleryCoverAspect = '1:1' | '16:9' | '9:16' | '4:5' | '3:4';
+
+export type GalleryItemStatus = 'draft' | 'published' | 'archived';
+
+export type GalleryVisibility = 'internal' | 'member' | 'public';
+
+export interface GalleryItem {
+  id: string;
+  slug: string;
+  title: string;
+  subtitle: string | null;
+  summary: string | null;
+  kind: GalleryKind;
+  source_table: string | null;
+  source_id: string | null;
+  cover_media_id: string | null;
+  cover_aspect: GalleryCoverAspect;
+  status: GalleryItemStatus;
+  visibility: GalleryVisibility;
+  is_featured: boolean;
+  featured_rank: number | null;
+  published_at: string | null;
+  featured_at: string | null;
+  created_at: string;
+  updated_at: string;
+  tags: string[];
+  brand: string;
+  author: string | null;
+  duration_minutes: number | null;
+  source_label: string;
+  metrics: Record<string, unknown>;
+}
+
+export interface GalleryItemWithCover extends GalleryItem {
+  cover_url: string | null;
+  cover_mime: string | null;
+}
+
+export type GalleryMediaRole = 'cover' | 'gallery' | 'detail' | 'hero_video';
+
+export interface GalleryItemMediaLink {
+  id: string;
+  item_id: string;
+  media_id: string;
+  role: GalleryMediaRole;
+  sort_order: number;
+  created_at: string;
+  media_url: string | null;
+  media_mime: string | null;
+  media_filename: string | null;
+}
+
+export interface GalleryItemDetail extends GalleryItemWithCover {
+  media_links: GalleryItemMediaLink[];
+}

--- a/scripts/seed-gallery.manifest.ts
+++ b/scripts/seed-gallery.manifest.ts
@@ -1,0 +1,276 @@
+/**
+ * AWC Gallery 1회성 Seed 매니페스트
+ *
+ * ~/Downloads/awc-assets/ 의 파일을 Supabase Storage(content-media) 에 업로드하고
+ * media + gallery_items + gallery_item_media 에 row 를 생성한다.
+ *
+ * 편집 가이드:
+ *  - filename  : ~/Downloads/awc-assets/ 기준 상대 파일명 (공백 포함 그대로)
+ *  - slug      : UNIQUE. 파일명 기반이지만 수동 편집 가능. /gallery/item/:slug
+ *  - title     : 카드 상단·상세 페이지 제목
+ *  - subtitle  : 카드 하단·상세 부제 (1줄)
+ *  - kind      : 'landing' | 'video' | 'ad' | 'image' | 'carousel' | 'case_study' | 'other'
+ *  - cover_aspect  : '1:1' | '16:9' | '9:16' | '4:5' | '3:4' (masonry 힌트)
+ *  - duration_minutes  : "Agentic Workflow · N분" 카드 메타 — 실제 제작 소요 시간 추정
+ *  - tags      : 필터·검색용 배열
+ *  - is_featured : 랜딩 masonry 9개 후보 여부
+ *  - featured_rank : is_featured=true 인 것들의 상대 정렬(작을수록 먼저). 10~20 권장
+ *  - visibility : 'public' | 'member' | 'internal' — 기본 'public'
+ *
+ * 실행 전 Jin 확인 필요 사항:
+ *  1. 각 title·subtitle·duration_minutes 현실 근사
+ *  2. featured 후보 10~12개 선정
+ *  3. (영상) cover_aspect 실 비율 (9:16 세로? 16:9 가로?)
+ *
+ * 실행:
+ *  cd ~/Projects/agentic-cms
+ *  SUPABASE_URL=https://euhxmmiqfyptvsvvbbvp.supabase.co \
+ *  SUPABASE_SERVICE_ROLE_KEY=... \
+ *  tsx scripts/seed-gallery.ts
+ */
+
+export type GallerySeedKind =
+  | 'landing'
+  | 'video'
+  | 'ad'
+  | 'image'
+  | 'carousel'
+  | 'case_study'
+  | 'other';
+
+export type GallerySeedAspect = '1:1' | '16:9' | '9:16' | '4:5' | '3:4';
+
+export type GallerySeedVisibility = 'internal' | 'member' | 'public';
+
+export interface GallerySeedItem {
+  filename: string;              // ~/Downloads/awc-assets/<filename>
+  slug: string;
+  title: string;
+  subtitle?: string;
+  summary?: string;
+  kind: GallerySeedKind;
+  cover_aspect: GallerySeedAspect;
+  duration_minutes: number;
+  tags: string[];
+  is_featured: boolean;
+  featured_rank?: number;
+  visibility?: GallerySeedVisibility; // default 'public'
+  author?: string;                    // default 'Agentic Workflow'
+}
+
+/**
+ * Phase 1 seed 매니페스트 — 18개 초안
+ * (Jin 확정 후 실행. 없는 파일은 skip.)
+ */
+export const GALLERY_SEED: GallerySeedItem[] = [
+  // ── LANDING 제작 (AI 랜딩페이지 시안) ─────────────────────────
+  {
+    filename: '03-3d-immersive.png',
+    slug: 'altereal-immersive-form',
+    title: 'Altereal — Immersive Form',
+    subtitle: '3D 몰입형 랜딩 시안',
+    kind: 'landing',
+    cover_aspect: '16:9',
+    duration_minutes: 14,
+    tags: ['landing', '3d', 'art-direction'],
+    is_featured: true,
+    featured_rank: 10,
+  },
+  {
+    filename: '01-y2k-maximalism.png',
+    slug: 'cyber-pop-star-y2k',
+    title: 'Cyber Pop Star',
+    subtitle: 'Y2K 맥시멀리즘 랜딩 시안',
+    kind: 'landing',
+    cover_aspect: '16:9',
+    duration_minutes: 11,
+    tags: ['landing', 'y2k', 'retro'],
+    is_featured: true,
+    featured_rank: 20,
+  },
+  {
+    filename: '02-neo-brutalism.png',
+    slug: 'brutal-co-neo-brutalism',
+    title: 'BRUTAL.CO · Break Grid',
+    subtitle: 'Neo Brutalism 랜딩 시안',
+    kind: 'landing',
+    cover_aspect: '16:9',
+    duration_minutes: 13,
+    tags: ['landing', 'brutalism', 'bold'],
+    is_featured: true,
+    featured_rank: 30,
+  },
+  {
+    filename: '08-gamification-dashboard.png',
+    slug: 'awc-member-dashboard',
+    title: 'AWC · Member Dashboard',
+    subtitle: '게이미피케이션 멤버십 시안',
+    kind: 'landing',
+    cover_aspect: '16:9',
+    duration_minutes: 18,
+    tags: ['landing', 'gamification', 'dashboard', 'awc'],
+    is_featured: true,
+    featured_rank: 40,
+  },
+
+  // ── VIDEO (AI 랜딩 hero autoplay) ─────────────────────────
+  {
+    filename: 'prism-hero-autoplay.mp4',
+    slug: 'prism-hero-autoplay',
+    title: 'Prism · Hero Motion',
+    subtitle: '랜딩 Hero Autoplay',
+    kind: 'video',
+    cover_aspect: '16:9',
+    duration_minutes: 8,
+    tags: ['video', 'hero', 'motion'],
+    is_featured: true,
+    featured_rank: 50,
+  },
+  {
+    filename: 'mulae-hero-autoplay.mp4',
+    slug: 'mulae-hero-autoplay',
+    title: 'Mulae · Hero Motion',
+    subtitle: '랜딩 Hero Autoplay',
+    kind: 'video',
+    cover_aspect: '16:9',
+    duration_minutes: 9,
+    tags: ['video', 'hero', 'motion'],
+    is_featured: false,
+  },
+  {
+    filename: 'parallel-hero-autoplay.mp4',
+    slug: 'parallel-hero-autoplay',
+    title: 'Parallel · Hero Motion',
+    subtitle: '랜딩 Hero Autoplay',
+    kind: 'video',
+    cover_aspect: '16:9',
+    duration_minutes: 9,
+    tags: ['video', 'hero', 'motion'],
+    is_featured: false,
+  },
+  {
+    filename: 'vespr-hero-autoplay.mp4',
+    slug: 'vespr-hero-autoplay',
+    title: 'Vespr · Hero Motion',
+    subtitle: '랜딩 Hero Autoplay',
+    kind: 'video',
+    cover_aspect: '16:9',
+    duration_minutes: 10,
+    tags: ['video', 'hero', 'motion'],
+    is_featured: false,
+  },
+
+  // ── AD VIDEO (AI 인물+제품 합성 광고) ─────────────────────────
+  {
+    filename: 'miumiu-ad-v1.mp4',
+    slug: 'miumiu-spring-edition',
+    title: 'Miu Miu · Spring Edition',
+    subtitle: '핸드백 광고 컷',
+    kind: 'video',
+    cover_aspect: '9:16',
+    duration_minutes: 22,
+    tags: ['ad', 'fashion', 'miumiu'],
+    is_featured: true,
+    featured_rank: 60,
+  },
+  {
+    filename: 'wukong-ad-v2.mp4',
+    slug: 'wukong-brand-film',
+    title: 'Wukong · Brand Film',
+    subtitle: '오공 브랜드 광고 영상',
+    kind: 'video',
+    cover_aspect: '16:9',
+    duration_minutes: 16,
+    tags: ['ad', 'brand-film'],
+    is_featured: true,
+    featured_rank: 70,
+  },
+
+  // ── AD IMAGE (AI 인물+제품 합성) ─────────────────────────
+  {
+    filename: 'image (5).png',
+    slug: 'isoi-golden-timing',
+    title: 'ISOI · Golden Timing',
+    subtitle: 'Eye & Wrinkle Patch 광고 포스터',
+    kind: 'ad',
+    cover_aspect: '3:4',
+    duration_minutes: 9,
+    tags: ['ad', 'beauty', 'isoi'],
+    is_featured: true,
+    featured_rank: 80,
+  },
+  {
+    filename: 'cut1-application.png',
+    slug: 'dermuno-gym-routine',
+    title: 'Dérmuno · Gym Routine',
+    subtitle: '선크림 적용 컷',
+    kind: 'ad',
+    cover_aspect: '3:4',
+    duration_minutes: 7,
+    tags: ['ad', 'beauty', 'lifestyle'],
+    is_featured: true,
+    featured_rank: 90,
+  },
+  {
+    filename: 'cut2-hero-product.png',
+    slug: 'dermuno-hero-product',
+    title: 'Dérmuno · Hero Cut',
+    subtitle: '제품+인물 시선 컷',
+    kind: 'ad',
+    cover_aspect: '3:4',
+    duration_minutes: 6,
+    tags: ['ad', 'beauty'],
+    is_featured: false,
+  },
+  {
+    filename: 'image.png',
+    slug: 'numbus-body-lotion',
+    title: 'numbus · Body Lotion',
+    subtitle: '인물+제품 컷',
+    kind: 'ad',
+    cover_aspect: '3:4',
+    duration_minutes: 5,
+    tags: ['ad', 'beauty'],
+    is_featured: false,
+  },
+
+  // ── PRODUCT · IMAGE (AI 렌더) ─────────────────────────
+  {
+    filename: 'image (11).png',
+    slug: 'miumiu-matelasse-wallet',
+    title: 'Miu Miu · Matelassé Wallet',
+    subtitle: '제품 클로즈업',
+    kind: 'image',
+    cover_aspect: '16:9',
+    duration_minutes: 4,
+    tags: ['product', 'fashion'],
+    is_featured: false,
+  },
+  {
+    filename: 'image (15).png',
+    slug: 'han-river-penthouse',
+    title: 'Han-River Penthouse',
+    subtitle: '프리미엄 인테리어 렌더',
+    kind: 'image',
+    cover_aspect: '16:9',
+    duration_minutes: 12,
+    tags: ['image', 'interior', 'render'],
+    is_featured: true,
+    featured_rank: 100,
+  },
+
+  // ── META (AWC 자체 랜딩 — 메타 사례) ─────────────────────────
+  {
+    filename: 'awc-landing-full.png',
+    slug: 'awc-landing-full',
+    title: 'AWC · 자체 랜딩 (v1)',
+    subtitle: 'Agentic Workflows Club 랜딩 전체 스냅샷',
+    kind: 'case_study',
+    cover_aspect: '9:16',
+    duration_minutes: 45,
+    tags: ['awc', 'landing', 'case-study', 'meta'],
+    is_featured: true,
+    featured_rank: 5, // 최우선 노출
+    author: 'AWC Team',
+  },
+];

--- a/scripts/seed-gallery.ts
+++ b/scripts/seed-gallery.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env tsx
+/**
+ * AWC Gallery 1회성 Seed — Downloads/awc-assets → Supabase Storage + gallery_items
+ *
+ * 사용법:
+ *   cd ~/Projects/agentic-cms
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... tsx scripts/seed-gallery.ts
+ *
+ * 옵션:
+ *   --dry      DB·Storage 쓰기 없이 매니페스트·파일 유효성만 확인
+ *   --force    이미 존재하는 slug의 gallery_items도 UPDATE
+ *
+ * 멱등성: media.storage_path + gallery_items.slug UNIQUE 로 재실행 시 중복 insert skip.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { basename, extname, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { GALLERY_SEED, type GallerySeedItem } from './seed-gallery.manifest.js';
+
+// ── config ────────────────────────────────────────────────────────
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const DRY_RUN = process.argv.includes('--dry');
+const FORCE = process.argv.includes('--force');
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('ERROR: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY env 필요');
+  process.exit(1);
+}
+
+const ASSET_DIR = resolve(homedir(), 'Downloads/awc-assets');
+const BUCKET = 'content-media';
+
+// ── helpers ────────────────────────────────────────────────────────
+const MIME_MAP: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+};
+
+function mimeFor(filename: string): string {
+  const ext = extname(filename).toLowerCase();
+  return MIME_MAP[ext] ?? 'application/octet-stream';
+}
+
+function storagePathFor(slug: string, filename: string): string {
+  const ext = extname(filename).toLowerCase();
+  return `gallery-seed/${slug}${ext}`;
+}
+
+function log(label: string, ...args: unknown[]) {
+  const tag = DRY_RUN ? '[DRY]' : '[SEED]';
+  console.log(`${tag} ${label}`, ...args);
+}
+
+// ── main ────────────────────────────────────────────────────────
+async function main() {
+  const sb = createClient(SUPABASE_URL!, SERVICE_KEY!, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  log(`manifest: ${GALLERY_SEED.length} items | asset dir: ${ASSET_DIR}`);
+
+  let ok = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const item of GALLERY_SEED) {
+    try {
+      const localPath = resolve(ASSET_DIR, item.filename);
+      if (!existsSync(localPath)) {
+        log(`SKIP (file missing): ${item.filename}`);
+        skipped++;
+        continue;
+      }
+
+      const storagePath = storagePathFor(item.slug, item.filename);
+      const mime = mimeFor(item.filename);
+      const fileSize = statSync(localPath).size;
+
+      // 1) Storage 업로드 (멱등: upsert:false 로 duplicate 시 error → skip)
+      let storageUrl = `${SUPABASE_URL}/storage/v1/object/public/${BUCKET}/${storagePath}`;
+      if (!DRY_RUN) {
+        const buffer = readFileSync(localPath);
+        const { error: uploadErr } = await sb.storage
+          .from(BUCKET)
+          .upload(storagePath, buffer, {
+            contentType: mime,
+            upsert: FORCE,
+          });
+        if (uploadErr && !uploadErr.message.includes('already exists')) {
+          throw new Error(`upload ${item.slug}: ${uploadErr.message}`);
+        }
+      }
+      log(`storage OK: ${item.slug} → ${storagePath} (${(fileSize / 1024 / 1024).toFixed(1)}MB)`);
+
+      // 2) media row 확보 (slug 로 조회 후 없으면 insert)
+      let mediaId: string | null = null;
+      if (!DRY_RUN) {
+        const { data: existingMedia } = await sb
+          .from('media')
+          .select('id')
+          .eq('storage_path', storagePath)
+          .maybeSingle();
+        if (existingMedia?.id) {
+          mediaId = existingMedia.id;
+        } else {
+          const { data: newMedia, error: mediaErr } = await sb
+            .from('media')
+            .insert({
+              filename: basename(item.filename),
+              mime_type: mime,
+              file_size: fileSize,
+              url: storageUrl,
+              storage_path: storagePath,
+              caption: item.subtitle ?? null,
+              alt_text: item.title,
+              created_by: 'seed:gallery',
+            })
+            .select('id')
+            .single();
+          if (mediaErr) throw new Error(`media insert ${item.slug}: ${mediaErr.message}`);
+          mediaId = newMedia.id;
+        }
+      }
+
+      // 3) gallery_items row (멱등: slug UNIQUE)
+      if (!DRY_RUN) {
+        const payload = {
+          slug: item.slug,
+          title: item.title,
+          subtitle: item.subtitle ?? null,
+          summary: item.summary ?? null,
+          kind: item.kind,
+          cover_media_id: mediaId,
+          cover_aspect: item.cover_aspect,
+          status: 'published' as const,
+          visibility: item.visibility ?? 'public',
+          is_featured: item.is_featured,
+          featured_rank: item.featured_rank ?? null,
+          published_at: new Date().toISOString(),
+          featured_at: item.is_featured ? new Date().toISOString() : null,
+          tags: item.tags,
+          brand: 'awc',
+          author: item.author ?? 'Agentic Workflow',
+          duration_minutes: item.duration_minutes,
+          source_label: 'Agentic Workflow',
+          metrics: {},
+        };
+
+        const { data: existing } = await sb
+          .from('gallery_items')
+          .select('id')
+          .eq('slug', item.slug)
+          .maybeSingle();
+
+        let itemId: string;
+        if (existing?.id) {
+          if (FORCE) {
+            const { error: updErr } = await sb
+              .from('gallery_items')
+              .update(payload)
+              .eq('id', existing.id);
+            if (updErr) throw new Error(`gallery_items update: ${updErr.message}`);
+            log(`gallery_items UPDATE: ${item.slug}`);
+          } else {
+            log(`gallery_items EXISTS (no --force): ${item.slug}`);
+          }
+          itemId = existing.id;
+        } else {
+          const { data: inserted, error: insErr } = await sb
+            .from('gallery_items')
+            .insert(payload)
+            .select('id')
+            .single();
+          if (insErr) throw new Error(`gallery_items insert: ${insErr.message}`);
+          itemId = inserted.id;
+          log(`gallery_items INSERT: ${item.slug}`);
+        }
+
+        // 4) gallery_item_media link (cover role, 1건)
+        const { data: existingLink } = await sb
+          .from('gallery_item_media')
+          .select('id')
+          .eq('item_id', itemId)
+          .eq('media_id', mediaId!)
+          .maybeSingle();
+        if (!existingLink) {
+          const { error: linkErr } = await sb.from('gallery_item_media').insert({
+            item_id: itemId,
+            media_id: mediaId,
+            role: 'cover',
+            sort_order: 0,
+          });
+          if (linkErr) throw new Error(`gallery_item_media insert: ${linkErr.message}`);
+        }
+      }
+
+      ok++;
+    } catch (e) {
+      failed++;
+      console.error(`FAIL [${item.slug}]`, e instanceof Error ? e.message : e);
+    }
+  }
+
+  console.log(`\n── Seed 완료: ok=${ok} skipped=${skipped} failed=${failed} (dry=${DRY_RUN})`);
+}
+
+main().catch((e) => {
+  console.error('FATAL', e);
+  process.exit(1);
+});

--- a/src/adapters/interface.ts
+++ b/src/adapters/interface.ts
@@ -21,6 +21,14 @@ import type {
   Revision,
   Media,
   MediaCreateInput,
+  GalleryItem,
+  GalleryItemCreateInput,
+  GalleryItemFilter,
+  GalleryFeaturedUpdate,
+  GalleryItemUpdateInput,
+  GalleryItemMedia,
+  GalleryMediaAttachInput,
+  GalleryMediaReorderInput,
 } from '../types.js';
 
 export interface CMSAdapter {
@@ -62,4 +70,19 @@ export interface CMSAdapter {
   // Media
   listMedia(limit?: number): Promise<Media[]>;
   createMedia(data: MediaCreateInput): Promise<Media>;
+
+  // Gallery (AWC Web + APP 페어링)
+  listGalleryItems(filter?: GalleryItemFilter): Promise<GalleryItem[]>;
+  getGalleryItem(id: string): Promise<GalleryItem | null>;
+  createGalleryItem(input: GalleryItemCreateInput): Promise<GalleryItem>;
+  updateGalleryItem(id: string, patch: GalleryItemUpdateInput): Promise<GalleryItem>;
+  deleteGalleryItem(id: string): Promise<void>;
+  setGalleryFeatured(input: GalleryFeaturedUpdate): Promise<GalleryItem>;
+
+  // Gallery item media (1 item → N media)
+  listGalleryMedia(itemId: string): Promise<GalleryItemMedia[]>;
+  attachGalleryMedia(input: GalleryMediaAttachInput): Promise<GalleryItemMedia>;
+  detachGalleryMedia(linkId: string): Promise<void>;
+  reorderGalleryMedia(updates: GalleryMediaReorderInput[]): Promise<void>;
+  setGalleryCover(itemId: string, mediaId: string): Promise<GalleryItem>;
 }

--- a/src/adapters/supabase.ts
+++ b/src/adapters/supabase.ts
@@ -23,6 +23,14 @@ import type {
   Revision,
   Media,
   MediaCreateInput,
+  GalleryItem,
+  GalleryItemCreateInput,
+  GalleryItemFilter,
+  GalleryFeaturedUpdate,
+  GalleryItemUpdateInput,
+  GalleryItemMedia,
+  GalleryMediaAttachInput,
+  GalleryMediaReorderInput,
 } from '../types.js';
 import { hooks } from '../hooks.js';
 
@@ -535,5 +543,170 @@ export class SupabaseAdapter implements CMSAdapter {
 
     if (error) throw new Error(`Failed to create media: ${error.message}`);
     return data as Media;
+  }
+
+  // ─── Gallery ──────────────────────────────────────────────
+
+  async listGalleryItems(filter: GalleryItemFilter = {}): Promise<GalleryItem[]> {
+    let q = this.client.from('gallery_items').select('*');
+
+    if (filter.status) q = q.eq('status', filter.status);
+    if (filter.kind) q = q.eq('kind', filter.kind);
+    if (typeof filter.is_featured === 'boolean') q = q.eq('is_featured', filter.is_featured);
+    if (filter.visibility) q = q.eq('visibility', filter.visibility);
+
+    q = q.order('is_featured', { ascending: false })
+      .order('featured_rank', { ascending: true, nullsFirst: false })
+      .order('published_at', { ascending: false, nullsFirst: false })
+      .limit(filter.limit ?? 50);
+
+    if (filter.offset) {
+      q = q.range(filter.offset, filter.offset + (filter.limit ?? 50) - 1);
+    }
+
+    const { data, error } = await q;
+    if (error) throw new Error(`Failed to list gallery items: ${error.message}`);
+    return data as GalleryItem[];
+  }
+
+  async createGalleryItem(input: GalleryItemCreateInput): Promise<GalleryItem> {
+    const payload = {
+      status: 'draft' as const,
+      visibility: 'public' as const,
+      is_featured: false,
+      cover_aspect: '16:9' as const,
+      source_label: 'Agentic CMS',
+      brand: 'awc',
+      tags: [] as string[],
+      ...input,
+    };
+
+    const { data, error } = await this.client
+      .from('gallery_items')
+      .insert(payload)
+      .select()
+      .single();
+
+    if (error) throw new Error(`Failed to create gallery item: ${error.message}`);
+    return data as GalleryItem;
+  }
+
+  async setGalleryFeatured(input: GalleryFeaturedUpdate): Promise<GalleryItem> {
+    const patch: Record<string, unknown> = {
+      is_featured: input.is_featured,
+      featured_rank: input.is_featured ? (input.featured_rank ?? null) : null,
+      featured_at: input.is_featured ? new Date().toISOString() : null,
+    };
+
+    const { data, error } = await this.client
+      .from('gallery_items')
+      .update(patch)
+      .eq('id', input.id)
+      .select()
+      .single();
+
+    if (error) throw new Error(`Failed to set gallery featured: ${error.message}`);
+    return data as GalleryItem;
+  }
+
+  async getGalleryItem(id: string): Promise<GalleryItem | null> {
+    const { data, error } = await this.client
+      .from('gallery_items')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw new Error(`Failed to get gallery item: ${error.message}`);
+    return (data as GalleryItem) ?? null;
+  }
+
+  async updateGalleryItem(id: string, patch: GalleryItemUpdateInput): Promise<GalleryItem> {
+    const finalPatch: Record<string, unknown> = { ...patch };
+    if (patch.status === 'published' && !('published_at' in patch)) {
+      finalPatch.published_at = new Date().toISOString();
+    }
+    if (patch.is_featured === true && !('featured_at' in patch)) {
+      finalPatch.featured_at = new Date().toISOString();
+    }
+    if (patch.is_featured === false) {
+      finalPatch.featured_rank = null;
+      finalPatch.featured_at = null;
+    }
+
+    const { data, error } = await this.client
+      .from('gallery_items')
+      .update(finalPatch)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) throw new Error(`Failed to update gallery item: ${error.message}`);
+    return data as GalleryItem;
+  }
+
+  async deleteGalleryItem(id: string): Promise<void> {
+    const { error } = await this.client.from('gallery_items').delete().eq('id', id);
+    if (error) throw new Error(`Failed to delete gallery item: ${error.message}`);
+  }
+
+  // ─── Gallery item media ─────────────────────────────────────
+
+  async listGalleryMedia(itemId: string): Promise<GalleryItemMedia[]> {
+    const { data, error } = await this.client
+      .from('gallery_item_media')
+      .select('*')
+      .eq('item_id', itemId)
+      .order('sort_order', { ascending: true });
+    if (error) throw new Error(`Failed to list gallery media: ${error.message}`);
+    return data as GalleryItemMedia[];
+  }
+
+  async attachGalleryMedia(input: GalleryMediaAttachInput): Promise<GalleryItemMedia> {
+    const payload = {
+      item_id: input.item_id,
+      media_id: input.media_id,
+      role: input.role ?? 'gallery',
+      sort_order: input.sort_order ?? 0,
+    };
+    const { data, error } = await this.client
+      .from('gallery_item_media')
+      .insert(payload)
+      .select()
+      .single();
+    if (error) throw new Error(`Failed to attach gallery media: ${error.message}`);
+    return data as GalleryItemMedia;
+  }
+
+  async detachGalleryMedia(linkId: string): Promise<void> {
+    const { error } = await this.client
+      .from('gallery_item_media')
+      .delete()
+      .eq('id', linkId);
+    if (error) throw new Error(`Failed to detach gallery media: ${error.message}`);
+  }
+
+  async reorderGalleryMedia(updates: GalleryMediaReorderInput[]): Promise<void> {
+    const results = await Promise.all(
+      updates.map((u) =>
+        this.client
+          .from('gallery_item_media')
+          .update({ sort_order: u.sort_order })
+          .eq('id', u.id)
+          .then((r) => ({ id: u.id, error: r.error }))
+      )
+    );
+    const failed = results.find((r) => r.error);
+    if (failed?.error) {
+      throw new Error(`Failed to reorder gallery media (${failed.id}): ${failed.error.message}`);
+    }
+  }
+
+  async setGalleryCover(itemId: string, mediaId: string): Promise<GalleryItem> {
+    const { data, error } = await this.client
+      .from('gallery_items')
+      .update({ cover_media_id: mediaId })
+      .eq('id', itemId)
+      .select()
+      .single();
+    if (error) throw new Error(`Failed to set gallery cover: ${error.message}`);
+    return data as GalleryItem;
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { registerCarouselTools } from './tools/carousels.js';
 import { registerNewsletterTools } from './tools/newsletter.js';
 import { registerVideoLinkTools } from './tools/video-link.js';
 import { registerPostizTools } from './tools/postiz.js';
+import { registerGalleryTools } from './tools/gallery.js';
 
 async function main(): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -65,6 +66,9 @@ async function main(): Promise<void> {
 
   // Postiz — 소셜 채널 실제 발행 (POSTIZ_API_URL + POSTIZ_API_KEY 필요).
   registerPostizTools(server, adapter);
+
+  // Gallery — AWC Web(/gallery) + APP Gallery 공용. list/create/set_featured 3 tool.
+  registerGalleryTools(server, adapter);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/gallery.ts
+++ b/src/tools/gallery.ts
@@ -1,0 +1,208 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CMSAdapter } from '../adapters/interface.js';
+
+const KIND = z.enum(['landing', 'video', 'ad', 'image', 'carousel', 'case_study', 'other']);
+const ASPECT = z.enum(['1:1', '16:9', '9:16', '4:5', '3:4']);
+const STATUS = z.enum(['draft', 'published', 'archived']);
+const VISIBILITY = z.enum(['internal', 'member', 'public']);
+const ROLE = z.enum(['cover', 'gallery', 'detail', 'hero_video']);
+
+function textResult(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function errorResult(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+export function registerGalleryTools(server: McpServer, adapter: CMSAdapter): void {
+  // 1. list_gallery_items
+  server.tool(
+    'list_gallery_items',
+    'List AWC Gallery items. Filter by status/kind/featured/visibility. Ordered by featured first, featured_rank asc, then published_at desc.',
+    {
+      status: STATUS.optional().describe("Lifecycle status filter (default: no filter)"),
+      kind: KIND.optional().describe('Kind filter'),
+      is_featured: z.boolean().optional().describe('Featured flag filter'),
+      visibility: VISIBILITY.optional().describe('Visibility filter'),
+      limit: z.number().min(1).max(100).optional().describe('Max results (default 50)'),
+      offset: z.number().min(0).optional().describe('Pagination offset'),
+    },
+    async (params) => {
+      try {
+        const items = await adapter.listGalleryItems(params);
+        return textResult({ items, count: items.length });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 2. create_gallery_item
+  server.tool(
+    'create_gallery_item',
+    'Create a Gallery item (default status=draft, visibility=public). Use set_gallery_featured afterwards to pin to the landing carousel.',
+    {
+      slug: z.string().min(1).describe('Unique slug (/gallery/item/:slug)'),
+      title: z.string().min(1),
+      subtitle: z.string().optional(),
+      summary: z.string().optional(),
+      kind: KIND,
+      cover_media_id: z.string().uuid().optional().describe('FK media.id for cover'),
+      cover_aspect: ASPECT.optional().describe("Cover aspect hint (default '16:9')"),
+      status: STATUS.optional().describe("Lifecycle status (default 'draft')"),
+      visibility: VISIBILITY.optional().describe("Visibility (default 'public')"),
+      tags: z.array(z.string()).optional().describe('Tags array (Phase 1 text[])'),
+      duration_minutes: z.number().int().min(0).optional(),
+      author: z.string().optional(),
+      source_table: z.string().optional(),
+      source_id: z.string().uuid().optional(),
+      published_at: z.string().datetime().optional(),
+    },
+    async (params) => {
+      try {
+        const item = await adapter.createGalleryItem(params);
+        return textResult({ message: 'Gallery item created', item });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 3. set_gallery_featured
+  server.tool(
+    'set_gallery_featured',
+    'Pin/unpin a Gallery item to the landing featured carousel. Set is_featured and featured_rank (lower = earlier).',
+    {
+      id: z.string().uuid().describe('gallery_items.id'),
+      is_featured: z.boolean().describe('true to pin, false to unpin'),
+      featured_rank: z.number().int().optional().describe('Sort key (e.g. 10, 20, 30). Only when is_featured=true.'),
+    },
+    async (params) => {
+      try {
+        const item = await adapter.setGalleryFeatured(params);
+        return textResult({ message: 'Gallery featured updated', item });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 4. update_gallery_item — meta + status/visibility 통합 patch
+  server.tool(
+    'update_gallery_item',
+    'Patch a Gallery item. Any subset of: title, subtitle, summary, kind, status, visibility, cover_aspect, tags, author, duration_minutes, is_featured, featured_rank, cover_media_id. published_at/featured_at are auto-set when status flips to published or is_featured flips to true.',
+    {
+      id: z.string().uuid(),
+      title: z.string().min(1).optional(),
+      subtitle: z.string().nullable().optional(),
+      summary: z.string().nullable().optional(),
+      kind: KIND.optional(),
+      cover_media_id: z.string().uuid().nullable().optional(),
+      cover_aspect: ASPECT.optional(),
+      status: STATUS.optional(),
+      visibility: VISIBILITY.optional(),
+      is_featured: z.boolean().optional(),
+      featured_rank: z.number().int().nullable().optional(),
+      tags: z.array(z.string()).optional(),
+      author: z.string().nullable().optional(),
+      duration_minutes: z.number().int().nullable().optional(),
+    },
+    async ({ id, ...patch }) => {
+      try {
+        const item = await adapter.updateGalleryItem(id, patch);
+        return textResult({ message: 'Gallery item updated', item });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 5. delete_gallery_item — gallery_item_media는 cascade
+  server.tool(
+    'delete_gallery_item',
+    'Hard-delete a Gallery item. gallery_item_media rows cascade. Underlying media rows + storage files are NOT deleted (other items may reference them).',
+    { id: z.string().uuid() },
+    async ({ id }) => {
+      try {
+        await adapter.deleteGalleryItem(id);
+        return textResult({ message: 'Gallery item deleted', id });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 6. list_gallery_media
+  server.tool(
+    'list_gallery_media',
+    'List gallery_item_media rows for an item, ordered by sort_order asc.',
+    { item_id: z.string().uuid() },
+    async ({ item_id }) => {
+      try {
+        const links = await adapter.listGalleryMedia(item_id);
+        return textResult({ links, count: links.length });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 7. attach_gallery_media — media row을 item에 link
+  server.tool(
+    'attach_gallery_media',
+    'Attach an existing media row to a gallery item with role + sort_order. role defaults to gallery.',
+    {
+      item_id: z.string().uuid(),
+      media_id: z.string().uuid(),
+      role: ROLE.optional().describe("Role (default 'gallery')"),
+      sort_order: z.number().int().optional(),
+    },
+    async (params) => {
+      try {
+        const link = await adapter.attachGalleryMedia(params);
+        return textResult({ message: 'Media attached', link });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 8. detach_gallery_media
+  server.tool(
+    'detach_gallery_media',
+    'Remove a gallery_item_media link. Underlying media row is preserved.',
+    { link_id: z.string().uuid() },
+    async ({ link_id }) => {
+      try {
+        await adapter.detachGalleryMedia(link_id);
+        return textResult({ message: 'Media detached', link_id });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+
+  // 9. set_gallery_cover — cover_media_id만 갱신 (link도 함께 만들지 않음)
+  server.tool(
+    'set_gallery_cover',
+    'Set gallery_items.cover_media_id. Use attach_gallery_media separately if you also want a gallery_item_media row with role=cover.',
+    {
+      item_id: z.string().uuid(),
+      media_id: z.string().uuid(),
+    },
+    async ({ item_id, media_id }) => {
+      try {
+        const item = await adapter.setGalleryCover(item_id, media_id);
+        return textResult({ message: 'Gallery cover updated', item });
+      } catch (e) {
+        return errorResult(e);
+      }
+    }
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,3 +240,122 @@ export interface ContentRelation {
   relation_type: 'related' | 'series' | 'parent-child';
   sort_order: number;
 }
+
+// ── Gallery (AWC Web + APP 공용) ──────────────────────────────
+export type GalleryKind =
+  | 'landing'
+  | 'video'
+  | 'ad'
+  | 'image'
+  | 'carousel'
+  | 'case_study'
+  | 'other';
+
+export type GalleryCoverAspect = '1:1' | '16:9' | '9:16' | '4:5' | '3:4';
+
+export type GalleryStatus = 'draft' | 'published' | 'archived';
+
+export type GalleryVisibility = 'internal' | 'member' | 'public';
+
+export interface GalleryItem {
+  id: string;
+  slug: string;
+  title: string;
+  subtitle?: string | null;
+  summary?: string | null;
+  kind: GalleryKind;
+  source_table?: string | null;
+  source_id?: string | null;
+  cover_media_id?: string | null;
+  cover_aspect: GalleryCoverAspect;
+  status: GalleryStatus;
+  visibility: GalleryVisibility;
+  is_featured: boolean;
+  featured_rank?: number | null;
+  published_at?: string | null;
+  featured_at?: string | null;
+  created_at: string;
+  updated_at: string;
+  tags: string[];
+  brand: string;
+  author?: string | null;
+  duration_minutes?: number | null;
+  source_label: string;
+  metrics: Record<string, unknown>;
+}
+
+export interface GalleryItemCreateInput {
+  slug: string;
+  title: string;
+  subtitle?: string;
+  summary?: string;
+  kind: GalleryKind;
+  source_table?: string;
+  source_id?: string;
+  cover_media_id?: string;
+  cover_aspect?: GalleryCoverAspect;
+  status?: GalleryStatus;
+  visibility?: GalleryVisibility;
+  is_featured?: boolean;
+  featured_rank?: number;
+  published_at?: string;
+  tags?: string[];
+  author?: string;
+  duration_minutes?: number;
+  source_label?: string;
+}
+
+export interface GalleryItemFilter {
+  status?: GalleryStatus;
+  kind?: GalleryKind;
+  is_featured?: boolean;
+  visibility?: GalleryVisibility;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GalleryFeaturedUpdate {
+  id: string;
+  is_featured: boolean;
+  featured_rank?: number | null;
+}
+
+export interface GalleryItemUpdateInput {
+  title?: string;
+  subtitle?: string | null;
+  summary?: string | null;
+  kind?: GalleryKind;
+  cover_media_id?: string | null;
+  cover_aspect?: GalleryCoverAspect;
+  status?: GalleryStatus;
+  visibility?: GalleryVisibility;
+  is_featured?: boolean;
+  featured_rank?: number | null;
+  published_at?: string | null;
+  tags?: string[];
+  author?: string | null;
+  duration_minutes?: number | null;
+}
+
+export type GalleryMediaRole = 'cover' | 'gallery' | 'detail' | 'hero_video';
+
+export interface GalleryItemMedia {
+  id: string;
+  item_id: string;
+  media_id: string;
+  role: GalleryMediaRole;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface GalleryMediaAttachInput {
+  item_id: string;
+  media_id: string;
+  role?: GalleryMediaRole;
+  sort_order?: number;
+}
+
+export interface GalleryMediaReorderInput {
+  id: string;
+  sort_order: number;
+}

--- a/supabase/migrations/20260423000000_gallery_items.sql
+++ b/supabase/migrations/20260423000000_gallery_items.sql
@@ -1,0 +1,117 @@
+-- AWC Gallery — 전시물(gallery_items) + 미디어 연결(gallery_item_media)
+-- Context: 4/23 회의 결정 t_8670eef. Web(랜딩+/my) + APP(DDD) Gallery 페어 신설.
+-- - media는 저수준 자산 풀(blog 본문/캐러셀 슬라이드 공유)으로 유지
+-- - gallery_items는 "Gallery 전시물" 추상 — 1 item이 여러 media 참조 가능(커버 + 추가)
+-- - Phase 1 lifecycle: draft → published → featured(flag). review 상태는 Phase 2.
+
+-- ── gallery_items: Gallery 전시물 ──
+create table gallery_items (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  title text not null,
+  subtitle text,
+  summary text,
+
+  -- 분류
+  kind text not null check (kind in (
+    'landing', 'video', 'ad', 'image', 'carousel', 'case_study', 'other'
+  )),
+
+  -- 원본 추적 (nullable — 외부 합성물·수동 업로드 대비)
+  source_table text,   -- 'blog_posts' | 'carousels' | 'social_posts' | 'video_projects' | null
+  source_id uuid,
+
+  -- 커버 미디어 (빠른 접근 캐시, 상세 표시는 gallery_item_media 사용)
+  cover_media_id uuid references media(id) on delete set null,
+  cover_aspect text default '16:9' check (cover_aspect in ('1:1', '16:9', '9:16', '4:5', '3:4')),
+
+  -- lifecycle (Phase 1 — review 생략)
+  status text not null default 'draft' check (status in ('draft', 'published', 'archived')),
+  visibility text not null default 'public' check (visibility in ('internal', 'member', 'public')),
+
+  -- 큐레이션
+  is_featured boolean default false,
+  featured_rank integer,
+
+  -- 시간
+  published_at timestamptz,
+  featured_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+
+  -- 메타
+  tags text[] default '{}',
+  brand text default 'awc',
+  author text,
+  duration_minutes integer,
+  source_label text default 'Agentic CMS',
+
+  -- 메트릭 미러 (Phase 3 auto-curation 판단용)
+  metrics jsonb default '{}'
+);
+
+-- ── gallery_item_media: 1 item → N media 순서 ──
+create table gallery_item_media (
+  id uuid primary key default gen_random_uuid(),
+  item_id uuid references gallery_items(id) on delete cascade,
+  media_id uuid references media(id) on delete restrict,
+  role text default 'gallery' check (role in ('cover', 'gallery', 'detail', 'hero_video')),
+  sort_order integer default 0,
+  created_at timestamptz default now()
+);
+
+-- ── 인덱스 ──
+create index idx_gallery_items_status on gallery_items(status, visibility);
+create index idx_gallery_items_featured on gallery_items(is_featured, featured_rank)
+  where is_featured = true;
+create index idx_gallery_items_kind on gallery_items(kind);
+create index idx_gallery_items_published_at on gallery_items(published_at desc);
+create index idx_gallery_items_tags on gallery_items using gin(tags);
+create index idx_gallery_item_media_item on gallery_item_media(item_id, sort_order);
+
+-- ── updated_at 자동 갱신 트리거 ──
+create or replace function fn_gallery_items_touch_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_gallery_items_updated_at
+  before update on gallery_items
+  for each row execute function fn_gallery_items_touch_updated_at();
+
+-- ── RLS ──
+alter table gallery_items enable row level security;
+alter table gallery_item_media enable row level security;
+
+-- anon: published + public 만 읽기
+create policy "anon read public gallery_items"
+  on gallery_items for select to anon
+  using (status = 'published' and visibility = 'public');
+
+create policy "anon read gallery_item_media of public items"
+  on gallery_item_media for select to anon
+  using (
+    item_id in (
+      select id from gallery_items
+      where status = 'published' and visibility = 'public'
+    )
+  );
+
+-- authenticated: member 이상까지 읽기 (member·public)
+create policy "auth read member+public gallery_items"
+  on gallery_items for select to authenticated
+  using (status = 'published' and visibility in ('member', 'public'));
+
+create policy "auth read gallery_item_media of member+public items"
+  on gallery_item_media for select to authenticated
+  using (
+    item_id in (
+      select id from gallery_items
+      where status = 'published' and visibility in ('member', 'public')
+    )
+  );
+
+-- service_role: 전체 관리 (bypass by default — 명시 정책은 생략)


### PR DESCRIPTION
## Summary
ledger task `t_1fb7b3d` 직격. AWC Web Studio(`/gallery`)가 소비하는 `gallery_items`를 agentic-cms dashboard에서 직접 업로드·큐레이션 가능하게 한다. 이전엔 `scripts/seed-gallery.ts` 1회성만 가능, 운영 진입점이 없었음.

## 백엔드
- **types**: `GalleryItemUpdateInput`, `GalleryMediaRole`, `GalleryItemMedia`, `GalleryMediaAttachInput`, `GalleryMediaReorderInput`
- **CMSAdapter** (8 신규): `getGalleryItem` · `updateGalleryItem` · `deleteGalleryItem` · `listGalleryMedia` · `attachGalleryMedia` · `detachGalleryMedia` · `reorderGalleryMedia` · `setGalleryCover`
- **MCP tools** (6 신규): `update_gallery_item`, `delete_gallery_item`, `list_gallery_media`, `attach_gallery_media`, `detach_gallery_media`, `set_gallery_cover`
- **마이그레이션**: `gallery_items` + `gallery_item_media` + RLS (anon=published+public, auth=member+public)
- **시드**: `scripts/seed-gallery.{ts,manifest.ts}` — `~/Downloads/awc-assets` 1회성 부트스트랩

## Dashboard
- **`/api/gallery/upload`** — multipart, 3 mode (`new` / `attach` / `replace_cover`). Storage upload + media insert + 분기. 실패 시 storage·media row cleanup `Promise.all`.
- **queries**: `getGalleryItemDetail` 단일 nested join 쿼리 (`gallery_items` + cover + `gallery_item_media` + media)
- **actions**: `removeGalleryMedia`, `reorderGalleryMedia` (`Promise.all`), `deleteGalleryItem`
- **`/gallery`** 헤더에 "+ New" 버튼
- **`/gallery/new`** — 파일 + 메타 폼 (title→slug auto kebab, 클라 mime/size 검증, 미리보기)
- **`/gallery/[id]`** 3 섹션 — Meta / Media / Danger Zone
  - **MediaPanel**: Cover 교체 + role별 그룹 (cover·gallery·detail·hero_video) + ↑↓ reorder + 카드 삭제
  - **DangerZone**: item 삭제 (cascade로 link 정리, media row·storage 보존)
- **gallery-constants**: `GALLERY_IMAGE_MAX` 10MB / `GALLERY_VIDEO_MAX` 100MB 공유 상수

## /simplify 적용 (5건)
- 🔴 `reorderGalleryMedia` for-of sequential → `Promise.all` (adapter + dashboard action 2곳)
- 🟠 `IMAGE_MAX`/`VIDEO_MAX` 3곳 중복 → `dashboard/src/lib/gallery-constants.ts` 공유
- 🟠 upload 실패 cleanup sequential → `Promise.all` (2→1 round-trip)
- 🟠 `getGalleryItemDetail` 2 query → 1 nested join (2→1 round-trip)
- 🟡 obvious 주석 정리

## Test plan
- [x] `npm run build` (root MCP TypeScript) PASS
- [x] `npx tsc --noEmit` (dashboard) PASS
- [x] Playwright E2E 11 시나리오 PASS — `/gallery` 진입 → "+ New" → 파일 업로드 + slug 자동 → 등록 → `/gallery/{id}` redirect → 미디어 추가 ×2 (gallery role) → ↑↓ reorder → 카드 삭제 → Cover 교체 → Item 삭제 → `/gallery` 카운트 17 복원
- [x] Console error 0 (favicon.ico 404 제외, 기능 무관)
- [ ] (사용자) AWC Web Studio에서 신규 등록 항목 노출 확인 (`AWC_WEB_REVALIDATE_URL`/`SECRET` env 세팅 후)

## 인프라 / Follow-up
- 마이그레이션 `20260423000000_gallery_items.sql` agentic-cms supabase(`euhxmmiqfyptvsvvbbvp`)에 적용 필요 (`supabase db push --linked`)
- `AWC_WEB_REVALIDATE_URL` / `AWC_WEB_REVALIDATE_SECRET` env 미설정 시 "AWC Web 랜딩 갱신" 버튼은 reason 메시지 반환 (별도 작업)
- 기존 미디어 라이브러리에서 picker로 선택 (이미 업로드된 media row 재사용)는 P1 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)