### PR TITLE
fix(dashboard): editor best-practice 이식 + Timeline 폴링 루프 fix + 재발 방지 가이드

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,20 @@
 
 ## 구조
 - `src/` — MCP 서버 (TypeScript ESM)
-- `dashboard/` — Next.js 15 + Tailwind 4 + shadcn/ui 대시보드
-- `editor/` — Python FastAPI 영상 편집 서버 (2026-04-18 brxce-editor 이식). 포트 8092. dashboard 가 iframe/proxy 로 임베드.
+- `dashboard/` — Next.js 15 + Tailwind 4 + shadcn/ui 대시보드 — **영상 편집기 UI도 여기 있음** (`dashboard/src/components/{studio,remotion}/`)
+- `editor/` — Python FastAPI 영상 편집 서버 (포트 8092) + Remotion server-side render bundle (`editor/remotion/src/`).
+  - **주의**: `editor/components/`, `editor/app/`, `editor/lib/` 는 dashboard로 fully ported된 후 historical reference로 보존. **dashboard 영상 편집기 변경은 절대 `editor/`가 아닌 `dashboard/src/components/...`에 적용**할 것 ([editor/DEPRECATED.md](./editor/DEPRECATED.md) 참조).
 - `supabase/` — DB 마이그레이션
 - `reference/` — Payload·Strapi·Directus·shadcn-admin 클론 (.gitignore)
+
+### 영상 편집기 변경 어디에 해야 하나? (가장 자주 헷갈리는 포인트)
+
+| 변경 영역 | 수정 위치 | 사용자가 보는 곳 |
+|---|---|---|
+| Player preview (Studio UI, Timeline, RemotionPreview, Panels 등) | `dashboard/src/components/studio/`, `dashboard/src/components/remotion/` | http://localhost:3000 (운영) |
+| Server-side Remotion render | `editor/remotion/src/` | render 시 ffmpeg 통해 mp4 생성 |
+| Python proxy/render API | `editor/src/server/` | port 8092 |
+| editor sub-app standalone (port 3100) | `editor/components/...` | 개별 테스트만, 운영 외 — **편집하지 말 것** |
 
 ## 기술 스택
 - MCP 서버: TypeScript, ESM, Supabase adapter

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -3,6 +3,13 @@ import path from "node:path";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Strict Mode causes the Player tree to mount → unmount → mount in dev,
+  // which double-invokes every <Video> element's fetch and shows up as
+  // (canceled) + 2x success per clip in DevTools. HTML5 <video> is an
+  // external resource (not React-managed), so Strict Mode's protection
+  // brings no benefit here while doubling network noise during media editing.
+  // Production builds are unaffected (Strict Mode is dev-only behavior).
+  reactStrictMode: false,
   // repo 루트에도 package-lock.json(MCP server 용)이 있어, Next.js 가 workspace root 를
   // dashboard 가 아니라 repo 루트로 잘못 추론해 webpack module resolution 이 깨지는 문제가
   // CI 에서 발견됨("Cannot read properties of undefined (reading 'call')").

--- a/dashboard/public/fonts
+++ b/dashboard/public/fonts
@@ -1,0 +1,1 @@
+../../editor/assets/fonts

