### PR TITLE
refactor(gallery): KIND/ASPECT 상수 SSOT 통합

### DIFF
--- a/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
@@ -17,19 +17,11 @@ import type {
   GalleryCoverAspect,
   GalleryKind,
 } from "@/lib/types";
+import {
+  GALLERY_KINDS as KIND_OPTIONS,
+  GALLERY_COVER_ASPECTS as ASPECT_OPTIONS,
+} from "@/lib/gallery-constants";
 import { updateGalleryMeta } from "../actions";
-
-const ASPECT_OPTIONS: GalleryCoverAspect[] = ["1:1", "16:9", "9:16", "4:5", "3:4"];
-const KIND_OPTIONS: GalleryKind[] = [
-  "landing",
-  "video",
-  "ad",
-  "image",
-  "carousel",
-  "case_study",
-  "ai_influencer",
-  "other",
-];
 
 export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
   const [pending, startTransition] = useTransition();

--- a/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
@@ -21,6 +21,7 @@ import type {
   GalleryKind,
   GalleryVisibility,
 } from "@/lib/types";
+import { GALLERY_KIND_FILTERS as KIND_FILTER } from "@/lib/gallery-constants";
 import {
   setGalleryFeatured,
   updateGalleryRank,
@@ -30,17 +31,6 @@ import {
 } from "./actions";
 
 const STATUS_OPTIONS: GalleryItemStatus[] = ["draft", "published", "archived"];
-const KIND_FILTER: (GalleryKind | "all")[] = [
-  "all",
-  "landing",
-  "video",
-  "ad",
-  "image",
-  "carousel",
-  "case_study",
-  "ai_influencer",
-  "other",
-];
 const VISIBILITY_OPTIONS: GalleryVisibility[] = ["public", "member", "internal"];
 
 function kindVariant(kind: GalleryKind) {

--- a/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
@@ -19,19 +19,13 @@ import type {
   GalleryItemStatus,
   GalleryVisibility,
 } from "@/lib/types";
-import { GALLERY_IMAGE_MAX, GALLERY_VIDEO_MAX } from "@/lib/gallery-constants";
+import {
+  GALLERY_IMAGE_MAX,
+  GALLERY_VIDEO_MAX,
+  GALLERY_KINDS as KIND_OPTIONS,
+  GALLERY_COVER_ASPECTS as ASPECT_OPTIONS,
+} from "@/lib/gallery-constants";
 
-const KIND_OPTIONS: GalleryKind[] = [
-  "landing",
-  "video",
-  "ad",
-  "image",
-  "carousel",
-  "case_study",
-  "ai_influencer",
-  "other",
-];
-const ASPECT_OPTIONS: GalleryCoverAspect[] = ["1:1", "16:9", "9:16", "4:5", "3:4"];
 const STATUS_OPTIONS: GalleryItemStatus[] = ["draft", "published", "archived"];
 const VISIBILITY_OPTIONS: GalleryVisibility[] = ["public", "member", "internal"];
 

--- a/dashboard/src/app/api/gallery/upload/route.ts
+++ b/dashboard/src/app/api/gallery/upload/route.ts
@@ -1,24 +1,18 @@
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { getSupabase } from "@/lib/supabase";
-import { GALLERY_IMAGE_MAX, GALLERY_VIDEO_MAX } from "@/lib/gallery-constants";
+import {
+  GALLERY_IMAGE_MAX,
+  GALLERY_VIDEO_MAX,
+  ALLOWED_GALLERY_KINDS as ALLOWED_KINDS,
+  ALLOWED_GALLERY_ASPECTS as ALLOWED_ASPECTS,
+} from "@/lib/gallery-constants";
 
 const BUCKET = "content-media";
 
 type Mode = "new" | "attach" | "replace_cover";
 type Role = "cover" | "gallery" | "detail" | "hero_video";
 
-const ALLOWED_KINDS = new Set([
-  "landing",
-  "video",
-  "ad",
-  "image",
-  "carousel",
-  "case_study",
-  "ai_influencer",
-  "other",
-]);
-const ALLOWED_ASPECTS = new Set(["1:1", "16:9", "9:16", "4:5", "3:4"]);
 const ALLOWED_ROLES = new Set<Role>(["cover", "gallery", "detail", "hero_video"]);
 
 function safeName(name: string): string {

--- a/dashboard/src/lib/gallery-constants.ts
+++ b/dashboard/src/lib/gallery-constants.ts
@@ -1,2 +1,32 @@
+import type { GalleryKind, GalleryCoverAspect } from "./types";
+
 export const GALLERY_IMAGE_MAX = 10 * 1024 * 1024;
 export const GALLERY_VIDEO_MAX = 100 * 1024 * 1024;
+
+export const GALLERY_KINDS: readonly GalleryKind[] = [
+  "landing",
+  "video",
+  "ad",
+  "image",
+  "carousel",
+  "case_study",
+  "ai_influencer",
+  "other",
+] as const;
+
+export const GALLERY_KIND_FILTERS: readonly (GalleryKind | "all")[] = [
+  "all",
+  ...GALLERY_KINDS,
+] as const;
+
+export const ALLOWED_GALLERY_KINDS = new Set<string>(GALLERY_KINDS);
+
+export const GALLERY_COVER_ASPECTS: readonly GalleryCoverAspect[] = [
+  "1:1",
+  "16:9",
+  "9:16",
+  "4:5",
+  "3:4",
+] as const;
+
+export const ALLOWED_GALLERY_ASPECTS = new Set<string>(GALLERY_COVER_ASPECTS);


### PR DESCRIPTION
## Summary

PR #47 (`feat(gallery): ai_influencer kind 추가`) 후속 simplify. 같은 enum 리스트가 4 파일에 하드코딩돼 있던 sync points 7개를 `dashboard/src/lib/gallery-constants.ts` 1곳으로 통합. 다음 enum 추가 시 한 줄만 고치면 됨.

## Changes

**dashboard/src/lib/gallery-constants.ts** (신규 export 5종)
- \`GALLERY_KINDS\` — readonly 8개 enum 배열
- \`GALLERY_KIND_FILTERS\` — \`["all", ...GALLERY_KINDS]\`
- \`ALLOWED_GALLERY_KINDS\` — Set\<string\>
- \`GALLERY_COVER_ASPECTS\` — readonly 5개 aspect 배열
- \`ALLOWED_GALLERY_ASPECTS\` — Set\<string\>

**4 사용처 import alias 적용**
- \`new-form.tsx\` — KIND_OPTIONS + ASPECT_OPTIONS
- \`meta-form.tsx\` — KIND_OPTIONS + ASPECT_OPTIONS
- \`gallery-table.tsx\` — KIND_FILTER
- \`api/gallery/upload/route.ts\` — ALLOWED_KINDS + ALLOWED_ASPECTS

## 영향
- 런타임 동작 변경 없음 (값·순서 동일)
- net diff +47 / -47 = 0 LOC
- \`tsc --noEmit\` pass

## /simplify 출처
- Code-reuse agent finding: KIND_OPTIONS / KIND_FILTER / ALLOWED_KINDS 4곳 중복 (MEDIUM)
- 다른 finding(주석 거짓·kindVariant 동일 variant·SQL CHECK 반복) 은 SKIP — 이유는 simplify 점검 보고서 참조

## Test plan
- [ ] Dashboard \`/gallery\` 진입 — KIND_FILTER 탭 동일 동작
- [ ] \`/gallery/new\` upload — KIND chip toggle 동일 동작
- [ ] \`/gallery/[id]\` meta-form — KIND/ASPECT select 동일 동작
- [ ] POST /api/gallery/upload — kind/aspect validation 동일 (invalid 값 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)