### PR TITLE
feat(gallery): ai_influencer kind 추가

### DIFF
--- a/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
@@ -27,6 +27,7 @@ const KIND_OPTIONS: GalleryKind[] = [
   "image",
   "carousel",
   "case_study",
+  "ai_influencer",
   "other",
 ];
 

--- a/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
@@ -38,6 +38,7 @@ const KIND_FILTER: (GalleryKind | "all")[] = [
   "image",
   "carousel",
   "case_study",
+  "ai_influencer",
   "other",
 ];
 const VISIBILITY_OPTIONS: GalleryVisibility[] = ["public", "member", "internal"];
@@ -47,6 +48,7 @@ function kindVariant(kind: GalleryKind) {
   if (kind === "landing") return "warning" as const;
   if (kind === "ad") return "success" as const;
   if (kind === "case_study") return "info" as const;
+  if (kind === "ai_influencer") return "info" as const;
   return "secondary" as const;
 }
 

--- a/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
@@ -28,6 +28,7 @@ const KIND_OPTIONS: GalleryKind[] = [
   "image",
   "carousel",
   "case_study",
+  "ai_influencer",
   "other",
 ];
 const ASPECT_OPTIONS: GalleryCoverAspect[] = ["1:1", "16:9", "9:16", "4:5", "3:4"];

--- a/dashboard/src/app/api/gallery/upload/route.ts
+++ b/dashboard/src/app/api/gallery/upload/route.ts
@@ -15,6 +15,7 @@ const ALLOWED_KINDS = new Set([
   "image",
   "carousel",
   "case_study",
+  "ai_influencer",
   "other",
 ]);
 const ALLOWED_ASPECTS = new Set(["1:1", "16:9", "9:16", "4:5", "3:4"]);

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -208,6 +208,7 @@ export type GalleryKind =
   | 'image'
   | 'carousel'
   | 'case_study'
+  | 'ai_influencer'
   | 'other';
 
 export type GalleryCoverAspect = '1:1' | '16:9' | '9:16' | '4:5' | '3:4';

--- a/src/tools/gallery.ts
+++ b/src/tools/gallery.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CMSAdapter } from '../adapters/interface.js';
 
-const KIND = z.enum(['landing', 'video', 'ad', 'image', 'carousel', 'case_study', 'other']);
+const KIND = z.enum(['landing', 'video', 'ad', 'image', 'carousel', 'case_study', 'ai_influencer', 'other']);
 const ASPECT = z.enum(['1:1', '16:9', '9:16', '4:5', '3:4']);
 const STATUS = z.enum(['draft', 'published', 'archived']);
 const VISIBILITY = z.enum(['internal', 'member', 'public']);

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,7 @@ export type GalleryKind =
   | 'image'
   | 'carousel'
   | 'case_study'
+  | 'ai_influencer'
   | 'other';
 
 export type GalleryCoverAspect = '1:1' | '16:9' | '9:16' | '4:5' | '3:4';

--- a/supabase/migrations/20260425000000_gallery_ai_influencer_kind.sql
+++ b/supabase/migrations/20260425000000_gallery_ai_influencer_kind.sql
@@ -1,0 +1,21 @@
+-- Add 'ai_influencer' to gallery_items kind/kinds CHECK constraints.
+-- Backward-compat: 기존 row·코드 영향 없음 (enum 확장만).
+-- 쌍 PR(brxce.ai) 과 순서 무관 — kind 확장은 AWC Web 쪽 코드 변경 없이도 안전.
+
+ALTER TABLE gallery_items DROP CONSTRAINT IF EXISTS gallery_items_kind_check;
+ALTER TABLE gallery_items DROP CONSTRAINT IF EXISTS gallery_items_kinds_valid;
+
+ALTER TABLE gallery_items
+  ADD CONSTRAINT gallery_items_kind_check
+    CHECK (kind = ANY (ARRAY[
+      'landing', 'video', 'ad', 'image', 'carousel', 'case_study', 'other', 'ai_influencer'
+    ]::text[]));
+
+ALTER TABLE gallery_items
+  ADD CONSTRAINT gallery_items_kinds_valid
+    CHECK (
+      cardinality(kinds) >= 1
+      AND kinds <@ ARRAY[
+        'landing', 'video', 'ad', 'image', 'carousel', 'case_study', 'other', 'ai_influencer'
+      ]::text[]
+    );


### PR DESCRIPTION
## Summary

Gallery `kind` enum에 `ai_influencer` 추가 — AI로 생성된 가상 인물이 중심인 콘텐츠를 별도 카테고리로 분리.

## Changes

**DB migration** (`20260425000000_gallery_ai_influencer_kind.sql`)
- `gallery_items_kind_check` + `gallery_items_kinds_valid` CHECK 제약 재정의
- 기존 row 영향 없음 (enum 확장만)
- prod 이미 `apply_migration` MCP로 적용 완료

**agentic-cms 코드 (6 files)**
- `src/types.ts` — `GalleryKind` 타입 확장
- `src/tools/gallery.ts` — MCP zod enum 확장
- `dashboard/src/lib/types.ts` — Dashboard 타입 확장
- `dashboard/src/app/api/gallery/upload/route.ts` — `ALLOWED_KINDS` set
- `dashboard/src/app/(dashboard)/gallery/new/new-form.tsx` — `KIND_OPTIONS`
- `dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx` — `KIND_OPTIONS`
- `dashboard/src/app/(dashboard)/gallery/gallery-table.tsx` — `KIND_FILTER` + badge variant

**데이터 큐레이션 (17건, 별도 SQL 적용)**
- 신규: `ai-influencer-persona-urban-mature-kr` — primary = `ai_influencer`
- 기존 16건: 인물 등장 뷰티·패션 광고·셀피·라이프스타일 — `kinds[]`에 `ai_influencer` append
  - ISOI (3), numbuzin (2), Miu Miu (4), Mediheal, AESTURA, dermuno (2), beige-coat, streetwear, numbus, miumiu-spring-edition

## 쌍 PR
- [brxce.ai#TBD](https://github.com/intellieffect/awc) — `/gallery/ai-influencer` URL 탭 + `GALLERY_KINDS` 리스트 확장

## Test plan
- [ ] Dashboard `/gallery` 테이블 필터에 `ai_influencer` 옵션 노출
- [ ] Dashboard `/gallery/[id]` chip toggle에 신규 kind 선택 가능
- [ ] MCP `create_gallery_item({ kinds: ["ai_influencer"] })` 통과 (zod + DB CHECK)
- [ ] AWC Web PR 머지 후 `/gallery/ai-influencer` 탭 노출 + 17건 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)