--- a/dashboard/src/components/remotion/AnimatedSubtitle.tsx
+++ b/dashboard/src/components/remotion/AnimatedSubtitle.tsx
@@ -86,12 +86,13 @@ const WordHighlightRenderer: React.FC<{
     >
       {words.map((word, i) => {
         const isActive = i === activeIdx;
+        // No CSS transition — Remotion renders frames independently;
+        // transitions are non-deterministic and would flicker in render.
         return (
           <span
             key={i}
             style={{
               color: isActive ? highlightColor : color,
-              transition: "color 0.1s",
               fontWeight: isActive ? 800 : "inherit",
             }}
           >
@@ -183,10 +184,12 @@ const WordBoxMoveRenderer: React.FC<{
   const containerRef = React.useRef<HTMLSpanElement>(null);
   const wordRefs = React.useRef<(HTMLSpanElement | null)[]>([]);
 
-  // Measure active word position
+  // Measure active word position. Use useLayoutEffect so measurement completes
+  // before browser paints — required for Remotion render: each frame must paint
+  // with the correct box position, never with a one-frame stale value.
   const [boxStyle, setBoxStyle] = React.useState<React.CSSProperties>({});
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const activeEl = wordRefs.current[activeIdx];
     const container = containerRef.current;
     if (!activeEl || !container) return;
@@ -199,6 +202,13 @@ const WordBoxMoveRenderer: React.FC<{
       height: wRect.height + 4 * scale,
     });
   }, [activeIdx, scale]);
+
+  // Smooth box arrival driven by Remotion's frame, not CSS transition (which is
+  // non-deterministic across render workers). Subtle scale pop-in via interpolate.
+  const localFrame = activeIdx >= 0 ? frame % Math.max(1, Math.round(fps * 0.4)) : 0;
+  const arriveScale = activeIdx >= 0
+    ? interpolate(localFrame, [0, 4], [0.94, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+    : 1;
 
   return (
     <span
@@ -216,13 +226,15 @@ const WordBoxMoveRenderer: React.FC<{
           : {}),
       }}
     >
-      {/* Animated background box */}
+      {/* Box snaps to active-word position each frame (deterministic);
+          subtle pop-in via interpolate keeps it lively without CSS transition. */}
       <span
         style={{
           position: "absolute",
           backgroundColor: highlightColor,
           borderRadius: `${6 * scale}px`,
-          transition: "all 0.15s cubic-bezier(0.34, 1.56, 0.64, 1)",
+          transform: `scale(${arriveScale})`,
+          transformOrigin: "center center",
           zIndex: 0,
           ...boxStyle,
         }}

--- a/dashboard/src/components/remotion/BgmAudio.tsx
+++ b/dashboard/src/components/remotion/BgmAudio.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Audio, useCurrentFrame, interpolate } from "remotion";
+import { Audio, interpolate } from "remotion";
 import { getEditorConfig } from "@/lib/editor-config";
 
 export interface BgmClipData {
@@ -40,40 +40,46 @@ export const BgmAudio: React.FC<BgmAudioProps> = ({
 
   const startFromFrame = Math.round(bgmClip.audioStart * fps);
   const baseVolume = bgmClip.volume / 100;
-  const frame = useCurrentFrame();
 
-  // Compute volume with fade in/out applied
+  // Stabilize fadeInOut deps by extracting primitives — 객체 참조 변경에 무관하게 동일 callback 유지
+  const fadeEnabled = !!fadeInOut?.enabled && totalDuration > 0;
+  const fadeInDuration = fadeInOut?.fadeInDuration ?? 0;
+  const fadeOutDuration = fadeInOut?.fadeOutDuration ?? 0;
+  const bgmStart = bgmClip.start;
+
   const getVolume = useCallback(
     (f: number) => {
-      if (!fadeInOut?.enabled || totalDuration <= 0) return baseVolume;
+      if (!fadeEnabled) return baseVolume;
 
       // f is relative to this Sequence; convert to absolute timeline time
-      const absoluteTime = bgmClip.start + f / fps;
-      const fadeInEnd = fadeInOut.fadeInDuration;
-      const fadeOutStart = totalDuration - fadeInOut.fadeOutDuration;
+      const absoluteTime = bgmStart + f / fps;
+      const fadeOutStart = totalDuration - fadeOutDuration;
 
       let multiplier = 1;
-      if (fadeInOut.fadeInDuration > 0 && absoluteTime < fadeInEnd) {
-        multiplier = Math.min(multiplier, interpolate(
-          absoluteTime, [0, fadeInEnd], [0, 1],
-          { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
-        ));
+      if (fadeInDuration > 0 && absoluteTime < fadeInDuration) {
+        multiplier = Math.min(
+          multiplier,
+          interpolate(absoluteTime, [0, fadeInDuration], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          }),
+        );
       }
-      if (fadeInOut.fadeOutDuration > 0 && absoluteTime > fadeOutStart) {
-        multiplier = Math.min(multiplier, interpolate(
-          absoluteTime, [fadeOutStart, totalDuration], [1, 0],
-          { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
-        ));
+      if (fadeOutDuration > 0 && absoluteTime > fadeOutStart) {
+        multiplier = Math.min(
+          multiplier,
+          interpolate(absoluteTime, [fadeOutStart, totalDuration], [1, 0], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          }),
+        );
       }
       return baseVolume * multiplier;
     },
-    [baseVolume, bgmClip.start, fps, fadeInOut, totalDuration],
+    [baseVolume, bgmStart, fps, fadeEnabled, fadeInDuration, fadeOutDuration, totalDuration],
   );
 
-  // If no fade, use static volume; otherwise use callback
-  const volumeProp = (!fadeInOut?.enabled || totalDuration <= 0)
-    ? baseVolume
-    : getVolume;
+  const volumeProp = fadeEnabled ? getVolume : baseVolume;
 
   return (
     <Audio

--- a/dashboard/src/components/remotion/VideoClip.tsx
+++ b/dashboard/src/components/remotion/VideoClip.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { OffthreadVideo, Video, useCurrentFrame, useVideoConfig, interpolate, getRemotionEnvironment } from "remotion";
 import { getEditorConfig } from "@/lib/editor-config";
 
@@ -120,17 +120,16 @@ export const VideoClip: React.FC<ClipProps> = ({
   const transform = transformParts.length > 0 ? transformParts.join(' ') : undefined;
 
   const clipOpacity = opacity != null ? opacity / 100 : undefined;
-  const clipVolume = audioMuted ? 0 : (volume != null ? volume / 100 : 1);
+  const clipVolume = volume != null ? volume / 100 : 1;
   const objectFit = fitMode === 'contain' ? 'contain' : 'cover';
   const objPosX = positionX ?? 50;
   const objPosY = positionY ?? 50;
   const objectPosition = (objPosX !== 50 || objPosY !== 50) ? `${objPosX}% ${objPosY}%` : undefined;
 
-  // Suppress video playback errors (HEVC originals may fail in browser during proxy generation)
-  const handleError = useCallback((err: Error) => {
-    // Silently ignore — errorFallback will show placeholder
+  // HEVC originals may fail in browser during proxy generation — log only, errorFallback renders placeholder
+  const handleError = (err: Error) => {
     console.debug(`[VideoClip] ${source}: ${err.message}`);
-  }, [source]);
+  };
 
   return (
     <div
@@ -148,6 +147,7 @@ export const VideoClip: React.FC<ClipProps> = ({
           startFrom={startFromFrame}
           playbackRate={speed}
           volume={clipVolume}
+          muted={audioMuted}
           onError={handleError}
           style={{
             width: "100%",
@@ -165,6 +165,9 @@ export const VideoClip: React.FC<ClipProps> = ({
           startFrom={startFromFrame}
           playbackRate={speed}
           volume={clipVolume}
+          muted={audioMuted}
+          pauseWhenBuffering
+          acceptableTimeShiftInSeconds={1}
           onError={handleError}
           style={{
             width: "100%",

--- a/dashboard/src/components/remotion/VideoProject.tsx
+++ b/dashboard/src/components/remotion/VideoProject.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   Sequence,
   useVideoConfig,
@@ -168,87 +168,85 @@ export const VideoProject: React.FC<ProjectData> = (props) => {
 
   const frame = useCurrentFrame();
 
-  // Build CSS filter string from globalEffects — applied directly to each <OffthreadVideo>
-  const getEffectVal = (type: string, defaultVal: number = 100) => {
-    const ef = (globalEffects || []).find((e) => e.type === type);
-    return ef?.value ?? defaultVal;
-  };
-  const brightness = getEffectVal("brightness", 100);
-  const contrast = getEffectVal("contrast", 100);
-  const saturation = getEffectVal("saturation", 100);
-  const blur = getEffectVal("blur", 0);
-  const grayscale = getEffectVal("grayscale", 0);
-  const sepia = getEffectVal("sepia", 0);
-  const hueRotate = getEffectVal("hueRotate", 0);
+  // Build CSS filter string from globalEffects — props 변경 시에만 재계산
+  const filterStr = useMemo(() => {
+    const get = (type: string, defaultVal: number) =>
+      (globalEffects || []).find((e) => e.type === type)?.value ?? defaultVal;
+    const brightness = get("brightness", 100);
+    const contrast = get("contrast", 100);
+    const saturation = get("saturation", 100);
+    const blur = get("blur", 0);
+    const grayscale = get("grayscale", 0);
+    const sepia = get("sepia", 0);
+    const hueRotate = get("hueRotate", 0);
 
-  const filterParts: string[] = [];
-  if (brightness !== 100) filterParts.push(`brightness(${brightness / 100})`);
-  if (contrast !== 100) filterParts.push(`contrast(${contrast / 100})`);
-  if (saturation !== 100) filterParts.push(`saturate(${saturation / 100})`);
-  if (blur > 0) filterParts.push(`blur(${blur}px)`);
-  if (grayscale > 0) filterParts.push(`grayscale(${grayscale / 100})`);
-  if (sepia > 0) filterParts.push(`sepia(${sepia / 100})`);
-  if (hueRotate > 0) filterParts.push(`hue-rotate(${hueRotate}deg)`);
+    const parts: string[] = [];
+    if (brightness !== 100) parts.push(`brightness(${brightness / 100})`);
+    if (contrast !== 100) parts.push(`contrast(${contrast / 100})`);
+    if (saturation !== 100) parts.push(`saturate(${saturation / 100})`);
+    if (blur > 0) parts.push(`blur(${blur}px)`);
+    if (grayscale > 0) parts.push(`grayscale(${grayscale / 100})`);
+    if (sepia > 0) parts.push(`sepia(${sepia / 100})`);
+    if (hueRotate > 0) parts.push(`hue-rotate(${hueRotate}deg)`);
+    return parts.length > 0 ? parts.join(" ") : undefined;
+  }, [globalEffects]);
 
-  const filterStr = filterParts.length > 0 ? filterParts.join(" ") : undefined;
-
-  // Calculate clip durations
-  const clipDurations: number[] = clips.map((clip, i) => {
-    const speed = clipMeta[i]?.speed ?? 1;
-    return (clip.end - clip.start) / speed;
-  });
-
-  // Calculate timeline positions (for subtitles/BGM positioning)
-  const transitionDurations: number[] = [];
-  for (let i = 0; i < clips.length - 1; i++) {
-    const t = transitions[i];
-    if (t && t.type !== "none" && t.duration > 0) {
-      transitionDurations.push(t.duration);
-    } else {
-      transitionDurations.push(0);
-    }
-  }
-
-  const clipStarts: number[] = [0];
-  for (let i = 1; i < clips.length; i++) {
-    const prevEnd = clipStarts[i - 1] + clipDurations[i - 1];
-    const overlap = transitionDurations[i - 1] ?? 0;
-    clipStarts.push(prevEnd - overlap);
-  }
-
-  // Get effective timeline start for a clip (multi-track: timelineStart, fallback: sequential)
-  const getClipTimelineStart = (i: number) => clips[i].timelineStart ?? clipStarts[i];
-
-  // Group clips by track for multi-track rendering
+  // Clip durations / timeline positions / track grouping — 매 프레임이 아닌 props 기반으로만 재계산
   const NUM_TRACKS = 3;
-  const trackClips: { clipIndex: number; clip: Clip }[][] = Array.from({ length: NUM_TRACKS }, () => []);
-  clips.forEach((clip, i) => {
-    const track = clip.track ?? 0;
-    const clampedTrack = Math.max(0, Math.min(NUM_TRACKS - 1, track));
-    trackClips[clampedTrack].push({ clipIndex: i, clip });
-  });
 
-  // For transition detection: find adjacent clips on same track
-  const getTrackTransitions = (trackIdx: number) => {
-    const tClips = trackClips[trackIdx];
-    if (tClips.length < 2) return [];
-    const sorted = [...tClips].sort((a, b) => getClipTimelineStart(a.clipIndex) - getClipTimelineStart(b.clipIndex));
-    const result: { transIndex: number; startSec: number; durationSec: number; type: string }[] = [];
-    for (let j = 0; j < sorted.length - 1; j++) {
-      const aIdx = sorted[j].clipIndex;
-      const bIdx = sorted[j + 1].clipIndex;
-      const aEnd = getClipTimelineStart(aIdx) + clipDurations[aIdx];
-      const bStart = getClipTimelineStart(bIdx);
-      if (Math.abs(aEnd - bStart) < 0.01) {
-        const tIdx = Math.min(aIdx, bIdx);
-        const t = transitions[tIdx];
-        if (t && t.type !== "none" && t.duration > 0) {
-          result.push({ transIndex: tIdx, startSec: aEnd - t.duration, durationSec: t.duration, type: t.type });
-        }
-      }
+  const layout = useMemo(() => {
+    const clipDurations: number[] = clips.map((clip, i) => {
+      const speed = clipMeta[i]?.speed ?? 1;
+      return (clip.end - clip.start) / speed;
+    });
+
+    const transitionDurations: number[] = [];
+    for (let i = 0; i < clips.length - 1; i++) {
+      const t = transitions[i];
+      transitionDurations.push(t && t.type !== "none" && t.duration > 0 ? t.duration : 0);
     }
-    return result;
-  };
+
+    const clipStarts: number[] = [0];
+    for (let i = 1; i < clips.length; i++) {
+      const prevEnd = clipStarts[i - 1] + clipDurations[i - 1];
+      clipStarts.push(prevEnd - (transitionDurations[i - 1] ?? 0));
+    }
+
+    const getClipTimelineStart = (i: number) => clips[i].timelineStart ?? clipStarts[i];
+
+    const trackClips: { clipIndex: number; clip: Clip }[][] = Array.from({ length: NUM_TRACKS }, () => []);
+    clips.forEach((clip, i) => {
+      const track = Math.max(0, Math.min(NUM_TRACKS - 1, clip.track ?? 0));
+      trackClips[track].push({ clipIndex: i, clip });
+    });
+
+    const trackTransitions: { transIndex: number; startSec: number; durationSec: number; type: string }[][] =
+      trackClips.map((tClips) => {
+        if (tClips.length < 2) return [];
+        const sorted = [...tClips].sort(
+          (a, b) => getClipTimelineStart(a.clipIndex) - getClipTimelineStart(b.clipIndex),
+        );
+        const result: { transIndex: number; startSec: number; durationSec: number; type: string }[] = [];
+        for (let j = 0; j < sorted.length - 1; j++) {
+          const aIdx = sorted[j].clipIndex;
+          const bIdx = sorted[j + 1].clipIndex;
+          const aEnd = getClipTimelineStart(aIdx) + clipDurations[aIdx];
+          const bStart = getClipTimelineStart(bIdx);
+          if (Math.abs(aEnd - bStart) < 0.01) {
+            const tIdx = Math.min(aIdx, bIdx);
+            const t = transitions[tIdx];
+            if (t && t.type !== "none" && t.duration > 0) {
+              result.push({ transIndex: tIdx, startSec: aEnd - t.duration, durationSec: t.duration, type: t.type });
+            }
+          }
+        }
+        return result;
+      });
+
+    return { clipDurations, clipStarts, getClipTimelineStart, trackClips, trackTransitions };
+  }, [clips, clipMeta, transitions]);
+
+  const { clipDurations, getClipTimelineStart, trackClips, trackTransitions } = layout;
 
   // Fade in/out opacity
   const totalDurationFrames = Math.ceil(props.totalDuration * fps);
@@ -302,7 +300,7 @@ export const VideoProject: React.FC<ProjectData> = (props) => {
               );
             })}
             {/* Transition overlays for this track */}
-            {getTrackTransitions(trackIdx).map((tr) => {
+            {trackTransitions[trackIdx].map((tr) => {
               const startFrame = Math.round(tr.startSec * fps);
               const durationFrames = Math.max(1, Math.ceil(tr.durationSec * fps));
               return (

--- a/dashboard/src/components/remotion/fonts.ts
+++ b/dashboard/src/components/remotion/fonts.ts
@@ -1,6 +1,9 @@
 /**
- * Register custom fonts for both Next.js (Player preview) and Remotion render.
- * Uses /fonts/ public directory.
+ * Register custom fonts for the Player preview (Next.js context).
+ * Uses FontFace API per Remotion best-practice — `document.fonts` ready promise gives
+ * deterministic font availability before Player starts rendering.
+ *
+ * Font files are served from /fonts/* via a symlink: dashboard/public/fonts → ../../editor/assets/fonts.
  */
 
 const FONTS: Array<{ family: string; file: string; weight?: number }> = [
@@ -21,21 +24,23 @@ const FONTS: Array<{ family: string; file: string; weight?: number }> = [
   { family: "LINESeedKR", file: "LINESeedKR-Bold.woff2", weight: 700 },
 ];
 
+let registered = false;
+
 export function registerFonts(): void {
   if (typeof document === "undefined") return;
-  if (document.getElementById("__remotion-fonts")) return;
+  if (registered) return;
+  registered = true;
 
-  const style = document.createElement("style");
-  style.id = "__remotion-fonts";
-  const rules = FONTS.map(
-    (f) => `@font-face {
-  font-family: '${f.family}';
-  src: url('/fonts/${f.file}') format('${f.file.endsWith(".woff2") ? "woff2" : "truetype"}');
-  font-weight: ${f.weight ?? 400};
-  font-display: block;
-}`
-  ).join("\n");
-
-  style.textContent = rules;
-  document.head.appendChild(style);
+  for (const f of FONTS) {
+    const url = `/fonts/${f.file}`;
+    const format = f.file.endsWith(".woff2") ? "woff2" : "truetype";
+    const font = new FontFace(f.family, `url('${url}') format('${format}')`, {
+      weight: String(f.weight ?? 400),
+      display: "block",
+    });
+    font
+      .load()
+      .then((loaded) => document.fonts.add(loaded))
+      .catch((err) => console.warn(`[fonts] failed to load ${f.family}:`, err));
+  }
 }

--- a/dashboard/src/components/studio/RemotionPreview.tsx
+++ b/dashboard/src/components/studio/RemotionPreview.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Player, type PlayerRef } from '@remotion/player';
-import { prefetch } from 'remotion';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Player, type PlayerRef, type CallbackListener } from '@remotion/player';
 import { VideoProject } from '../remotion/VideoProject';
 import { registerFonts } from '../remotion/fonts';
 import { getEditorConfig } from '@/lib/editor-config';
@@ -17,12 +16,23 @@ const FPS = 30;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const VideoProjectComponent = VideoProject as React.ComponentType<any>;
 
-export const RemotionPreview: React.FC = () => {
-  const playerRef = useRef<PlayerRef>(null);
-  const previewContainerRef = useRef<HTMLDivElement>(null);
-  const fontsLoaded = useRef(false);
-  const [isFullscreen, setIsFullscreen] = useState(false);
+// ─── Inner Player — isolated from frequently-changing UI state ───
+// Per Remotion best-practice: keep <Player> in its own component sibling to
+// controls/overlays that subscribe to currentTime, so frame updates don't
+// re-render the Player tree.
+//
+// Note: Remotion `prefetch()` was intentionally removed. In dev with missing/in-progress
+// media proxies it 404s, and Remotion's internal HTTP rejection surfaces as an
+// "unhandled rejection" Runtime Error in Next.js's dev overlay even when wrapped in
+// waitUntilDone().catch(...). The Player loads media on demand via <OffthreadVideo>/<Video> —
+// prefetch was a perf micro-opt for first-play snappiness, not a correctness requirement.
 
+type InnerPlayerProps = {
+  playerRef: React.RefObject<PlayerRef | null>;
+  fontsLoaded: React.MutableRefObject<boolean>;
+};
+
+const PlayerOnly: React.FC<InnerPlayerProps> = ({ playerRef, fontsLoaded }) => {
   const {
     clips, clipMeta, clipCrops, clipZooms, clipSubStyles,
     transitions, globalSubs, bgmClips, globalEffects, fadeInOut,
@@ -44,8 +54,6 @@ export const RemotionPreview: React.FC = () => {
     totalDuration: s.totalDuration,
     sources: s.sources,
   })));
-  const setCurrentFrame = useEditorStore((s) => s.setCurrentFrame);
-  const setIsPlaying = useEditorStore((s) => s.setIsPlaying);
 
   // Load fonts once
   useEffect(() => {
@@ -53,46 +61,130 @@ export const RemotionPreview: React.FC = () => {
       registerFonts();
       fontsLoaded.current = true;
     }
+  }, [fontsLoaded]);
+
+  const mediaBasePath = useMemo(() => {
+    const u = getEditorConfig().apiUrl;
+    return typeof window !== 'undefined' ? `${window.location.origin}${u}` : u;
   }, []);
 
-  // Sync player frame → store (poll via RAF)
-  useEffect(() => {
-    let rafId: number;
-    let lastFrame = -1;
+  // Memoize inputProps — 공식문서 권장: 미메모이제이션 시 Player 트리 전체 재렌더 병목
+  const inputProps = useMemo(
+    () => ({
+      clips,
+      clipMeta,
+      clipCrops,
+      clipZooms,
+      clipSubStyles,
+      transitions,
+      subs: [] as unknown[],
+      globalSubs: subsEnabled ? globalSubs : [],
+      bgmClips: bgmEnabled ? bgmClips : [],
+      totalDuration,
+      sources,
+      globalEffects,
+      fadeInOut,
+      mediaBasePath,
+    }),
+    [
+      clips,
+      clipMeta,
+      clipCrops,
+      clipZooms,
+      clipSubStyles,
+      transitions,
+      subsEnabled,
+      globalSubs,
+      bgmEnabled,
+      bgmClips,
+      totalDuration,
+      sources,
+      globalEffects,
+      fadeInOut,
+      mediaBasePath,
+    ],
+  );
 
-    const tick = () => {
-      const player = playerRef.current;
-      if (player) {
-        try {
-          const frame = player.getCurrentFrame();
-          if (frame !== lastFrame) {
-            lastFrame = frame;
-            setCurrentFrame(frame);
-          }
-        } catch {
-          // player not ready yet
-        }
-      }
-      rafId = requestAnimationFrame(tick);
+  const durationInFrames = Math.max(1, Math.ceil(totalDuration * FPS));
+  const compositionWidth = orientation === 'square' ? 540 : orientation === 'horizontal' ? 960 : 540;
+  const compositionHeight = orientation === 'square' ? 540 : orientation === 'horizontal' ? 540 : 960;
+
+  return (
+    <Player
+      ref={playerRef}
+      component={VideoProjectComponent}
+      inputProps={inputProps}
+      durationInFrames={durationInFrames}
+      fps={FPS}
+      compositionWidth={compositionWidth}
+      compositionHeight={compositionHeight}
+      style={{
+        width: '100%',
+        height: '100%',
+      }}
+      controls
+      clickToPlay
+      showVolumeControls
+      autoPlay={false}
+      loop
+      overflowVisible={false}
+      numberOfSharedAudioTags={8}
+      errorFallback={({ error }: { error: Error }) => {
+        console.debug('[Player errorFallback]', error.message);
+        return (
+          <div style={{ color: '#666', fontSize: 11, padding: 20, textAlign: 'center' }}>
+            영상 로딩 중... 재생 버튼을 눌러주세요
+          </div>
+        );
+      }}
+    />
+  );
+};
+
+export const RemotionPreview: React.FC = () => {
+  const playerRef = useRef<PlayerRef>(null);
+  const previewContainerRef = useRef<HTMLDivElement>(null);
+  const fontsLoaded = useRef(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const clipsLength = useEditorStore((s) => s.clips.length);
+  const orientation = useEditorStore((s) => s.orientation);
+  const setCurrentFrame = useEditorStore((s) => s.setCurrentFrame);
+  const setIsPlaying = useEditorStore((s) => s.setIsPlaying);
+
+  // Sync player frame → store via Remotion's throttled `timeupdate` event
+  // (replaces 60fps RAF polling — 공식 docs: timeupdate fires at most every 250ms).
+  // Also handles play/pause/ended via events instead of setInterval ref-poll.
+  useEffect(() => {
+    const player = playerRef.current;
+    if (!player) return;
+
+    const onTime: CallbackListener<'timeupdate'> = (e) => {
+      setCurrentFrame(e.detail.frame);
     };
-    rafId = requestAnimationFrame(tick);
+    const onSeeked: CallbackListener<'seeked'> = (e) => {
+      setCurrentFrame(e.detail.frame);
+    };
+    const onPlay: CallbackListener<'play'> = () => setIsPlaying(true);
+    const onPause: CallbackListener<'pause'> = () => setIsPlaying(false);
+    const onEnded: CallbackListener<'ended'> = () => setIsPlaying(false);
 
-    return () => cancelAnimationFrame(rafId);
-  }, [setCurrentFrame]);
+    player.addEventListener('timeupdate', onTime);
+    player.addEventListener('seeked', onSeeked);
+    player.addEventListener('play', onPlay);
+    player.addEventListener('pause', onPause);
+    player.addEventListener('ended', onEnded);
 
-  // Play/pause events
-  useEffect(() => {
-    const check = setInterval(() => {
-      const player = playerRef.current;
-      if (!player) return;
-      clearInterval(check);
-      const onPlay = () => setIsPlaying(true);
-      const onPause = () => setIsPlaying(false);
-      player.addEventListener('play', onPlay);
-      player.addEventListener('pause', onPause);
-    }, 200);
-    return () => clearInterval(check);
-  }, [setIsPlaying]);
+    return () => {
+      player.removeEventListener('timeupdate', onTime);
+      player.removeEventListener('seeked', onSeeked);
+      player.removeEventListener('play', onPlay);
+      player.removeEventListener('pause', onPause);
+      player.removeEventListener('ended', onEnded);
+    };
+  // playerRef.current is stable across mounts; clipsLength toggles between empty/non-empty UI
+  // which conditionally mounts <PlayerOnly>, so re-attaching listeners on that flip is correct.
+  }, [setCurrentFrame, setIsPlaying, clipsLength]);
 
   const seekTo = useCallback((frame: number) => {
     playerRef.current?.seekTo(frame);
@@ -124,7 +216,6 @@ export const RemotionPreview: React.FC = () => {
     }
   }, []);
 
-  // Listen for fullscreen changes
   useEffect(() => {
     const onFsChange = () => {
       setIsFullscreen(!!document.fullscreenElement);
@@ -133,78 +224,19 @@ export const RemotionPreview: React.FC = () => {
     return () => document.removeEventListener('fullscreenchange', onFsChange);
   }, []);
 
-  // Listen for 'F' key from Timeline keyboard handler
   useEffect(() => {
     const handler = () => toggleFullscreen();
     window.addEventListener('studio-fullscreen-toggle', handler);
     return () => window.removeEventListener('studio-fullscreen-toggle', handler);
   }, [toggleFullscreen]);
 
-  const durationInFrames = Math.max(1, Math.ceil(totalDuration * FPS));
-
-  // 미디어 로딩 상태 추적
-  // 프로젝트 로딩 상태 (store에서 clips가 채워지기 전)
+  // 미디어 로딩 인디케이터 — 프로젝트 로딩 후 첫 frame 준비될 때까지
   const [mediaLoading, setMediaLoading] = useState(true);
   useEffect(() => {
-    if (clips.length > 0) setMediaLoading(false);
-  }, [clips.length]);
+    if (clipsLength > 0) setMediaLoading(false);
+  }, [clipsLength]);
 
-  // BGM + 영상 프리로드 — Remotion prefetch로 재생 딜레이 제거
-  const prefetchFreeRef = useRef<(() => void)[]>([]);
-  useEffect(() => {
-    // 이전 prefetch 해제
-    prefetchFreeRef.current.forEach((free) => free());
-    prefetchFreeRef.current = [];
-
-    const apiUrl = getEditorConfig().apiUrl;
-    const base = typeof window !== 'undefined' ? `${window.location.origin}${apiUrl}` : apiUrl;
-
-    // BGM 프리로드
-    if (bgmEnabled && bgmClips.length) {
-      for (const bgm of bgmClips) {
-        try {
-          const url = `${base}/${bgm.source}`;
-          const { free } = prefetch(url, { method: 'blob-url', contentType: 'audio/mpeg' });
-          prefetchFreeRef.current.push(free);
-        } catch { /* ignore prefetch errors */ }
-      }
-    }
-
-    // 영상 클립 프리로드 (처음 3개만)
-    for (const clip of clips.slice(0, 3)) {
-      const src = clip.source;
-      if (!src) continue;
-      try {
-        const url = `${base}/${src}`;
-        const { free } = prefetch(url, { method: 'blob-url', contentType: 'video/mp4' });
-        prefetchFreeRef.current.push(free);
-      } catch { /* ignore prefetch errors */ }
-    }
-
-    return () => {
-      prefetchFreeRef.current.forEach((free) => free());
-      prefetchFreeRef.current = [];
-    };
-  }, [bgmClips, bgmEnabled, clips]);
-
-  const inputProps = {
-    clips,
-    clipMeta,
-    clipCrops,
-    clipZooms,
-    clipSubStyles,
-    transitions,
-    subs: [] as unknown[],
-    globalSubs: subsEnabled ? globalSubs : [],
-    bgmClips: bgmEnabled ? bgmClips : [],
-    totalDuration,
-    sources,
-    globalEffects,
-    fadeInOut,
-    mediaBasePath: (() => { const u = getEditorConfig().apiUrl; return typeof window !== 'undefined' ? `${window.location.origin}${u}` : u; })(),
-  };
-
-  if (clips.length === 0) {
+  if (clipsLength === 0) {
     return (
       <div style={{
         flex: 1,
@@ -218,6 +250,8 @@ export const RemotionPreview: React.FC = () => {
       </div>
     );
   }
+
+  const aspectRatio = orientation === 'square' ? '1/1' : orientation === 'horizontal' ? '16/9' : '9/16';
 
   return (
     <div
@@ -246,32 +280,8 @@ export const RemotionPreview: React.FC = () => {
           <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
         </div>
       )}
-      <div style={{ position: 'relative', width: '100%', maxHeight: '100%', aspectRatio: orientation === 'square' ? '1/1' : orientation === 'horizontal' ? '16/9' : '9/16' }}>
-        <Player
-          ref={playerRef}
-          component={VideoProjectComponent}
-          inputProps={inputProps}
-          durationInFrames={durationInFrames}
-          fps={FPS}
-          compositionWidth={orientation === 'square' ? 540 : orientation === 'horizontal' ? 960 : 540}
-          compositionHeight={orientation === 'square' ? 540 : orientation === 'horizontal' ? 540 : 960}
-          style={{
-            width: '100%',
-            height: '100%',
-          }}
-          controls
-          clickToPlay
-          showVolumeControls
-          autoPlay={false}
-          loop
-          overflowVisible={false}
-          numberOfSharedAudioTags={8}
-          errorFallback={({ error }: { error: Error }) => (
-            <div style={{ color: '#666', fontSize: 11, padding: 20, textAlign: 'center' }}>
-              영상 로딩 중... 재생 버튼을 눌러주세요
-            </div>
-          )}
-        />
+      <div style={{ position: 'relative', width: '100%', maxHeight: '100%', aspectRatio }}>
+        <PlayerOnly playerRef={playerRef} fontsLoaded={fontsLoaded} />
         <CanvasOverlay />
       </div>
       {/* Fullscreen button */}

--- a/dashboard/src/components/studio/timeline/useWaveform.ts
+++ b/dashboard/src/components/studio/timeline/useWaveform.ts
@@ -13,6 +13,13 @@ export function useWaveform() {
   const [clipAudioInfo, setClipAudioInfo] = useState<Record<string, ClipAudioInfo>>({});
   const [waveformVersion, setWaveformVersion] = useState(0);
 
+  // Per-source dedupe — prevents the effect from re-fetching the same media when
+  // any unrelated state update re-triggers this hook (StrictMode double-mount,
+  // sibling re-renders). The Map shares an in-flight promise; the Set marks any
+  // source that completed (success OR failure) so failures are never retried.
+  const waveformAttempts = useRef<Map<string, Promise<{ peaks: Float32Array; duration: number } | null>>>(new Map());
+  const waveformTried = useRef<Set<string>>(new Set());
+
   const buildMediaUrl = useCallback((source: string) => {
     const isAudio = /\.(mp3|wav|ogg|m4a|aac|flac)$/i.test(source);
     if (isAudio) {
@@ -23,36 +30,49 @@ export function useWaveform() {
   }, []);
 
   const extractWaveform = useCallback(async (source: string) => {
-    const url = buildMediaUrl(source);
-    try {
-      const response = await fetch(url);
-      if (!response.ok) return null;
-      const buf = await response.arrayBuffer();
-      const audioCtx = new AudioContext();
+    // Dedupe: share the in-flight promise; refuse to re-fetch a tried source.
+    const inFlight = waveformAttempts.current.get(source);
+    if (inFlight) return inFlight;
+    if (waveformTried.current.has(source)) return null;
+
+    const promise = (async () => {
+      const url = buildMediaUrl(source);
       try {
-        const decoded = await audioCtx.decodeAudioData(buf);
-        const data = decoded.getChannelData(0);
-        const targetLen = Math.min(16000, data.length);
-        const windowSize = Math.max(1, Math.floor(data.length / targetLen));
-        const result = new Float32Array(targetLen);
-        for (let i = 0; i < targetLen; i++) {
-          const start = i * windowSize;
-          const end = Math.min(start + windowSize, data.length);
-          let peak = 0;
-          for (let j = start; j < end; j++) {
-            const abs = Math.abs(data[j]);
-            if (abs > peak) peak = abs;
+        const response = await fetch(url);
+        if (!response.ok) return null;
+        const buf = await response.arrayBuffer();
+        const audioCtx = new AudioContext();
+        try {
+          const decoded = await audioCtx.decodeAudioData(buf);
+          const data = decoded.getChannelData(0);
+          const targetLen = Math.min(16000, data.length);
+          const windowSize = Math.max(1, Math.floor(data.length / targetLen));
+          const result = new Float32Array(targetLen);
+          for (let i = 0; i < targetLen; i++) {
+            const start = i * windowSize;
+            const end = Math.min(start + windowSize, data.length);
+            let peak = 0;
+            for (let j = start; j < end; j++) {
+              const abs = Math.abs(data[j]);
+              if (abs > peak) peak = abs;
+            }
+            result[i] = peak;
           }
-          result[i] = peak;
+          return { peaks: result, duration: decoded.duration };
+        } finally {
+          void audioCtx.close();
         }
-        const audioDuration = decoded.duration;
-        return { peaks: result, duration: audioDuration };
+      } catch {
+        // decodeAudioData on a video container with no decodable audio track throws — expected.
+        return null;
       } finally {
-        void audioCtx.close();
+        waveformTried.current.add(source);
+        waveformAttempts.current.delete(source);
       }
-    } catch {
-      return null;
-    }
+    })();
+
+    waveformAttempts.current.set(source, promise);
+    return promise;
   }, [buildMediaUrl]);
 
   const drawWaveformBars = useCallback((ctx: CanvasRenderingContext2D, widthPx: number, h: number, waveData: Float32Array | undefined, color: string, fallbackColor: string) => {

--- a/editor/DEPRECATED.md
+++ b/editor/DEPRECATED.md
@@ -1,0 +1,51 @@
+# ⚠️ editor/ 디렉토리 DEPRECATED — DO NOT EDIT FOR DASHBOARD CHANGES
+
+## TL;DR
+
+**dashboard 영상 편집기를 수정하려면 `editor/`가 아니라 `dashboard/src/components/`를 수정하세요.**
+
+## 왜 DEPRECATED인가
+
+- **2026-04-18**: brxce-editor가 agentic-cms로 이식되면서 `dashboard/src/components/{studio,remotion}/` 으로 fully ported됨
+- **`editor/` 디렉토리는 historical reference로만 보존** (이식 source / standalone 사용 백업)
+- dashboard는 editor를 import하지 않음 — `grep "from .*editor" dashboard/src` → 0건
+- 같은 컴포넌트의 두 사본 (editor + dashboard) — 미세하게 다르게 진화함
+
+## 자주 일어나는 실수
+
+❌ 사용자가 "영상 편집기에 버그 있어요" 하면 `editor/components/...` 수정 → **dashboard 화면(`localhost:3000`)에 반영 안 됨**
+
+✅ 영상 편집기 변경은 항상 `dashboard/src/components/{studio,remotion}/`에 적용
+
+## 어디에 무엇이 있나
+
+| 변경 대상 | 수정할 위치 | 사용 환경 |
+|---|---|---|
+| 영상 편집기 UI / 동작 | **`dashboard/src/components/studio/`** | http://localhost:3000 (운영) |
+| Remotion preview 컴포넌트 | **`dashboard/src/components/remotion/`** | http://localhost:3000 (운영) |
+| Timeline 동작 | **`dashboard/src/components/studio/timeline/`** + `Timeline.tsx` | http://localhost:3000 (운영) |
+| editor sub-app standalone (port 3100) | `editor/components/...` | 개별 테스트만, 운영 외 |
+| Remotion **render** (server-side ffmpeg + remotion bundler) | `editor/remotion/src/` | render server (Python에서 호출) |
+| Python API (proxy/render) | `editor/src/server/` | port 8092 |
+
+## render 경로는 여전히 editor/ 사용
+
+- `editor/remotion/src/` — Remotion Studio + 서버 render bundle용 (Root.tsx 포함)
+- 이것은 dashboard에 사본이 없음 — render는 editor의 Python API가 호출
+- 따라서 **render 동작 변경 (예: VideoClip render 시 동작)** 은 `editor/remotion/src/`도 수정해야 함
+
+## 변경 시 sync 가이드
+
+| 변경 영역 | dashboard 사본 | editor sub-app 사본 | editor render 사본 |
+|---|---|---|---|
+| 영상 편집기 preview만 | `dashboard/src/components/{studio,remotion}/*` | (선택, standalone 안 쓰면 skip) | (영향 없음) |
+| 영상 render도 영향 | `dashboard/src/components/remotion/*` | `editor/components/remotion/*` | `editor/remotion/src/*` ← **반드시** |
+
+## 향후 정리 계획
+
+이 디렉토리는 다음 중 하나로 정리될 예정:
+- (a) editor sub-app 완전 deprecation → 해당 코드 제거 (render 코드만 별도 패키지로)
+- (b) 단일 source 만들기 (workspace package + dashboard symlink)
+- (c) 현 상태 유지 + sync 자동화 (CI check)
+
+결정 전까지는 위 sync 가이드를 반드시 준수.

--- a/editor/README.md
+++ b/editor/README.md
@@ -1,9 +1,16 @@
 # brxce-editor (agentic-cms 에 이식됨)
 
+> # ⚠️ DEPRECATED for editing — see [DEPRECATED.md](./DEPRECATED.md)
+>
+> **dashboard의 영상 편집기를 수정하려면 `editor/`가 아닌 `dashboard/src/components/{studio,remotion}/`을 수정하세요.**
+>
+> 이 디렉토리의 `components/`, `app/`, `lib/` 는 dashboard로 fully ported된 후 historical reference로 보존 중입니다.
+> 단, `editor/remotion/src/` (server-side Remotion render bundle) 와 `editor/src/server/` (Python API) 는 여전히 운영에서 사용됩니다.
+
 AI 기반 숏폼 영상 편집기. 레퍼런스 분석 → 소스 자동 매칭 → 비트 싱크 → BGM 매칭 → 프로젝트 생성까지 자동화.
 
 > **이식 안내 (2026-04-18)**: 이 프로젝트는 원래 독립 repo (`https://github.com/intelli-ddd/brxce-editor`) 였으나, `agentic-cms` 의 `editor/` 서브디렉토리로 흡수됨. 독립 실행도 가능하지만, 기본 사용 방식은 agentic-cms dashboard 의 영상 관련 기능이 이 서버에 proxy 로 위임하는 구조.
-> 자세한 통합 내역: `../CHANGELOG.md`
+> 자세한 통합 내역: `../CHANGELOG.md` · sync 가이드: [`./DEPRECATED.md`](./DEPRECATED.md)
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
PR #49는 사실상 사용되지 않는 \`editor/\` (legacy reference)에만 적용되어 사용자 화면(dashboard, localhost:3000)에는 반영되지 않았음. 실제 운영 코드인 dashboard에 동일한 변경을 이식하고, 같은 실수가 재발하지 않도록 가이드 문서를 추가.

## 핵심 임팩트
- **사용자 보고 critical bug**: Timeline 폴링 루프 dashboard에 fix 적용 (extractWaveform이 비디오 audio decode 실패 시 영원히 재시도되던 문제)
- **Runtime Error 'HTTP error, status = 404'** dashboard에 fix (RemotionPreview의 prefetch 제거)
- **폰트 14개 404** dashboard fix (\`dashboard/public/fonts → ../../editor/assets/fonts\` symlink)
- **재발 방지**: \`editor/\` 디렉토리에 DEPRECATED 마커 + AGENTS.md / README.md에 "어디에 무엇이 있나" 표 추가

## Files

### dashboard 변경 (실제 운영)
- \`dashboard/src/components/studio/RemotionPreview.tsx\` — PlayerOnly 분리 + inputProps useMemo + timeupdate event + prefetch 제거 + setInterval 제거
- \`dashboard/src/components/studio/timeline/useWaveform.ts\` — in-flight Promise Map + tried Set
- \`dashboard/src/components/remotion/AnimatedSubtitle.tsx\` — CSS transition 제거 + useLayoutEffect + frame-driven interpolate
- \`dashboard/src/components/remotion/BgmAudio.tsx\` — fadeInOut primitive 분해
- \`dashboard/src/components/remotion/VideoClip.tsx\` — muted prop + pauseWhenBuffering
- \`dashboard/src/components/remotion/VideoProject.tsx\` — useMemo로 layout 계산
- \`dashboard/src/components/remotion/fonts.ts\` — FontFace API
- \`dashboard/next.config.ts\` — reactStrictMode false (dev only)
- \`dashboard/public/fonts\` — symlink 추가

### 재발 방지 가이드 (가장 중요)
- \`editor/DEPRECATED.md\` (신규) — editor/ 디렉토리 활용/금지 가이드 + render path는 여전히 editor 사용한다는 점 명시
- \`editor/README.md\` — 상단에 굵은 DEPRECATED 마커
- \`AGENTS.md\` — 구조 섹션에 "영상 편집기 변경 어디에 해야 하나" 표 추가

## 왜 PR #49로 안 됐나
\`editor/components/...\` 와 \`dashboard/src/components/...\` 가 동일 컴포넌트의 두 사본이고, dashboard는 editor를 import하지 않음 (\`grep "from .*editor" dashboard/src\` → 0건). PR #49는 editor 사본만 수정해서 dashboard 화면에는 효과 없었음.

## Test plan
- [x] \`npx tsc --noEmit\` PASS (dashboard)
- [x] 폰트 14개 cURL 200 확인 (\`http://localhost:3000/fonts/*.ttf\`)
- [x] dashboard dev 서버 정상 가동
- [ ] (사용자 측) http://localhost:3000 hard reload 후 영상 페이지에서 폴링 루프 / 404 / 폰트 누락 모두 사라졌는지 확인

## 향후 정리 (별개 작업)
- editor/ 와 dashboard/ 사본이 두 벌 유지되는 구조 자체가 sync 누락의 근본 원인 — 추후 (a) editor sub-app 완전 deprecation (b) workspace package + symlink (c) CI sync check 중 결정 필요. DEPRECATED.md에 옵션 정리됨.