### PR TITLE
feat(gallery): 다중 카테고리 (kind → kinds[])

### DIFF
--- a/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
@@ -11,13 +11,24 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import type {
   GalleryItemWithCover,
   GalleryCoverAspect,
+  GalleryKind,
 } from "@/lib/types";
 import { updateGalleryMeta } from "../actions";
 
 const ASPECT_OPTIONS: GalleryCoverAspect[] = ["1:1", "16:9", "9:16", "4:5", "3:4"];
+const KIND_OPTIONS: GalleryKind[] = [
+  "landing",
+  "video",
+  "ad",
+  "image",
+  "carousel",
+  "case_study",
+  "other",
+];
 
 export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
   const [pending, startTransition] = useTransition();
@@ -30,9 +41,19 @@ export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
   );
   const [aspect, setAspect] = useState<GalleryCoverAspect>(item.cover_aspect);
   const [tagsInput, setTagsInput] = useState(item.tags.join(", "));
+  const [kinds, setKinds] = useState<GalleryKind[]>(
+    item.kinds && item.kinds.length > 0 ? item.kinds : [item.kind]
+  );
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
+  const toggleKind = (k: GalleryKind) => {
+    setKinds((prev) =>
+      prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]
+    );
+  };
+
   const save = () => {
+    if (kinds.length === 0) return;
     startTransition(async () => {
       await updateGalleryMeta(item.id, {
         title,
@@ -41,6 +62,7 @@ export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
         author: author || null,
         duration_minutes: duration ? Number.parseInt(duration, 10) : null,
         cover_aspect: aspect,
+        kinds,
         tags: tagsInput
           .split(",")
           .map((t) => t.trim())
@@ -93,6 +115,33 @@ export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
             </Select>
           </Field>
         </div>
+        <Field label="Kinds (다중 선택, 첫 번째가 primary ★)">
+          <div className="flex flex-wrap gap-2">
+            {KIND_OPTIONS.map((k) => {
+              const active = kinds.includes(k);
+              const isPrimary = active && kinds[0] === k;
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => toggleKind(k)}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs transition-colors",
+                    active
+                      ? isPrimary
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-primary/40 bg-primary/10 text-foreground"
+                      : "border-border bg-background text-muted-foreground hover:border-primary/50"
+                  )}
+                >
+                  {k}
+                  {isPrimary && <span className="ml-1 opacity-70">★</span>}
+                </button>
+              );
+            })}
+          </div>
+        </Field>
+
         <Field label="Tags (쉼표 구분)">
           <Input
             value={tagsInput}

--- a/dashboard/src/app/(dashboard)/gallery/actions.ts
+++ b/dashboard/src/app/(dashboard)/gallery/actions.ts
@@ -6,6 +6,7 @@ import type {
   GalleryItemStatus,
   GalleryCoverAspect,
   GalleryVisibility,
+  GalleryKind,
 } from "@/lib/types";
 
 // ── status 변경 ─────────────────────────────────────────
@@ -61,7 +62,7 @@ export async function updateGalleryVisibility(id: string, visibility: GalleryVis
   revalidatePath("/gallery");
 }
 
-// ── 메타 편집 (title / subtitle / summary / tags / duration / cover_aspect) ─────────
+// ── 메타 편집 (title / subtitle / summary / tags / duration / cover_aspect / kinds) ─────────
 export interface GalleryMetaPatch {
   title?: string;
   subtitle?: string | null;
@@ -70,6 +71,7 @@ export interface GalleryMetaPatch {
   duration_minutes?: number | null;
   cover_aspect?: GalleryCoverAspect;
   author?: string | null;
+  kinds?: GalleryKind[];
 }
 
 export async function updateGalleryMeta(id: string, patch: GalleryMetaPatch) {

--- a/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
@@ -62,7 +62,8 @@ export function GalleryTable({ items }: { items: GalleryItemWithCover[] }) {
   const [featuredOnly, setFeaturedOnly] = useState(false);
 
   const filtered = items.filter((i) => {
-    if (kindFilter !== "all" && i.kind !== kindFilter) return false;
+    const itemKinds = i.kinds && i.kinds.length > 0 ? i.kinds : [i.kind];
+    if (kindFilter !== "all" && !itemKinds.includes(kindFilter as GalleryKind)) return false;
     if (statusFilter !== "all" && i.status !== statusFilter) return false;
     if (featuredOnly && !i.is_featured) return false;
     return true;
@@ -208,7 +209,13 @@ function GalleryRow({ item }: { item: GalleryItemWithCover }) {
       </td>
 
       <td className="px-3 py-3">
-        <Badge variant={kindVariant(item.kind)}>{item.kind}</Badge>
+        <div className="flex flex-wrap gap-1">
+          {(item.kinds && item.kinds.length > 0 ? item.kinds : [item.kind]).map((k) => (
+            <Badge key={k} variant={kindVariant(k)}>
+              {k}
+            </Badge>
+          ))}
+        </div>
       </td>
 
       <td className="px-3 py-3">

--- a/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import type {
   GalleryKind,
   GalleryCoverAspect,
@@ -54,7 +55,7 @@ export function NewGalleryForm() {
   const [title, setTitle] = useState("");
   const [slug, setSlug] = useState("");
   const [slugTouched, setSlugTouched] = useState(false);
-  const [kind, setKind] = useState<GalleryKind>("image");
+  const [kinds, setKinds] = useState<GalleryKind[]>(["image"]);
   const [coverAspect, setCoverAspect] = useState<GalleryCoverAspect>("16:9");
   const [subtitle, setSubtitle] = useState("");
   const [summary, setSummary] = useState("");
@@ -87,11 +88,20 @@ export function NewGalleryForm() {
     if (previewUrl) URL.revokeObjectURL(previewUrl);
     setPreviewUrl(f ? URL.createObjectURL(f) : null);
     if (f?.type.startsWith("video/")) {
-      setKind((k) => (k === "image" ? "video" : k));
+      setKinds((prev) =>
+        prev.includes("video") ? prev : ["video", ...prev.filter((k) => k !== "image")]
+      );
     }
   };
 
-  const canSubmit = !!file && !sizeOver && title.trim() && slug.trim() && !pending;
+  const toggleKind = (k: GalleryKind) => {
+    setKinds((prev) =>
+      prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]
+    );
+  };
+
+  const canSubmit =
+    !!file && !sizeOver && title.trim() && slug.trim() && kinds.length > 0 && !pending;
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -103,7 +113,7 @@ export function NewGalleryForm() {
     fd.set("mode", "new");
     fd.set("slug", slug.trim());
     fd.set("title", title.trim());
-    fd.set("kind", kind);
+    fd.set("kinds", kinds.join(","));
     fd.set("cover_aspect", coverAspect);
     fd.set("status", status);
     fd.set("visibility", visibility);
@@ -178,21 +188,34 @@ export function NewGalleryForm() {
           </div>
         </Field>
 
-        <div className="grid grid-cols-3 gap-4">
-          <Field label="Kind">
-            <Select value={kind} onValueChange={(v) => setKind(v as GalleryKind)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {KIND_OPTIONS.map((k) => (
-                  <SelectItem key={k} value={k}>
-                    {k}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
+        <Field label="Kinds (다중 선택, 첫 번째가 primary ★)">
+          <div className="flex flex-wrap gap-2">
+            {KIND_OPTIONS.map((k) => {
+              const active = kinds.includes(k);
+              const isPrimary = active && kinds[0] === k;
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => toggleKind(k)}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs transition-colors",
+                    active
+                      ? isPrimary
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-primary/40 bg-primary/10 text-foreground"
+                      : "border-border bg-background text-muted-foreground hover:border-primary/50"
+                  )}
+                >
+                  {k}
+                  {isPrimary && <span className="ml-1 opacity-70">★</span>}
+                </button>
+              );
+            })}
+          </div>
+        </Field>
+
+        <div className="grid grid-cols-2 gap-4">
           <Field label="Cover Aspect">
             <Select value={coverAspect} onValueChange={(v) => setCoverAspect(v as GalleryCoverAspect)}>
               <SelectTrigger>

--- a/dashboard/src/app/api/gallery/upload/route.ts
+++ b/dashboard/src/app/api/gallery/upload/route.ts
@@ -75,7 +75,12 @@ export async function POST(req: Request) {
     if (mode === "new") {
       const slug = (fd.get("slug") as string | null)?.trim();
       const title = (fd.get("title") as string | null)?.trim();
-      const kind = (fd.get("kind") as string | null) ?? "image";
+      const kindsRaw =
+        (fd.get("kinds") as string | null) ?? (fd.get("kind") as string | null) ?? "image";
+      const kinds = kindsRaw
+        .split(",")
+        .map((k) => k.trim())
+        .filter(Boolean);
 
       if (!slug) return NextResponse.json({ error: "slug required" }, { status: 400 });
       if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
@@ -85,8 +90,12 @@ export async function POST(req: Request) {
         );
       }
       if (!title) return NextResponse.json({ error: "title required" }, { status: 400 });
-      if (!ALLOWED_KINDS.has(kind)) {
-        return NextResponse.json({ error: `invalid kind: ${kind}` }, { status: 400 });
+      if (kinds.length === 0) {
+        return NextResponse.json({ error: "kinds required (at least one)" }, { status: 400 });
+      }
+      const invalidKind = kinds.find((k) => !ALLOWED_KINDS.has(k));
+      if (invalidKind) {
+        return NextResponse.json({ error: `invalid kind: ${invalidKind}` }, { status: 400 });
       }
       slugForPath = slug;
       role = "cover";
@@ -176,7 +185,12 @@ export async function POST(req: Request) {
     if (mode === "new") {
       const slug = fd.get("slug") as string;
       const title = fd.get("title") as string;
-      const kind = (fd.get("kind") as string) ?? "image";
+      const kindsRaw =
+        (fd.get("kinds") as string | null) ?? (fd.get("kind") as string | null) ?? "image";
+      const kinds = kindsRaw
+        .split(",")
+        .map((k) => k.trim())
+        .filter(Boolean);
       const subtitle = (fd.get("subtitle") as string | null) || null;
       const summary = (fd.get("summary") as string | null) || null;
       const author = (fd.get("author") as string | null) || null;
@@ -204,7 +218,7 @@ export async function POST(req: Request) {
           title,
           subtitle,
           summary,
-          kind,
+          kinds,
           cover_media_id: mediaId,
           cover_aspect,
           status,

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -223,6 +223,7 @@ export interface GalleryItem {
   subtitle: string | null;
   summary: string | null;
   kind: GalleryKind;
+  kinds: GalleryKind[];
   source_table: string | null;
   source_id: string | null;
   cover_media_id: string | null;

--- a/src/adapters/supabase.ts
+++ b/src/adapters/supabase.ts
@@ -551,7 +551,7 @@ export class SupabaseAdapter implements CMSAdapter {
     let q = this.client.from('gallery_items').select('*');
 
     if (filter.status) q = q.eq('status', filter.status);
-    if (filter.kind) q = q.eq('kind', filter.kind);
+    if (filter.kinds && filter.kinds.length > 0) q = q.overlaps('kinds', filter.kinds);
     if (typeof filter.is_featured === 'boolean') q = q.eq('is_featured', filter.is_featured);
     if (filter.visibility) q = q.eq('visibility', filter.visibility);
 

--- a/src/tools/gallery.ts
+++ b/src/tools/gallery.ts
@@ -24,10 +24,10 @@ export function registerGalleryTools(server: McpServer, adapter: CMSAdapter): vo
   // 1. list_gallery_items
   server.tool(
     'list_gallery_items',
-    'List AWC Gallery items. Filter by status/kind/featured/visibility. Ordered by featured first, featured_rank asc, then published_at desc.',
+    'List AWC Gallery items. Filter by status/kinds/featured/visibility. kinds is OR-match (any overlap). Ordered by featured first, featured_rank asc, then published_at desc.',
     {
       status: STATUS.optional().describe("Lifecycle status filter (default: no filter)"),
-      kind: KIND.optional().describe('Kind filter'),
+      kinds: z.array(KIND).optional().describe('Kinds filter — items with ANY of these kinds match'),
       is_featured: z.boolean().optional().describe('Featured flag filter'),
       visibility: VISIBILITY.optional().describe('Visibility filter'),
       limit: z.number().min(1).max(100).optional().describe('Max results (default 50)'),
@@ -46,13 +46,13 @@ export function registerGalleryTools(server: McpServer, adapter: CMSAdapter): vo
   // 2. create_gallery_item
   server.tool(
     'create_gallery_item',
-    'Create a Gallery item (default status=draft, visibility=public). Use set_gallery_featured afterwards to pin to the landing carousel.',
+    'Create a Gallery item with one or more kinds (kinds[0] is the primary). Default status=draft, visibility=public. Use set_gallery_featured afterwards to pin to the landing carousel.',
     {
       slug: z.string().min(1).describe('Unique slug (/gallery/item/:slug)'),
       title: z.string().min(1),
       subtitle: z.string().optional(),
       summary: z.string().optional(),
-      kind: KIND,
+      kinds: z.array(KIND).min(1).describe('Categories — first one is the primary. e.g. ["video","ad"] for a brand film.'),
       cover_media_id: z.string().uuid().optional().describe('FK media.id for cover'),
       cover_aspect: ASPECT.optional().describe("Cover aspect hint (default '16:9')"),
       status: STATUS.optional().describe("Lifecycle status (default 'draft')"),
@@ -96,13 +96,13 @@ export function registerGalleryTools(server: McpServer, adapter: CMSAdapter): vo
   // 4. update_gallery_item — meta + status/visibility 통합 patch
   server.tool(
     'update_gallery_item',
-    'Patch a Gallery item. Any subset of: title, subtitle, summary, kind, status, visibility, cover_aspect, tags, author, duration_minutes, is_featured, featured_rank, cover_media_id. published_at/featured_at are auto-set when status flips to published or is_featured flips to true.',
+    'Patch a Gallery item. Any subset of: title, subtitle, summary, kinds, status, visibility, cover_aspect, tags, author, duration_minutes, is_featured, featured_rank, cover_media_id. kinds[0] is treated as primary. published_at/featured_at are auto-set when status flips to published or is_featured flips to true.',
     {
       id: z.string().uuid(),
       title: z.string().min(1).optional(),
       subtitle: z.string().nullable().optional(),
       summary: z.string().nullable().optional(),
-      kind: KIND.optional(),
+      kinds: z.array(KIND).min(1).optional(),
       cover_media_id: z.string().uuid().nullable().optional(),
       cover_aspect: ASPECT.optional(),
       status: STATUS.optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,6 +264,7 @@ export interface GalleryItem {
   subtitle?: string | null;
   summary?: string | null;
   kind: GalleryKind;
+  kinds: GalleryKind[];
   source_table?: string | null;
   source_id?: string | null;
   cover_media_id?: string | null;
@@ -289,7 +290,7 @@ export interface GalleryItemCreateInput {
   title: string;
   subtitle?: string;
   summary?: string;
-  kind: GalleryKind;
+  kinds: GalleryKind[];
   source_table?: string;
   source_id?: string;
   cover_media_id?: string;
@@ -307,7 +308,7 @@ export interface GalleryItemCreateInput {
 
 export interface GalleryItemFilter {
   status?: GalleryStatus;
-  kind?: GalleryKind;
+  kinds?: GalleryKind[];
   is_featured?: boolean;
   visibility?: GalleryVisibility;
   limit?: number;
@@ -324,7 +325,7 @@ export interface GalleryItemUpdateInput {
   title?: string;
   subtitle?: string | null;
   summary?: string | null;
-  kind?: GalleryKind;
+  kinds?: GalleryKind[];
   cover_media_id?: string | null;
   cover_aspect?: GalleryCoverAspect;
   status?: GalleryStatus;

--- a/supabase/migrations/20260424000000_gallery_kinds.sql
+++ b/supabase/migrations/20260424000000_gallery_kinds.sql
@@ -1,0 +1,54 @@
+-- AWC Gallery — 다중 카테고리 지원 (kind 단일 → kinds text[])
+-- 사용자 요구: 한 콘텐츠가 여러 kind 탭 (영상/광고/이미지/랜딩 등)에 동시 노출.
+--
+-- 호환성 전략: 기존 `kind` 컬럼 유지 + 신규 `kinds text[]` 추가 + 양방향 트리거.
+--   - 구코드 (`SELECT kind`, `WHERE kind=...`) 그대로 작동
+--   - 신코드 (`SELECT kinds`, `WHERE kinds @> ARRAY[...]`) 작동
+--   - kind = kinds[1] (primary), 둘 중 하나만 변경해도 다른 쪽 자동 sync
+--
+-- 이 트리거는 cleanup 마이그레이션 (kind 컬럼 삭제) 시점에 함께 제거.
+
+-- 1) kinds 컬럼 추가 + 기존 데이터 백필
+alter table gallery_items add column kinds text[] default '{}';
+update gallery_items set kinds = ARRAY[kind] where cardinality(kinds) = 0;
+alter table gallery_items alter column kinds set not null;
+
+-- 2) 각 원소가 enum 안에 있는지 검증
+alter table gallery_items add constraint gallery_items_kinds_valid check (
+  cardinality(kinds) >= 1
+  and kinds <@ ARRAY['landing','video','ad','image','carousel','case_study','other']::text[]
+);
+
+-- 3) GIN 인덱스 — 다중 kind 필터(`@>`, `&&`) 지원
+create index idx_gallery_items_kinds on gallery_items using gin(kinds);
+
+-- 4) 양방향 동기화 트리거
+--   - kind 만 변경 → kinds[1] = 새 kind (기존 kinds 보존하지 않고 단일로 reset)
+--   - kinds 만 변경 → kind = kinds[1]
+--   - 둘 다 변경 → kinds 우선 적용
+--   - INSERT 시 kinds 비어있으면 ARRAY[kind] 로 초기화
+create or replace function fn_gallery_kinds_sync()
+returns trigger as $$
+begin
+  if TG_OP = 'INSERT' then
+    if NEW.kinds is null or cardinality(NEW.kinds) = 0 then
+      NEW.kinds := ARRAY[NEW.kind];
+    else
+      NEW.kind := NEW.kinds[1];
+    end if;
+    return NEW;
+  end if;
+
+  -- UPDATE: 무엇이 바뀌었는지로 우선순위 결정
+  if NEW.kinds is distinct from OLD.kinds then
+    NEW.kind := NEW.kinds[1];
+  elsif NEW.kind is distinct from OLD.kind then
+    NEW.kinds := ARRAY[NEW.kind];
+  end if;
+  return NEW;
+end;
+$$ language plpgsql;
+
+create trigger trg_gallery_kinds_sync
+  before insert or update on gallery_items
+  for each row execute function fn_gallery_kinds_sync();


### PR DESCRIPTION
## Summary
한 콘텐츠가 여러 kind 탭(영상/광고/이미지/랜딩 등)에 동시 노출되도록 `kind text` 단일 → `kinds text[]` 다중 카테고리로 확장. 랜딩 hero 영상 = video + landing, 광고 영상 = video + ad 처럼 콘텐츠 본질을 다중 분류로 표현.

## Migration (backward-compat)
- `gallery_items.kinds text[]` 컬럼 추가, `ARRAY[kind]` 백필
- enum CHECK 제약, GIN 인덱스
- 양방향 동기화 트리거: `kind ⇆ kinds[1]` (primary alias)
- 기존 코드(`SELECT kind`, `WHERE kind=`) 그대로 작동
- AWC Web([brxce.ai PR](https://github.com/intellieffect/brxce.ai/pulls)) 배포와 어느 순서로 머지해도 안전

## Backend (types/adapter/MCP)
- `GalleryItem.kinds` 추가 (`kind`는 primary alias로 유지)
- Filter `.kind` → `.kinds` (any-overlap, OR-match)
- Adapter `listGalleryItems`: `.eq("kind")` → `.overlaps("kinds")`
- MCP `create_gallery_item` / `update_gallery_item`: `kinds` 배열 receive

## Dashboard UI
- `/gallery` 테이블: 다중 badge 표시, 필터 any-match
- `/gallery/new` + `/[id]` meta-form: chip toggle (첫 번째 ★ = primary)
- `/api/gallery/upload`: comma-separated `kinds` 받음 (`kind` 단일도 호환)

## 데이터 큐레이션 (36개)
| 추가 매핑 | 콘텐츠 |
|---|---|
| video → +landing | prism/mulae/parallel/vespr (랜딩 hero) |
| video → +ad | miumiu-spring / wukong (광고 영상) |
| case_study → +landing | awc-landing-full |
| ad → +image | 18개 광고 정지컷 |
| image → +ad | porsche 911 night / rainy |
| image → +case_study | penthouse 2장 |

**분포**: image 25 · ad 22 · landing 9 · video 6 · case_study 3 (총 36 콘텐츠 = 65 노출)

## Test plan
- [x] DB migration: `gallery_items.kinds` 백필 확인 (모든 row `[kind]` 초기값)
- [x] 트리거: `UPDATE kinds = ARRAY['ad','image']` → `kind = 'ad'` 자동 sync 확인
- [x] `npm run build` (root MCP TypeScript) PASS
- [x] `npx tsc --noEmit` (dashboard) PASS
- [x] dashboard `/gallery`, `/gallery/new` HTTP 200
- [ ] (사용자) brxce.ai web에서 `/gallery/landing` 탭에 영상 4장 + awc-landing 함께 노출 확인 (cache 5분 TTL 후 또는 수동 revalidate)

## Cleanup follow-up
이 PR은 backward-compat 유지를 위해 `kind` 컬럼 + 동기화 트리거 보존. 양쪽 코드가 `kinds`로 완전 마이그레이션된 후 (몇 주 후) cleanup PR로:
- `kind` 컬럼 삭제
- `fn_gallery_kinds_sync` 트리거 + 함수 제거
- `idx_gallery_items_kind` 인덱스 제거 (`idx_gallery_items_kinds` GIN만 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)