### PR TITLE
fix(blog-manage): 상세 페이지 썸네일·편집 영역 본문 폭 정렬

### DIFF
--- a/dashboard/src/app/(dashboard)/blog-manage/[id]/page.tsx
+++ b/dashboard/src/app/(dashboard)/blog-manage/[id]/page.tsx
@@ -599,7 +599,7 @@ export default function BlogDetailPage() {
       <hr className="border-[#222] mb-8" />
 
       {/* Thumbnail */}
-      <div className="mb-8">
+      <div className="mb-8 mx-auto max-w-2xl">
         <h3 className="text-sm font-medium text-[#888] mb-3">썸네일</h3>
         <input
           ref={fileInputRef}
@@ -643,7 +643,7 @@ export default function BlogDetailPage() {
         />
         {post.thumbnail_url ? (
           <div>
-            <div className="relative aspect-[16/9] max-w-md rounded-lg overflow-hidden bg-[#111]">
+            <div className="relative aspect-[16/9] w-full rounded-lg overflow-hidden bg-[#111]">
               <Image
                 src={post.thumbnail_url}
                 alt="썸네일"
@@ -687,7 +687,7 @@ export default function BlogDetailPage() {
         ) : (
           <button
             type="button"
-            className="w-full max-w-md aspect-[16/9] rounded-lg border border-dashed border-[#333] bg-[#111] hover:border-[#555] transition-colors flex items-center justify-center cursor-pointer"
+            className="w-full aspect-[16/9] rounded-lg border border-dashed border-[#333] bg-[#111] hover:border-[#555] transition-colors flex items-center justify-center cursor-pointer"
             onClick={() => fileInputRef.current?.click()}
             disabled={uploading}
           >
@@ -707,7 +707,7 @@ export default function BlogDetailPage() {
           onCancel={() => setEditMode(false)}
         />
       ) : (
-        <div>
+        <div className="mx-auto max-w-2xl">
           <div className="flex justify-end mb-4">
             <Button variant="outline" size="sm" onClick={() => setEditMode(true)}>
               편집


### PR DESCRIPTION
## Summary

`/blog-manage/[id]` 상세 페이지에서 썸네일 섹션과 편집 버튼이 본문(`PlatePreview` `max-w-2xl`)보다 좌/우로 벌어져 시각적 misalignment 발생. 두 wrapper를 본문과 동일한 `mx-auto max-w-2xl` 폭으로 맞춤.

## Changes (`dashboard/src/app/(dashboard)/blog-manage/[id]/page.tsx`)

- 썸네일 wrapper: `mb-8` → `mb-8 mx-auto max-w-2xl`
- 썸네일 이미지 컨테이너: `max-w-md`(448px) → `w-full` (부모 폭 가득)
- 썸네일 placeholder dashed 박스: `w-full max-w-md` → `w-full`
- 편집 버튼 + PlatePreview wrapper: `<div>` → `<div className="mx-auto max-w-2xl">`

## Test plan
- [ ] `/blog-manage/{id}` 진입 — 썸네일·변경/삭제·편집 버튼·본문이 동일한 좌/우 가장자리(672px wrapper)에 정렬
- [ ] 썸네일 이미지 비율 16:9 유지 + ultrawide 모니터에서도 본문 폭 안에 정렬
- [ ] 헤더(제목/뉴스레터/게시/삭제 액션)는 의도적 full-width 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)