### PR TITLE
feat(studio): 영상 편집기 사이드 패널 redesign — 인스펙터 아코디언 + lucide 아이콘 + 통합 스타일링

### DIFF
--- a/dashboard/src/app/(dashboard)/video/projects/page.tsx
+++ b/dashboard/src/app/(dashboard)/video/projects/page.tsx
@@ -14,6 +14,7 @@ import { BgmPanel } from '@/components/studio/BgmPanel';
 import { TransitionPanel } from '@/components/studio/TransitionPanel';
 import { ReferencePanel } from '@/components/studio/ReferencePanel';
 import { EffectPanel } from '@/components/studio/EffectPanel';
+import { Captions, Film, Image, Music, Sparkles, Wand2 } from 'lucide-react';
 
 // ─── Project Summary types ───
 
@@ -313,20 +314,20 @@ function StudioEditor({ projectId }: { projectId: string }) {
   }, []);
 
   const panels = [
-    { key: 'subtitle' as const, label: '자막' },
-    { key: 'clip' as const, label: '클립' },
-    { key: 'bgm' as const, label: 'BGM' },
-    { key: 'transition' as const, label: '전환' },
-    { key: 'reference' as const, label: '레퍼런스' },
-    { key: 'effect' as const, label: '이펙트' },
+    { key: 'subtitle' as const, label: '자막', icon: Captions },
+    { key: 'clip' as const, label: '클립', icon: Film },
+    { key: 'bgm' as const, label: 'BGM', icon: Music },
+    { key: 'transition' as const, label: '전환', icon: Wand2 },
+    { key: 'reference' as const, label: '레퍼런스', icon: Image },
+    { key: 'effect' as const, label: '이펙트', icon: Sparkles },
   ];
 
-  const [panelWidth, setPanelWidth] = React.useState(500);
+  const [panelWidth, setPanelWidth] = React.useState(520);
   const panelInitRef = React.useRef(false);
   React.useEffect(() => {
     if (!panelInitRef.current) {
       panelInitRef.current = true;
-      setPanelWidth(Math.round(window.innerWidth * 0.675));
+      setPanelWidth(Math.max(420, Math.min(620, Math.round(window.innerWidth * 0.34))));
     }
   }, []);
   const [timelineHeight, setTimelineHeight] = React.useState(380);
@@ -337,7 +338,7 @@ function StudioEditor({ projectId }: { projectId: string }) {
     const onMove = (e: MouseEvent) => {
       if (panelDrag.current) {
         const delta = panelDrag.current.startX - e.clientX;
-        setPanelWidth(Math.max(Math.round(window.innerWidth * 0.5), Math.min(Math.round(window.innerWidth * 0.7), panelDrag.current.startW + delta)));
+        setPanelWidth(Math.max(380, Math.min(720, panelDrag.current.startW + delta)));
       }
       if (tlDrag.current) {
         const delta = tlDrag.current.startY - e.clientY;
@@ -392,36 +393,32 @@ function StudioEditor({ projectId }: { projectId: string }) {
             document.body.style.cursor = 'col-resize';
             document.body.style.userSelect = 'none';
           }}
-          style={{ width: 5, cursor: 'col-resize', background: '#1a1a1a', flexShrink: 0, transition: 'background .15s' }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = '#333')}
-          onMouseLeave={(e) => (e.currentTarget.style.background = '#1a1a1a')}
+          style={{ width: 6, cursor: 'col-resize', background: '#171717', flexShrink: 0, transition: 'background .15s', borderLeft: '1px solid #262626', borderRight: '1px solid #050505' }}
+          onMouseEnter={(e) => (e.currentTarget.style.background = '#2f67d8')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = '#171717')}
         />
 
         <div style={{
-          width: panelWidth, flexShrink: 0, background: '#141414',
-          borderLeft: '1px solid #2a2a2a', overflow: 'auto',
+          width: panelWidth, flexShrink: 0, background: '#101113',
+          borderLeft: '1px solid #272a31', overflow: 'hidden',
           display: 'flex', flexDirection: 'column',
         }}>
-          <div style={{ display: 'flex', gap: 0, borderBottom: '1px solid #2a2a2a', flexShrink: 0 }}>
-            {panels.map((tab) => (
+          <div className="studio-panel-tabs">
+            {panels.map((tab) => {
+              const Icon = tab.icon;
+              return (
               <button
                 key={tab.key}
                 onClick={() => useEditorStore.getState().setActivePanel(tab.key)}
-                style={{
-                  flex: 1, borderRadius: 0, border: 'none',
-                  borderBottom: activePanel === tab.key ? '2px solid #60a5fa' : '2px solid transparent',
-                  fontSize: 10, padding: '8px 0',
-                  background: activePanel === tab.key ? '#1a1a2a' : 'transparent',
-                  color: activePanel === tab.key ? '#60a5fa' : '#888',
-                  cursor: 'pointer',
-                }}
+                className={activePanel === tab.key ? 'is-active' : ''}
               >
+                <Icon size={17} />
                 {tab.label}
               </button>
-            ))}
+            );})}
           </div>
 
-          <div style={{ flex: 1, overflow: 'auto' }}>
+          <div style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
             {activePanel === 'subtitle' && <SubtitlePanel />}
             {activePanel === 'clip' && <ClipPanel />}
             {activePanel === 'bgm' && <BgmPanel />}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -105,3 +105,766 @@ body {
 .top-bar-title { font-size: 12px; font-weight: 600; color: #ccc; }
 .top-bar-right { margin-left: auto; display: flex; gap: 4px; align-items: center; flex-shrink: 0; flex-wrap: nowrap; }
 .top-bar .be-btn { white-space: nowrap; flex-shrink: 0; }
+
+/* ─── Studio inspector redesign ─── */
+.studio-panel-tabs {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  flex-shrink: 0;
+  min-height: 68px;
+  border-bottom: 1px solid #24272d;
+  background:
+    radial-gradient(circle at 50% -60%, rgba(59, 130, 246, 0.14), transparent 58%),
+    linear-gradient(180deg, #17181b 0%, #101113 100%);
+}
+.studio-panel-tabs button {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 0;
+  border-right: 1px solid rgba(255,255,255,0.035);
+  background: transparent;
+  color: #8d939f;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  transition: color .15s, background .15s;
+}
+.studio-panel-tabs button:hover {
+  background: rgba(255,255,255,0.035);
+  color: #d4d8df;
+}
+.studio-panel-tabs button.is-active {
+  color: #6fa8ff;
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.14), rgba(59, 130, 246, 0.035));
+}
+.studio-panel-tabs button.is-active::after {
+  content: "";
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 0;
+  height: 2px;
+  border-radius: 999px;
+  background: #4b91ff;
+  box-shadow: 0 0 14px rgba(75,145,255,.65);
+}
+.studio-panel-tabs button:focus {
+  outline: none;
+}
+.studio-panel-tabs button:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(75,145,255,.55);
+}
+
+.studio-panel-content {
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  color: #e8eaee;
+  background: #101113;
+}
+.studio-panel-content > div {
+  color: #d7dbe2;
+}
+.studio-panel-content > div:not(:first-child),
+.studio-panel-content-bgm > div[style*="border"],
+.studio-panel-content-transition > div[style*="border"],
+.studio-panel-content-reference > div > div[style*="border"],
+.studio-panel-subeditor {
+  border-color: #2a2d34 !important;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.038), rgba(255,255,255,0.012)),
+    #18191d !important;
+  border-radius: 8px !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.045), 0 8px 24px rgba(0,0,0,.14);
+}
+.studio-panel-content-subtitle > div:first-child,
+.studio-panel-content-bgm > div:first-child,
+.studio-panel-content-effect > div:first-child {
+  position: sticky;
+  top: -12px;
+  z-index: 2;
+  padding: 8px 0 10px;
+  background: linear-gradient(180deg, #101113 70%, rgba(16,17,19,0));
+}
+.studio-panel-content-subtitle > div:first-child > div:first-child,
+.studio-panel-content-bgm > div:first-child > div:first-child,
+.studio-panel-content-effect > div:first-child > div:first-child,
+.studio-panel-content-transition > div[style*="uppercase"],
+.studio-panel-content-effect div[style*="uppercase"] {
+  color: #aeb6c4 !important;
+  font-size: 12px !important;
+  font-weight: 800 !important;
+  letter-spacing: -0.01em !important;
+  text-transform: none !important;
+}
+.studio-panel-content .be-btn,
+.studio-panel-content button:not(.studio-primary-action):not(.studio-secondary-action) {
+  border-color: #343842 !important;
+  border-radius: 6px !important;
+  background: #1d1f24 !important;
+  color: #d6d9df !important;
+  font-weight: 700;
+  transition: border-color .15s, background .15s, color .15s;
+}
+.studio-panel-content .be-btn:hover,
+.studio-panel-content button:not(.studio-primary-action):not(.studio-secondary-action):hover {
+  border-color: #4b91ff !important;
+  background: #242934 !important;
+  color: #fff !important;
+}
+.studio-panel-content .be-btn-on,
+.studio-panel-content button.is-active {
+  border-color: #4b91ff !important;
+  background: rgba(75,145,255,.18) !important;
+  color: #cfe2ff !important;
+}
+.studio-panel-content input:not([type="range"]):not([type="color"]),
+.studio-panel-content textarea,
+.studio-panel-content select,
+.studio-panel-content .filter-select {
+  border: 1px solid #30343d !important;
+  border-radius: 6px !important;
+  background: #111215 !important;
+  color: #f0f2f5 !important;
+  outline: none !important;
+  font-size: 12px !important;
+  font-family: inherit !important;
+}
+.studio-panel-content input:not([type="range"]):not([type="color"]):focus,
+.studio-panel-content textarea:focus,
+.studio-panel-content select:focus,
+.studio-panel-content .filter-select:focus {
+  border-color: #4b91ff !important;
+  box-shadow: 0 0 0 2px rgba(75,145,255,.16);
+}
+.studio-panel-content label,
+.studio-panel-content span[style*="color: '#666'"],
+.studio-panel-content span[style*="color: #666"],
+.studio-panel-content div[style*="color: '#666'"],
+.studio-panel-content div[style*="color: #666"] {
+  color: #8f97a3 !important;
+}
+.studio-panel-content input[type="range"] {
+  width: 100%;
+  accent-color: #4b91ff !important;
+}
+.studio-panel-content-bgm input[type="range"] {
+  accent-color: #35b983 !important;
+}
+.studio-panel-content-effect input[type="range"] {
+  accent-color: #4b91ff !important;
+}
+.studio-panel-content textarea {
+  min-height: 92px;
+}
+.studio-panel-content-subtitle > div:nth-child(2) > div {
+  border-color: #30343d !important;
+  background: #17191e !important;
+  border-radius: 6px !important;
+  padding: 8px 10px !important;
+}
+.studio-panel-content-subtitle > div:nth-child(2) > div[style*="7c3aed"] {
+  border-color: #4b91ff !important;
+  background: rgba(75,145,255,.16) !important;
+}
+.studio-panel-subeditor {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  padding: 12px;
+}
+.studio-panel-subeditor > label {
+  margin-top: 4px;
+  color: #aeb6c4 !important;
+  font-size: 11px !important;
+  font-weight: 700;
+}
+.studio-panel-content-bgm > div[style*="dashed"] {
+  border-color: #343842 !important;
+  background: rgba(255,255,255,.015) !important;
+}
+.studio-panel-content-bgm > div[style*="border"] {
+  padding: 12px !important;
+}
+.studio-panel-content-bgm div[style*="a7f3d0"] {
+  color: #adf0d1 !important;
+}
+.studio-panel-content-transition > div[style*="background"] {
+  padding: 12px !important;
+}
+.studio-panel-content-reference {
+  padding: 12px;
+  gap: 12px !important;
+}
+.studio-panel-content-reference > div {
+  border: 1px solid #2a2d34 !important;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #18191d;
+}
+.studio-panel-content-reference img,
+.studio-panel-content-reference video {
+  border-radius: 6px;
+}
+.studio-panel-content-effect > div:not(:first-child) {
+  padding: 12px !important;
+  margin: 0 !important;
+}
+.studio-panel-header-card {
+  padding: 12px !important;
+  border: 1px solid #2a2d34 !important;
+  border-radius: 8px !important;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012)),
+    #18191d !important;
+  color: #dfe5ee !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.045), 0 8px 24px rgba(0,0,0,.14);
+}
+.studio-upload-card {
+  border: 1px dashed #3a414d !important;
+  border-radius: 8px !important;
+  background: linear-gradient(180deg, rgba(53,185,131,.06), rgba(255,255,255,.012)) !important;
+  padding: 18px 12px !important;
+}
+.studio-audio-card,
+.studio-effect-row,
+.studio-subtitle-list,
+.studio-reference-preview-card,
+.studio-reference-list-card,
+.studio-reference-thumb,
+.studio-result-item {
+  border: 1px solid #2a2d34 !important;
+  border-radius: 8px !important;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.038), rgba(255,255,255,0.012)),
+    #18191d !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.045), 0 8px 24px rgba(0,0,0,.14);
+}
+.studio-audio-title {
+  color: #adf0d1 !important;
+  font-size: 13px !important;
+}
+.studio-subtitle-list-item {
+  min-height: 34px;
+  border: 1px solid #30343d !important;
+  border-radius: 6px !important;
+  background: #17191e !important;
+  padding: 8px 10px !important;
+}
+.studio-subtitle-list-item:hover,
+.studio-reference-thumb:hover,
+.studio-result-item:hover {
+  border-color: #4b91ff !important;
+  background: #20242d !important;
+}
+.studio-reference-preview-card,
+.studio-reference-list-card {
+  min-width: 0;
+}
+.studio-reference-thumb {
+  overflow: hidden;
+}
+
+.studio-inspector-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  color: #e8eaee;
+  background: #101113;
+}
+.studio-inspector-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px 12px 16px;
+}
+.studio-inspector-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 8px;
+  color: #6f7682;
+  text-align: center;
+  padding: 24px;
+}
+.studio-inspector-empty strong {
+  color: #d8dbe1;
+  font-size: 13px;
+}
+.studio-inspector-empty span {
+  max-width: 260px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+.studio-card,
+.studio-clip-hero-card,
+.studio-inspector-section {
+  border: 1px solid #2a2d34;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.038), rgba(255,255,255,0.012)),
+    #18191d;
+  border-radius: 8px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.045), 0 8px 24px rgba(0,0,0,.18);
+}
+.studio-card {
+  padding: 12px;
+  margin-top: 8px;
+}
+.studio-card h3 {
+  margin: 0 0 10px;
+  color: #f3f5f8;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.studio-clip-hero-card {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+}
+.studio-clip-icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid #343842;
+  border-radius: 8px;
+  color: #aeb6c4;
+  background: #24262c;
+}
+.studio-clip-title-block {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.studio-clip-title-block span {
+  color: #8a919d;
+  font-size: 11px;
+}
+.studio-clip-title-block strong {
+  overflow: hidden;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 750;
+  letter-spacing: -0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.studio-duration-badge,
+.studio-value-pill,
+.studio-speed-chip {
+  border: 1px solid #343944;
+  border-radius: 5px;
+  background: #202228;
+  color: #f1f4f8;
+  font-variant-numeric: tabular-nums;
+}
+.studio-duration-badge {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.studio-icon-button,
+.studio-action-grid button,
+.studio-split-row button,
+.studio-stepper-row button,
+.studio-align-row button,
+.studio-segmented button,
+.studio-mini-fields button,
+.studio-primary-action,
+.studio-secondary-action {
+  border: 1px solid #343842;
+  border-radius: 6px;
+  background: #1d1f24;
+  color: #d6d9df;
+  cursor: pointer;
+  transition: border-color .15s, background .15s, color .15s, transform .15s;
+}
+.studio-icon-button:hover,
+.studio-action-grid button:hover,
+.studio-split-row button:hover,
+.studio-stepper-row button:hover,
+.studio-align-row button:hover,
+.studio-segmented button:hover,
+.studio-mini-fields button:hover,
+.studio-secondary-action:hover {
+  border-color: #4b91ff;
+  background: #242934;
+  color: #fff;
+}
+.studio-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 11px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.studio-button-blue {
+  color: #b8d4ff;
+  border-color: #315891;
+}
+.studio-button-danger {
+  width: 34px;
+  padding: 0;
+  color: #ff6b6b;
+  border-color: rgba(239,68,68,.45);
+}
+.studio-action-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+.studio-action-grid button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 38px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.studio-time-grid {
+  display: grid;
+  grid-template-columns: 1fr 22px 1fr;
+  align-items: end;
+  gap: 8px;
+}
+.studio-time-grid label,
+.studio-split-row,
+.studio-mini-fields label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #9aa1ad;
+  font-size: 11px;
+}
+.studio-time-grid label {
+  align-items: stretch;
+  flex-direction: column;
+}
+.studio-link-mark {
+  align-self: center;
+  color: #8a919d;
+  text-align: center;
+}
+.studio-time-grid input,
+.studio-split-row input,
+.studio-mini-fields input,
+.studio-select {
+  min-width: 0;
+  border: 1px solid #30343d;
+  border-radius: 6px;
+  background: #111215;
+  color: #f0f2f5;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  outline: none;
+}
+.studio-time-grid input {
+  height: 34px;
+  padding: 0 10px;
+}
+.studio-waveform-bar {
+  position: relative;
+  height: 58px;
+  margin-top: 12px;
+  overflow: hidden;
+  border: 1px solid #2f333b;
+  border-radius: 6px;
+  background: #101114;
+}
+.studio-waveform-texture {
+  position: absolute;
+  inset: 0;
+  opacity: .42;
+  background:
+    repeating-linear-gradient(90deg, rgba(255,255,255,.26) 0 2px, transparent 2px 6px),
+    linear-gradient(180deg, transparent 0 34%, rgba(255,255,255,.2) 35% 65%, transparent 66%);
+  clip-path: polygon(0 50%, 3% 32%, 6% 62%, 10% 44%, 14% 70%, 19% 25%, 24% 58%, 29% 36%, 35% 66%, 42% 29%, 49% 60%, 56% 40%, 63% 74%, 70% 28%, 76% 58%, 83% 35%, 90% 65%, 96% 42%, 100% 52%);
+}
+.studio-trim-selection {
+  position: absolute;
+  top: 7px;
+  bottom: 7px;
+  min-width: 18px;
+  border: 2px solid #ff9b2f;
+  border-radius: 6px;
+  background: rgba(184, 101, 25, .72);
+  box-shadow: 0 0 0 1px rgba(255,255,255,.18) inset, 0 0 18px rgba(255,139,29,.25);
+  cursor: grab;
+}
+.studio-trim-selection span {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 9px;
+  background: #fff;
+  cursor: ew-resize;
+}
+.studio-trim-selection span:first-child {
+  left: -2px;
+  border-radius: 5px 0 0 5px;
+}
+.studio-trim-selection span:last-child {
+  right: -2px;
+  border-radius: 0 5px 5px 0;
+}
+.studio-time-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
+  color: #858d9a;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.studio-speed-chip {
+  padding: 4px 13px;
+  font-size: 12px;
+}
+.studio-split-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  margin-top: 12px;
+}
+.studio-split-row input {
+  height: 32px;
+  padding: 0 9px;
+}
+.studio-split-row button {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+.studio-transform-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.studio-transform-group {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid #272b33;
+  border-radius: 7px;
+  background: rgba(0,0,0,.16);
+}
+.studio-transform-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  color: #c9ced7;
+  font-size: 12px;
+  font-weight: 700;
+}
+.studio-mini-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 6px;
+  margin-bottom: 9px;
+}
+.studio-mini-fields label {
+  min-width: 0;
+}
+.studio-mini-fields input {
+  width: 100%;
+  height: 30px;
+  padding: 0 7px;
+  text-align: right;
+}
+.studio-mini-fields button {
+  width: 30px;
+}
+.studio-transform-group input[type="range"],
+.studio-control-row input[type="range"] {
+  width: 100%;
+  accent-color: #4b91ff;
+}
+.studio-section-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+.studio-inspector-section {
+  overflow: hidden;
+}
+.studio-inspector-section-trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 40px;
+  padding: 0 12px;
+  border: 0;
+  background: transparent;
+  color: #d8dce3;
+  cursor: pointer;
+}
+.studio-inspector-section-title,
+.studio-inspector-section-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.studio-inspector-section-title {
+  font-size: 12px;
+  font-weight: 700;
+}
+.studio-inspector-section-summary {
+  color: #9aa1ad;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.studio-inspector-section-summary svg {
+  transition: transform .15s;
+}
+.studio-inspector-section-summary svg.is-open {
+  transform: rotate(90deg);
+}
+.studio-inspector-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 12px 12px;
+  border-top: 1px solid rgba(255,255,255,.05);
+}
+.studio-control-row {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr) 56px;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  color: #9aa1ad;
+  font-size: 11px;
+}
+.studio-value-pill {
+  padding: 4px 7px;
+  text-align: right;
+  font-size: 11px;
+}
+.studio-stepper-row,
+.studio-align-row,
+.studio-segmented {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+}
+.studio-stepper-row button,
+.studio-align-row button,
+.studio-segmented button {
+  min-height: 30px;
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+}
+.studio-stepper-row strong {
+  min-width: 44px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+.studio-select {
+  width: 100%;
+  height: 34px;
+  padding: 0 10px;
+}
+.studio-segmented button {
+  flex: 1;
+}
+.studio-segmented button.is-active {
+  border-color: #4b91ff;
+  background: rgba(75,145,255,.18);
+  color: #cfe2ff;
+}
+.studio-align-row button {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.studio-inspector-footer {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border-top: 1px solid #262a31;
+  background: linear-gradient(180deg, rgba(20,22,27,.92), #101113);
+  box-shadow: 0 -10px 28px rgba(0,0,0,.3);
+}
+.studio-primary-action,
+.studio-secondary-action {
+  height: 38px;
+  font-size: 12px;
+  font-weight: 800;
+}
+.studio-primary-action {
+  border-color: #4b91ff;
+  background: linear-gradient(180deg, #3177e6, #2459b8);
+  color: #fff;
+  box-shadow: 0 0 18px rgba(75,145,255,.22);
+}
+.studio-primary-action:hover {
+  transform: translateY(-1px);
+  background: linear-gradient(180deg, #438aff, #2d67cf);
+}
+.studio-save-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: center;
+  min-width: 82px;
+  height: 38px;
+  border: 1px solid #272b33;
+  border-radius: 6px;
+  background: #17191e;
+  color: #d6dbe3;
+  font-size: 12px;
+}
+.studio-save-status span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #22c55e;
+  box-shadow: 0 0 12px rgba(34,197,94,.58);
+}
+.studio-save-status.is-idle span,
+.studio-save-status.is-saving span {
+  background: #64748b;
+  box-shadow: 0 0 12px rgba(100,116,139,.42);
+}
+.studio-save-status.is-failed {
+  color: #fecaca;
+  border-color: rgba(239,68,68,.36);
+}
+.studio-save-status.is-failed span {
+  background: #ef4444;
+  box-shadow: 0 0 12px rgba(239,68,68,.58);
+}
+
+@media (max-width: 1180px) {
+  .studio-panel-tabs button {
+    font-size: 10px;
+  }
+  .studio-action-grid,
+  .studio-transform-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .studio-inspector-footer {
+    grid-template-columns: 1fr;
+  }
+}

--- a/dashboard/src/components/studio/BgmPanel.tsx
+++ b/dashboard/src/components/studio/BgmPanel.tsx
@@ -108,8 +108,8 @@ export const BgmPanel: React.FC = () => {
   };
 
   return (
-    <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <div className="studio-panel-content studio-panel-content-bgm" style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div className="studio-panel-header-card" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div style={{ fontSize: 10, fontWeight: 600, color: '#888', textTransform: 'uppercase' }}>
           BGM ({bgmClips.length})
         </div>
@@ -117,6 +117,7 @@ export const BgmPanel: React.FC = () => {
 
       {/* Upload area */}
       <div
+        className="studio-upload-card"
         onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
         onDragLeave={() => setDragOver(false)}
         onDrop={handleDrop}
@@ -144,15 +145,15 @@ export const BgmPanel: React.FC = () => {
       </div>
 
       {bgmClips.length === 0 && (
-        <div style={{ color: '#555', fontSize: 11, textAlign: 'center', padding: 8 }}>
+        <div className="studio-card" style={{ color: '#555', fontSize: 11, textAlign: 'center', padding: 8 }}>
           BGM 트랙 없음
         </div>
       )}
 
       {bgmClips.map((bgm, i) => (
-        <div key={bgm.id || i} style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 8, background: '#1a1a1a', borderRadius: 6, border: '1px solid #2a2a2a' }}>
+        <div key={bgm.id || i} className="studio-card studio-audio-card" style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 8, background: '#1a1a1a', borderRadius: 6, border: '1px solid #2a2a2a' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div style={{ fontSize: 10, color: '#a7f3d0', fontWeight: 600 }}>
+            <div className="studio-audio-title" style={{ fontSize: 10, color: '#a7f3d0', fontWeight: 600 }}>
               {bgm.source}
             </div>
             <button
@@ -238,9 +239,10 @@ export const BgmPanel: React.FC = () => {
 
           {/* Analyze results */}
           {activeAnalyzeIdx === i && analyzeResults.length > 0 && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 120, overflow: 'auto' }}>
+            <div className="studio-result-list" style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 120, overflow: 'auto' }}>
               {analyzeResults.map((result, ri) => (
                 <div
+                  className="studio-result-item"
                   key={ri}
                   onClick={() => applyAnalyzeResult(i, result)}
                   style={{

--- a/dashboard/src/components/studio/ClipPanel.tsx
+++ b/dashboard/src/components/studio/ClipPanel.tsx
@@ -1,9 +1,88 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  AlignCenter,
+  AlignEndHorizontal,
+  AlignStartHorizontal,
+  ChevronRight,
+  Copy,
+  Crop,
+  Film,
+  Maximize2,
+  Move,
+  RotateCcw,
+  RotateCw,
+  Scissors,
+  SlidersHorizontal,
+  Trash2,
+  Volume2,
+  VolumeX,
+  Zap,
+} from 'lucide-react';
 import { getEditorConfig } from '@/lib/editor-config';
 import { useEditorStore } from './store';
 import type { ClipZoom } from './types';
+
+type SectionKey = 'speed' | 'crop' | 'zoom' | 'position' | 'audio' | 'align';
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const formatShortTime = (seconds: number) => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+};
+
+const getFileName = (source: string) => source.split('/').pop() || source;
+
+interface InspectorSectionProps {
+  id: SectionKey;
+  icon: React.ReactNode;
+  title: string;
+  summary: string;
+  open: boolean;
+  onToggle: (id: SectionKey) => void;
+  children: React.ReactNode;
+}
+
+function InspectorSection({ id, icon, title, summary, open, onToggle, children }: InspectorSectionProps) {
+  return (
+    <section className="studio-inspector-section">
+      <button className="studio-inspector-section-trigger" onClick={() => onToggle(id)} type="button">
+        <span className="studio-inspector-section-title">
+          {icon}
+          {title}
+        </span>
+        <span className="studio-inspector-section-summary">
+          {summary}
+          <ChevronRight className={open ? 'is-open' : ''} size={15} />
+        </span>
+      </button>
+      {open && <div className="studio-inspector-section-body">{children}</div>}
+    </section>
+  );
+}
+
+interface SliderRowProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  unit?: string;
+  onChange: (value: number) => void;
+}
+
+function SliderRow({ label, value, min, max, step = 1, unit = '', onChange }: SliderRowProps) {
+  return (
+    <div className="studio-control-row">
+      <label>{label}</label>
+      <input type="range" min={min} max={max} step={step} value={value} onChange={(e) => onChange(Number(e.target.value))} />
+      <span className="studio-value-pill">{value}{unit}</span>
+    </div>
+  );
+}
 
 export const ClipPanel: React.FC = () => {
   const selectedClipIndex = useEditorStore((s) => s.selectedClipIndex);
@@ -14,22 +93,27 @@ export const ClipPanel: React.FC = () => {
   const updateClip = useEditorStore((s) => s.updateClip);
   const updateClipMeta = useEditorStore((s) => s.updateClipMeta);
   const setAllClipAudioMuted = useEditorStore((s) => s.setAllClipAudioMuted);
+  const copyClipSettingsToAll = useEditorStore((s) => s.copyClipSettingsToAll);
   const updateClipCrop = useEditorStore((s) => s.updateClipCrop);
   const updateClipZoom = useEditorStore((s) => s.updateClipZoom);
   const splitClip = useEditorStore((s) => s.splitClip);
   const removeClip = useEditorStore((s) => s.removeClip);
   const replaceClipSource = useEditorStore((s) => s.replaceClipSource);
+  const copyClip = useEditorStore((s) => s.copyClip);
+  const paste = useEditorStore((s) => s.paste);
+  const getProjectData = useEditorStore((s) => s.getProjectData);
 
   const [sourceDuration, setSourceDuration] = useState(0);
   const [splitTime, setSplitTime] = useState<number | null>(null);
-  const [showSpeed, setShowSpeed] = useState(false);
-  const [showCrop, setShowCrop] = useState(false);
-  const [showZoom, setShowZoom] = useState(false);
-  const [showOpacity, setShowOpacity] = useState(false);
-  const [showRotation, setShowRotation] = useState(false);
-  const [showAlign, setShowAlign] = useState(false);
-  const [showVolume, setShowVolume] = useState(false);
-  const [showPosition, setShowPosition] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'failed'>('idle');
+  const [openSections, setOpenSections] = useState<Record<SectionKey, boolean>>({
+    speed: false,
+    crop: false,
+    zoom: false,
+    position: false,
+    audio: false,
+    align: false,
+  });
   const barRef = useRef<HTMLDivElement>(null);
 
   const clip = selectedClipIndex >= 0 && selectedClipIndex < clips.length ? clips[selectedClipIndex] : null;
@@ -45,25 +129,20 @@ export const ClipPanel: React.FC = () => {
   const posX = meta.positionX ?? 50;
   const posY = meta.positionY ?? 50;
 
-  // 소스 영상 전체 길이 프로브
   useEffect(() => {
     if (!clip) return;
     fetch(`${getEditorConfig().apiUrl}/api/media/probe/${encodeURIComponent(clip.source)}`)
-      .then(r => r.json())
-      .then(d => setSourceDuration(d.duration || clip.end + 10))
+      .then((r) => r.json())
+      .then((d) => setSourceDuration(d.duration || clip.end + 10))
       .catch(() => setSourceDuration(clip.end + 10));
-  }, [clip?.source]);
-
-  const fmtTime = (s: number) => {
-    const m = Math.floor(s / 60);
-    const sec = Math.floor(s % 60);
-    return `${m}:${sec.toString().padStart(2, '0')}`;
-  };
+  }, [clip?.source, clip?.end]);
 
   if (!clip) {
     return (
-      <div style={{ padding: 12, color: '#555', fontSize: 11 }}>
-        타임라인에서 클립을 선택하세요
+      <div className="studio-inspector-empty">
+        <Film size={22} />
+        <strong>클립을 선택하세요</strong>
+        <span>타임라인에서 비디오 클립을 선택하면 속성 패널이 표시됩니다.</span>
       </div>
     );
   }
@@ -72,8 +151,10 @@ export const ClipPanel: React.FC = () => {
   const barTotal = sourceDuration || clip.end + 5;
   const barStartPct = (clip.start / barTotal) * 100;
   const barWidthPct = ((clip.end - clip.start) / barTotal) * 100;
+  const splitAt = splitTime ?? Number(((clip.start + clip.end) / 2).toFixed(1));
 
-  // 구간 바 드래그
+  const toggleSection = (id: SectionKey) => setOpenSections((prev) => ({ ...prev, [id]: !prev[id] }));
+
   const handleBarMouseDown = (e: React.MouseEvent, type: 'left' | 'right' | 'move') => {
     e.preventDefault();
     const bar = barRef.current;
@@ -87,514 +168,243 @@ export const ClipPanel: React.FC = () => {
       const dx = ev.clientX - startX;
       const dt = (dx / rect.width) * barTotal;
       if (type === 'left') {
-        updateClip(selectedClipIndex, { start: Math.max(0, Math.min(origEnd - 0.1, origStart + dt)) });
+        updateClip(selectedClipIndex, { start: clamp(origStart + dt, 0, origEnd - 0.1) });
       } else if (type === 'right') {
-        updateClip(selectedClipIndex, { end: Math.max(origStart + 0.1, Math.min(barTotal, origEnd + dt)) });
+        updateClip(selectedClipIndex, { end: clamp(origEnd + dt, origStart + 0.1, barTotal) });
       } else {
         const dur = origEnd - origStart;
-        const newStart = Math.max(0, Math.min(barTotal - dur, origStart + dt));
+        const newStart = clamp(origStart + dt, 0, barTotal - dur);
         updateClip(selectedClipIndex, { start: newStart, end: newStart + dur });
       }
     };
-    const onUp = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
   };
 
-  const btnStyle: React.CSSProperties = {
-    background: '#222', border: '1px solid #444', color: '#ddd',
-    borderRadius: 4, width: 24, height: 24, cursor: 'pointer',
-    fontSize: 10, display: 'flex', alignItems: 'center', justifyContent: 'center',
+  const handleReplaceSource = async () => {
+    try {
+      const r = await fetch(`${getEditorConfig().apiUrl}/api/resolver/pick-file`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: '영상' }),
+      });
+      if (!r.ok) return;
+      const d = await r.json();
+      if (!d.filepath) return;
+      const fname = d.filepath.split('/').pop() || 'video.mp4';
+      await fetch(`${getEditorConfig().apiUrl}/api/resolver/link-file`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: fname, filepath: d.filepath }),
+      });
+      let duration = 10;
+      try {
+        const pr = await fetch(`${getEditorConfig().apiUrl}/api/media/probe/${encodeURIComponent(fname)}`);
+        if (pr.ok) {
+          const pd = await pr.json();
+          duration = pd.duration || 10;
+        }
+      } catch {}
+      replaceClipSource(selectedClipIndex, fname, duration);
+    } catch {}
+  };
+
+  const duplicateSelectedClip = () => {
+    copyClip();
+    paste();
+  };
+
+  const resetSelectedClip = () => {
+    updateClipMeta(selectedClipIndex, { speed: 1, opacity: 100, rotation: 0, volume: 100, audioMuted: false, fitMode: 'cover', positionX: 50, positionY: 50 });
+    updateClipCrop(selectedClipIndex, { x: 0, y: 0, w: 100, h: 100 });
+    updateClipZoom(selectedClipIndex, { scale: 1, panX: 0, panY: 0, animation: 'none', scaleEnd: undefined, panXEnd: undefined, panYEnd: undefined });
+  };
+
+  const saveProject = async () => {
+    setSaveStatus('saving');
+    try {
+      const r = await fetch(`${getEditorConfig().apiUrl}/api/projects/save`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(getProjectData()),
+      });
+      setSaveStatus(r.ok ? 'saved' : 'failed');
+    } catch {
+      setSaveStatus('failed');
+    }
   };
 
   return (
-    <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
-      {/* 헤더 */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ fontSize: 10, fontWeight: 600, color: '#888' }}>📎 #{selectedClipIndex + 1} / {clips.length}</span>
-        <button
-          onClick={() => removeClip(selectedClipIndex)}
-          style={{ background: 'none', border: 'none', color: '#ef4444', cursor: 'pointer', fontSize: 11 }}
-        >🗑</button>
-      </div>
-
-      {/* 소스 + 변경 */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        <span style={{ fontSize: 9, color: '#666' }}>소스</span>
-        <span style={{ flex: 1, fontSize: 10, color: '#ccc', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{clip.source}</span>
-        <button
-          onClick={async () => {
-            try {
-              const r = await fetch(`${getEditorConfig().apiUrl}/api/resolver/pick-file`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ filename: '영상' }),
-              });
-              if (!r.ok) return;
-              const d = await r.json();
-              if (!d.filepath) return;
-              const fname = d.filepath.split('/').pop() || 'video.mp4';
-              await fetch(`${getEditorConfig().apiUrl}/api/resolver/link-file`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ filename: fname, filepath: d.filepath }),
-              });
-              let duration = 10;
-              try {
-                const pr = await fetch(`${getEditorConfig().apiUrl}/api/media/probe/${encodeURIComponent(fname)}`);
-                if (pr.ok) { const pd = await pr.json(); duration = pd.duration || 10; }
-              } catch {}
-              replaceClipSource(selectedClipIndex, fname, duration);
-            } catch {}
-          }}
-          style={{ background: '#1a1a1a', border: '1px solid #444', color: '#60a5fa', borderRadius: 4, padding: '2px 6px', cursor: 'pointer', fontSize: 9, whiteSpace: 'nowrap' }}
-        >🔄 변경</button>
-      </div>
-
-      {/* 시작/끝 입력 */}
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <span style={{ fontSize: 9, color: '#666', width: 24 }}>시작</span>
-        <input
-          type="number" min={0} max={clip.end - 0.1} step={0.1} value={Number(clip.start.toFixed(1))}
-          onChange={(e) => updateClip(selectedClipIndex, { start: Math.max(0, Math.min(clip.end - 0.1, Number(e.target.value))) })}
-          style={{ flex: 1, background: '#1a1a1a', border: '1px solid #333', color: '#ddd', padding: '5px 8px', borderRadius: 4, fontSize: 11 }}
-        />
-        <span style={{ fontSize: 9, color: '#666', width: 16 }}>끝</span>
-        <input
-          type="number" min={clip.start + 0.1} step={0.1} value={Number(clip.end.toFixed(1))}
-          onChange={(e) => updateClip(selectedClipIndex, { end: Math.max(clip.start + 0.1, Number(e.target.value)) })}
-          style={{ flex: 1, background: '#1a1a1a', border: '1px solid #333', color: '#ddd', padding: '5px 8px', borderRadius: 4, fontSize: 11 }}
-        />
-      </div>
-
-      {/* 시각적 구간 바 */}
-      <div
-        ref={barRef}
-        style={{ position: 'relative', height: 32, background: '#222', borderRadius: 4, overflow: 'hidden', cursor: 'default' }}
-      >
-        <div
-          onMouseDown={(e) => handleBarMouseDown(e, 'move')}
-          style={{
-            position: 'absolute',
-            left: `${barStartPct}%`,
-            width: `${barWidthPct}%`,
-            top: 0, bottom: 0,
-            background: 'linear-gradient(135deg, #c2742f, #e8954a)',
-            borderRadius: 4,
-            cursor: 'grab',
-            border: '2px solid #e8954a',
-            minWidth: 8,
-          }}
-        >
-          <div
-            onMouseDown={(e) => { e.stopPropagation(); handleBarMouseDown(e, 'left'); }}
-            style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: 8, cursor: 'ew-resize', background: 'rgba(255,255,255,0.3)', borderRadius: '4px 0 0 4px' }}
-          />
-          <div
-            onMouseDown={(e) => { e.stopPropagation(); handleBarMouseDown(e, 'right'); }}
-            style={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 8, cursor: 'ew-resize', background: 'rgba(255,255,255,0.3)', borderRadius: '0 4px 4px 0' }}
-          />
-        </div>
-      </div>
-
-      {/* 타임코드 */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9, color: '#666' }}>
-        <span>{fmtTime(clip.start)}</span>
-        <span>{meta.speed}x</span>
-        <span>{fmtTime(sourceDuration)}</span>
-      </div>
-
-      {/* 길이 표시 */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 10 }}>
-        <span style={{ color: '#666' }}>길이</span>
-        <span style={{ color: '#ddd', fontWeight: 600 }}>{clipDuration.toFixed(1)}s</span>
-      </div>
-
-      {/* 블레이드 */}
-      <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-        <span style={{ fontSize: 9, color: '#666', whiteSpace: 'nowrap' }}>분할 지점</span>
-        <input
-          type="number"
-          min={clip.start + 0.1}
-          max={clip.end - 0.1}
-          step={0.1}
-          value={splitTime ?? Number(((clip.start + clip.end) / 2).toFixed(1))}
-          onChange={(e) => setSplitTime(Number(e.target.value))}
-          style={{ flex: 1, background: '#1a1a1a', border: '1px solid #333', color: '#ddd', padding: '4px 6px', borderRadius: 4, fontSize: 10 }}
-        />
-        <span style={{ fontSize: 8, color: '#555' }}>s</span>
-      </div>
-      <button
-        onClick={() => {
-          const t = splitTime ?? (clip.start + clip.end) / 2;
-          splitClip(selectedClipIndex, t);
-          setSplitTime(null);
-        }}
-        style={{ width: '100%', padding: '5px 0', background: '#1a1a1a', border: '1px solid #333', color: '#ddd', borderRadius: 4, fontSize: 10, cursor: 'pointer' }}
-      >✂️ 클립 분할</button>
-
-      {/* 속도 (접이식) */}
-      <div
-        onClick={() => setShowSpeed(!showSpeed)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showSpeed ? '▼' : '▶'}</span> ⚡ 속도
-      </div>
-      {showSpeed && (
-        <div style={{ paddingLeft: 8 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 10 }}>
-            <button onClick={() => updateClipMeta(selectedClipIndex, { speed: Math.max(0.25, meta.speed - 0.25) })}
-              style={{ background: '#222', border: '1px solid #444', color: '#ddd', borderRadius: 4, width: 24, height: 24, cursor: 'pointer', fontSize: 12 }}>−</button>
-            <span style={{ color: '#ddd', minWidth: 24, textAlign: 'center' }}>{meta.speed}x</span>
-            <button onClick={() => updateClipMeta(selectedClipIndex, { speed: Math.min(4, meta.speed + 0.25) })}
-              style={{ background: '#222', border: '1px solid #444', color: '#ddd', borderRadius: 4, width: 24, height: 24, cursor: 'pointer', fontSize: 12 }}>+</button>
-            <button onClick={() => updateClipMeta(selectedClipIndex, { speed: 1 })}
-              style={{ background: '#222', border: '1px solid #444', color: '#888', borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontSize: 9 }}>맞춤</button>
+    <div className="studio-inspector-shell">
+      <div className="studio-inspector-scroll">
+        <section className="studio-clip-hero-card">
+          <div className="studio-clip-icon"><Film size={28} /></div>
+          <div className="studio-clip-title-block">
+            <span>클립 {selectedClipIndex + 1} / {clips.length}</span>
+            <strong title={clip.source}>{getFileName(clip.source)}</strong>
           </div>
-        </div>
-      )}
+          <span className="studio-duration-badge">{clipDuration.toFixed(1)}s</span>
+          <button className="studio-icon-button studio-button-blue" onClick={handleReplaceSource} type="button">변경</button>
+          <button className="studio-icon-button studio-button-danger" onClick={() => removeClip(selectedClipIndex)} type="button" aria-label="클립 삭제">
+            <Trash2 size={15} />
+          </button>
+        </section>
 
-      {/* 크롭 (접이식) */}
-      <div
-        onClick={() => setShowCrop(!showCrop)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showCrop ? '▼' : '▶'}</span> 🔲 크롭
-      </div>
-      {showCrop && (
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, paddingLeft: 8 }}>
-          {(['x', 'y', 'w', 'h'] as const).map((key) => (
-            <div key={key}>
-              <label style={{ fontSize: 9, color: '#555' }}>{key.toUpperCase()}: {crop[key]}%</label>
-              <input type="range" min={0} max={100} value={crop[key]}
-                onChange={(e) => updateClipCrop(selectedClipIndex, { [key]: Number(e.target.value) })}
-                style={{ width: '100%', accentColor: '#2563eb' }} />
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* 줌 (접이식) */}
-      <div
-        onClick={() => setShowZoom(!showZoom)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showZoom ? '▼' : '▶'}</span> 🔍 줌
-      </div>
-      {showZoom && (
-        <div style={{ paddingLeft: 8, display: 'flex', flexDirection: 'column', gap: 4 }}>
-          {/* 줌 애니메이션 프리셋 */}
-          <div>
-            <label style={{ fontSize: 9, color: '#555' }}>🎬 줌 애니메이션</label>
-            <select
-              value={zoom.animation || 'none'}
-              onChange={(e) => updateClipZoom(selectedClipIndex, { animation: e.target.value as ClipZoom['animation'] })}
-              className="filter-select"
-              style={{ width: '100%', marginTop: 2 }}
-            >
-              <option value="none">없음 (정적)</option>
-              <option value="zoomIn">줌 인 (확대)</option>
-              <option value="zoomOut">줌 아웃 (축소)</option>
-              <option value="panLeft">팬 ← (왼쪽 이동)</option>
-              <option value="panRight">팬 → (오른쪽 이동)</option>
-              <option value="panUp">팬 ↑ (위로 이동)</option>
-              <option value="panDown">팬 ↓ (아래로 이동)</option>
-              <option value="custom">커스텀 (시작→끝 직접 설정)</option>
-            </select>
+        <section className="studio-card">
+          <h3>빠른 작업</h3>
+          <div className="studio-action-grid">
+            <button type="button" onClick={() => splitClip(selectedClipIndex, splitAt)}><Scissors size={15} />분할</button>
+            <button type="button" onClick={duplicateSelectedClip}><Copy size={15} />복제</button>
+            <button type="button" onClick={() => updateClipMeta(selectedClipIndex, { audioMuted: !isAudioMuted })}>{isAudioMuted ? <Volume2 size={15} /> : <VolumeX size={15} />}{isAudioMuted ? '오디오 켜기' : '오디오 끄기'}</button>
+            <button type="button" onClick={resetSelectedClip}><RotateCcw size={15} />리셋</button>
           </div>
-          {zoom.animation && zoom.animation !== 'none' && zoom.animation !== 'custom' && (
-            <div style={{ fontSize: 9, color: '#7c3aed', padding: '2px 0' }}>
-              ✓ {
-                { zoomIn: '줌 인 — 재생하면서 점점 확대', zoomOut: '줌 아웃 — 재생하면서 점점 축소',
-                  panLeft: '왼쪽 팬 — 오른쪽→왼쪽 이동', panRight: '오른쪽 팬 — 왼쪽→오른쪽 이동',
-                  panUp: '위로 팬 — 아래→위 이동', panDown: '아래로 팬 — 위→아래 이동',
-                }[zoom.animation]
-              }
+        </section>
+
+        <section className="studio-card studio-trim-card">
+          <h3>구간 편집</h3>
+          <div className="studio-time-grid">
+            <label>
+              <span>시작</span>
+              <input type="number" min={0} max={clip.end - 0.1} step={0.1} value={Number(clip.start.toFixed(1))} onChange={(e) => updateClip(selectedClipIndex, { start: clamp(Number(e.target.value), 0, clip.end - 0.1) })} />
+            </label>
+            <span className="studio-link-mark">⌁</span>
+            <label>
+              <span>종료</span>
+              <input type="number" min={clip.start + 0.1} step={0.1} value={Number(clip.end.toFixed(1))} onChange={(e) => updateClip(selectedClipIndex, { end: Math.max(clip.start + 0.1, Number(e.target.value)) })} />
+            </label>
+          </div>
+          <div className="studio-waveform-bar" ref={barRef}>
+            <div className="studio-waveform-texture" />
+            <div className="studio-trim-selection" onMouseDown={(e) => handleBarMouseDown(e, 'move')} style={{ left: `${barStartPct}%`, width: `${barWidthPct}%` }}>
+              <span onMouseDown={(e) => { e.stopPropagation(); handleBarMouseDown(e, 'left'); }} />
+              <span onMouseDown={(e) => { e.stopPropagation(); handleBarMouseDown(e, 'right'); }} />
             </div>
-          )}
-          {zoom.animation === 'custom' && (
-            <div style={{ background: '#1a1a1a', border: '1px solid #333', borderRadius: 4, padding: 6, display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <span style={{ fontSize: 8, color: '#666' }}>시작 → 끝 값 (클립 재생 동안 보간)</span>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 4 }}>
-                <div>
-                  <label style={{ fontSize: 8, color: '#555' }}>Scale 시작: {zoom.scale.toFixed(1)}</label>
-                  <input type="range" min={0.5} max={3} step={0.1} value={zoom.scale}
-                    onChange={(e) => updateClipZoom(selectedClipIndex, { scale: Number(e.target.value) })}
-                    style={{ width: '100%', accentColor: '#7c3aed' }} />
-                </div>
-                <div>
-                  <label style={{ fontSize: 8, color: '#555' }}>Scale 끝: {(zoom.scaleEnd ?? zoom.scale).toFixed(1)}</label>
-                  <input type="range" min={0.5} max={3} step={0.1} value={zoom.scaleEnd ?? zoom.scale}
-                    onChange={(e) => updateClipZoom(selectedClipIndex, { scaleEnd: Number(e.target.value) })}
-                    style={{ width: '100%', accentColor: '#7c3aed' }} />
-                </div>
-                <div>
-                  <label style={{ fontSize: 8, color: '#555' }}>PanX 시작: {zoom.panX}%</label>
-                  <input type="range" min={-50} max={50} value={zoom.panX}
-                    onChange={(e) => updateClipZoom(selectedClipIndex, { panX: Number(e.target.value) })}
-                    style={{ width: '100%', accentColor: '#7c3aed' }} />
-                </div>
-                <div>
-                  <label style={{ fontSize: 8, color: '#555' }}>PanX 끝: {(zoom.panXEnd ?? zoom.panX)}%</label>
-                  <input type="range" min={-50} max={50} value={zoom.panXEnd ?? zoom.panX}
-                    onChange={(e) => updateClipZoom(selectedClipIndex, { panXEnd: Number(e.target.value) })}
-                    style={{ width: '100%', accentColor: '#7c3aed' }} />
-                </div>
-                <div>
-                  <label style={{ fontSize: 8, color: '#555' }}>PanY 시작: {zoom.panY}%</label>
-                  <input type="range" min={-50} max={50} value={zoom.panY}
-                    onChange={(e) => updateClipZoom(selectedClipIndex, { panY: Number(e.target.value) })}
-                    style={{ width: '100%', accentColor: '#7c3aed' }} />
-                </div>
-                <div>
-                  <label style={{ fontSize: 8, color: '#555' }}>PanY 끝: {(zoom.panYEnd ?? zoom.panY)}%</label>
-                  <input type="range" min={-50} max={50} value={zoom.panYEnd ?? zoom.panY}
-                    onChange={(e) => updateClipZoom(selectedClipIndex, { panYEnd: Number(e.target.value) })}
-                    style={{ width: '100%', accentColor: '#7c3aed' }} />
-                </div>
+          </div>
+          <div className="studio-time-footer">
+            <span>{formatShortTime(clip.start)}</span>
+            <span className="studio-speed-chip">{meta.speed}x</span>
+            <span>{formatShortTime(sourceDuration)}</span>
+          </div>
+          <div className="studio-split-row">
+            <label>분할 지점</label>
+            <input type="number" min={clip.start + 0.1} max={clip.end - 0.1} step={0.1} value={splitAt} onChange={(e) => setSplitTime(Number(e.target.value))} />
+            <button type="button" onClick={() => { splitClip(selectedClipIndex, splitAt); setSplitTime(null); }}>분할</button>
+          </div>
+        </section>
+
+        <section className="studio-card studio-transform-card">
+          <h3>변형 (Transform)</h3>
+          <div className="studio-transform-grid">
+            <div className="studio-transform-group">
+              <div className="studio-transform-heading"><Move size={14} />위치</div>
+              <div className="studio-mini-fields">
+                <label>X<input type="number" value={posX} onChange={(e) => updateClipMeta(selectedClipIndex, { positionX: clamp(Number(e.target.value), 0, 100) })} /></label>
+                <label>Y<input type="number" value={posY} onChange={(e) => updateClipMeta(selectedClipIndex, { positionY: clamp(Number(e.target.value), 0, 100) })} /></label>
+                <button type="button" onClick={() => updateClipMeta(selectedClipIndex, { positionX: 50, positionY: 50 })}><RotateCcw size={13} /></button>
               </div>
+              <input type="range" min={0} max={100} value={posX} onChange={(e) => updateClipMeta(selectedClipIndex, { positionX: Number(e.target.value) })} />
             </div>
-          )}
-          <div style={{ borderTop: '1px solid #2a2a2a', paddingTop: 4 }}>
-            <label style={{ fontSize: 9, color: '#555' }}>기본 Scale: {zoom.scale.toFixed(1)}</label>
-            <input type="range" min={0.5} max={3} step={0.1} value={zoom.scale}
-              onChange={(e) => updateClipZoom(selectedClipIndex, { scale: Number(e.target.value) })}
-              style={{ width: '100%', accentColor: '#2563eb' }} />
+            <div className="studio-transform-group">
+              <div className="studio-transform-heading"><RotateCw size={14} />회전</div>
+              <div className="studio-mini-fields">
+                <label><input type="number" min={-360} max={360} value={rotation} onChange={(e) => updateClipMeta(selectedClipIndex, { rotation: clamp(Number(e.target.value), -360, 360) })} />°</label>
+                <button type="button" onClick={() => updateClipMeta(selectedClipIndex, { rotation: 0 })}><RotateCcw size={13} /></button>
+              </div>
+              <input type="range" min={-360} max={360} value={rotation} onChange={(e) => updateClipMeta(selectedClipIndex, { rotation: Number(e.target.value) })} />
+            </div>
+            <div className="studio-transform-group">
+              <div className="studio-transform-heading"><Maximize2 size={14} />크기</div>
+              <div className="studio-mini-fields">
+                <label>W<input type="number" value={Number((zoom.scale * 100).toFixed(0))} onChange={(e) => updateClipZoom(selectedClipIndex, { scale: clamp(Number(e.target.value) / 100, 0.5, 3) })} /></label>
+                <label>H<input type="number" value={Number((zoom.scale * 100).toFixed(0))} onChange={(e) => updateClipZoom(selectedClipIndex, { scale: clamp(Number(e.target.value) / 100, 0.5, 3) })} /></label>
+              </div>
+              <input type="range" min={0.5} max={3} step={0.1} value={zoom.scale} onChange={(e) => updateClipZoom(selectedClipIndex, { scale: Number(e.target.value) })} />
+            </div>
+            <div className="studio-transform-group">
+              <div className="studio-transform-heading"><SlidersHorizontal size={14} />불투명도</div>
+              <div className="studio-mini-fields"><label><input type="number" value={opacity} onChange={(e) => updateClipMeta(selectedClipIndex, { opacity: clamp(Number(e.target.value), 0, 100) })} />%</label></div>
+              <input type="range" min={0} max={100} value={opacity} onChange={(e) => updateClipMeta(selectedClipIndex, { opacity: Number(e.target.value) })} />
+            </div>
           </div>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6 }}>
-            <div>
-              <label style={{ fontSize: 9, color: '#555' }}>Pan X: {zoom.panX}%</label>
-              <input type="range" min={-50} max={50} value={zoom.panX}
-                onChange={(e) => updateClipZoom(selectedClipIndex, { panX: Number(e.target.value) })}
-                style={{ width: '100%', accentColor: '#2563eb' }} />
-            </div>
-            <div>
-              <label style={{ fontSize: 9, color: '#555' }}>Pan Y: {zoom.panY}%</label>
-              <input type="range" min={-50} max={50} value={zoom.panY}
-                onChange={(e) => updateClipZoom(selectedClipIndex, { panY: Number(e.target.value) })}
-                style={{ width: '100%', accentColor: '#2563eb' }} />
-            </div>
-          </div>
-        </div>
-      )}
+        </section>
 
-      {/* Clip Position (가로 영상 위치 조절, 접이식) */}
-      <div
-        onClick={() => setShowPosition(!showPosition)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showPosition ? '▼' : '▶'}</span> 🎯 영상 위치
-      </div>
-      {showPosition && (
-        <div style={{ paddingLeft: 8 }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 8 }}>
-            <span style={{ fontSize: 9, color: '#666' }}>세로 화면 배치 방식</span>
-            <div style={{ display: 'flex', gap: 4 }}>
-              <button
-                onClick={() => updateClipMeta(selectedClipIndex, { fitMode: 'cover', positionX: 50, positionY: 50 })}
-                style={{ flex: 1, background: fitMode === 'cover' ? '#2563eb' : '#222', border: '1px solid #444', color: fitMode === 'cover' ? '#fff' : '#888', borderRadius: 4, padding: '4px 6px', cursor: 'pointer', fontSize: 9 }}
-              >
-                1. 세로 채우기
-              </button>
-              <button
-                onClick={() => updateClipMeta(selectedClipIndex, { fitMode: 'contain', positionX: 50, positionY: 50 })}
-                style={{ flex: 1, background: fitMode === 'contain' ? '#2563eb' : '#222', border: '1px solid #444', color: fitMode === 'contain' ? '#fff' : '#888', borderRadius: 4, padding: '4px 6px', cursor: 'pointer', fontSize: 9 }}
-              >
-                2. 가로 맞춤
-              </button>
+        <div className="studio-section-stack">
+          <InspectorSection id="speed" icon={<Zap size={15} />} title="속도" summary={`${meta.speed}x`} open={openSections.speed} onToggle={toggleSection}>
+            <div className="studio-stepper-row">
+              <button onClick={() => updateClipMeta(selectedClipIndex, { speed: Math.max(0.25, meta.speed - 0.25) })}>−</button>
+              <strong>{meta.speed}x</strong>
+              <button onClick={() => updateClipMeta(selectedClipIndex, { speed: Math.min(4, meta.speed + 0.25) })}>+</button>
+              <button onClick={() => updateClipMeta(selectedClipIndex, { speed: 1 })}>기본값</button>
             </div>
-            <div style={{ fontSize: 8, color: '#666', lineHeight: 1.4 }}>
-              {fitMode === 'contain'
-                ? '가로 길이 기준으로 중앙 표시, 위아래 검은 여백'
-                : '세로 길이 기준으로 꽉 채우기, 좌우 크롭'}
+          </InspectorSection>
+
+          <InspectorSection id="crop" icon={<Crop size={15} />} title="크롭" summary={crop.w === 100 && crop.h === 100 ? '없음' : `${crop.w}×${crop.h}%`} open={openSections.crop} onToggle={toggleSection}>
+            <div className="studio-crop-grid">
+              {(['x', 'y', 'w', 'h'] as const).map((key) => (
+                <SliderRow key={key} label={key.toUpperCase()} min={0} max={100} value={crop[key]} unit="%" onChange={(value) => updateClipCrop(selectedClipIndex, { [key]: value })} />
+              ))}
             </div>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-            <span style={{ fontSize: 9, color: '#888', minWidth: 20 }}>좌우</span>
-            <input type="range" min={0} max={100} step={1} value={posX}
-              onChange={(e) => updateClipMeta(selectedClipIndex, { positionX: Number(e.target.value) })}
-              style={{ flex: 1, accentColor: '#2563eb' }} />
-            <span style={{ fontSize: 10, color: '#ddd', minWidth: 30, textAlign: 'right' }}>{posX}%</span>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-            <span style={{ fontSize: 9, color: '#888', minWidth: 20 }}>상하</span>
-            <input type="range" min={0} max={100} step={1} value={posY}
-              onChange={(e) => updateClipMeta(selectedClipIndex, { positionY: Number(e.target.value) })}
-              style={{ flex: 1, accentColor: '#2563eb' }} />
-            <span style={{ fontSize: 10, color: '#ddd', minWidth: 30, textAlign: 'right' }}>{posY}%</span>
-          </div>
-          <div style={{ display: 'flex', gap: 4 }}>
-            <button
-              onClick={() => updateClipMeta(selectedClipIndex, { positionX: 0 })}
-              style={{ background: posX === 0 ? '#2563eb' : '#222', border: '1px solid #444', color: posX === 0 ? '#fff' : '#888', borderRadius: 4, padding: '2px 6px', cursor: 'pointer', fontSize: 9 }}
-            >◀ 왼쪽</button>
-            <button
-              onClick={() => updateClipMeta(selectedClipIndex, { positionX: 50, positionY: 50 })}
-              style={{ background: (posX === 50 && posY === 50) ? '#2563eb' : '#222', border: '1px solid #444', color: (posX === 50 && posY === 50) ? '#fff' : '#888', borderRadius: 4, padding: '2px 6px', cursor: 'pointer', fontSize: 9 }}
-            >● 가운데</button>
-            <button
-              onClick={() => updateClipMeta(selectedClipIndex, { positionX: 100 })}
-              style={{ background: posX === 100 ? '#2563eb' : '#222', border: '1px solid #444', color: posX === 100 ? '#fff' : '#888', borderRadius: 4, padding: '2px 6px', cursor: 'pointer', fontSize: 9 }}
-            >▶ 오른쪽</button>
-          </div>
-        </div>
-      )}
+          </InspectorSection>
 
-      {/* Clip Audio Volume (접이식) */}
-      <div
-        onClick={() => setShowVolume(!showVolume)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showVolume ? '▼' : '▶'}</span> 🔊 영상 소리
-      </div>
-      {showVolume && (
-        <div style={{ paddingLeft: 8 }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 6 }}>
-            <span style={{ fontSize: 9, color: '#666' }}>클립 오디오</span>
-            <button
-              onClick={() => updateClipMeta(selectedClipIndex, { audioMuted: !isAudioMuted })}
-              style={{
-                background: isAudioMuted ? '#3a1a1a' : '#1a3a2a',
-                border: `1px solid ${isAudioMuted ? '#ef4444' : '#10b981'}`,
-                color: isAudioMuted ? '#fca5a5' : '#a7f3d0',
-                borderRadius: 4,
-                padding: '2px 8px',
-                cursor: 'pointer',
-                fontSize: 9,
-              }}
-            >
-              {isAudioMuted ? '🔇 꺼짐' : '🔊 켜짐'}
-            </button>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, opacity: isAudioMuted ? 0.45 : 1 }}>
-            <input type="range" min={0} max={100} step={1} value={clipVolume}
-              onChange={(e) => updateClipMeta(selectedClipIndex, { volume: Number(e.target.value), audioMuted: false })}
-              style={{ flex: 1, accentColor: '#2563eb' }} />
-            <span style={{ fontSize: 10, color: '#ddd', minWidth: 30, textAlign: 'right' }}>{clipVolume}%</span>
-          </div>
-          <div style={{ display: 'flex', gap: 4, marginTop: 4 }}>
-            <button
-              onClick={() => updateClipMeta(selectedClipIndex, { audioMuted: true })}
-              style={{ background: isAudioMuted ? '#2563eb' : '#222', border: '1px solid #444', color: isAudioMuted ? '#fff' : '#888', borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontSize: 9 }}
-            >🔇 음소거</button>
-            <button
-              onClick={() => updateClipMeta(selectedClipIndex, { volume: 100, audioMuted: false })}
-              style={{ background: '#222', border: '1px solid #444', color: '#888', borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontSize: 9 }}
-            >↺ 초기화</button>
-          </div>
-          <div style={{ display: 'flex', gap: 4, marginTop: 6 }}>
-            <button
-              onClick={() => setAllClipAudioMuted(true)}
-              style={{ flex: 1, background: allClipAudioMuted ? '#2563eb' : '#222', border: '1px solid #444', color: allClipAudioMuted ? '#fff' : '#888', borderRadius: 4, padding: '3px 8px', cursor: 'pointer', fontSize: 9 }}
-            >
-              전체 음소거
-            </button>
-            <button
-              onClick={() => setAllClipAudioMuted(false)}
-              style={{ flex: 1, background: !allClipAudioMuted ? '#2563eb' : '#222', border: '1px solid #444', color: !allClipAudioMuted ? '#fff' : '#888', borderRadius: 4, padding: '3px 8px', cursor: 'pointer', fontSize: 9 }}
-            >
-              전체 켜기
-            </button>
-          </div>
-        </div>
-      )}
+          <InspectorSection id="zoom" icon={<Maximize2 size={15} />} title="줌 애니메이션" summary={zoom.animation && zoom.animation !== 'none' ? zoom.animation : '없음'} open={openSections.zoom} onToggle={toggleSection}>
+            <select className="studio-select" value={zoom.animation || 'none'} onChange={(e) => updateClipZoom(selectedClipIndex, { animation: e.target.value as ClipZoom['animation'] })}>
+              <option value="none">없음 (정적)</option>
+              <option value="zoomIn">줌 인</option>
+              <option value="zoomOut">줌 아웃</option>
+              <option value="panLeft">팬 왼쪽</option>
+              <option value="panRight">팬 오른쪽</option>
+              <option value="panUp">팬 위</option>
+              <option value="panDown">팬 아래</option>
+              <option value="custom">커스텀</option>
+            </select>
+            <SliderRow label="Scale" min={0.5} max={3} step={0.1} value={Number(zoom.scale.toFixed(1))} onChange={(value) => updateClipZoom(selectedClipIndex, { scale: value })} />
+            <SliderRow label="Pan X" min={-50} max={50} value={zoom.panX} unit="%" onChange={(value) => updateClipZoom(selectedClipIndex, { panX: value })} />
+            <SliderRow label="Pan Y" min={-50} max={50} value={zoom.panY} unit="%" onChange={(value) => updateClipZoom(selectedClipIndex, { panY: value })} />
+          </InspectorSection>
 
-      {/* Feature 9: Opacity (접이식) */}
-      <div
-        onClick={() => setShowOpacity(!showOpacity)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showOpacity ? '▼' : '▶'}</span> 🔆 불투명도
-      </div>
-      {showOpacity && (
-        <div style={{ paddingLeft: 8 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <input type="range" min={0} max={100} step={1} value={opacity}
-              onChange={(e) => updateClipMeta(selectedClipIndex, { opacity: Number(e.target.value) })}
-              style={{ flex: 1, accentColor: '#2563eb' }} />
-            <span style={{ fontSize: 10, color: '#ddd', minWidth: 30, textAlign: 'right' }}>{opacity}%</span>
-          </div>
-        </div>
-      )}
-
-      {/* Feature 9: Rotation (접이식) */}
-      <div
-        onClick={() => setShowRotation(!showRotation)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showRotation ? '▼' : '▶'}</span> 🔄 회전
-      </div>
-      {showRotation && (
-        <div style={{ paddingLeft: 8 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <input type="range" min={-360} max={360} step={1} value={rotation}
-              onChange={(e) => updateClipMeta(selectedClipIndex, { rotation: Number(e.target.value) })}
-              style={{ flex: 1, accentColor: '#2563eb' }} />
-            <input
-              type="number" min={-360} max={360} step={1} value={rotation}
-              onChange={(e) => updateClipMeta(selectedClipIndex, { rotation: Math.max(-360, Math.min(360, Number(e.target.value))) })}
-              style={{ width: 50, background: '#1a1a1a', border: '1px solid #333', color: '#ddd', padding: '3px 6px', borderRadius: 4, fontSize: 10, textAlign: 'right' }}
-            />
-            <span style={{ fontSize: 9, color: '#666' }}>°</span>
-          </div>
-          <button
-            onClick={() => updateClipMeta(selectedClipIndex, { rotation: 0 })}
-            style={{ marginTop: 4, background: '#222', border: '1px solid #444', color: '#888', borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontSize: 9 }}
-          >초기화</button>
-        </div>
-      )}
-
-      {/* Feature 10: Alignment (접이식) */}
-      <div
-        onClick={() => setShowAlign(!showAlign)}
-        style={{ fontSize: 10, color: '#888', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}
-      >
-        <span style={{ fontSize: 8 }}>{showAlign ? '▼' : '▶'}</span> 📐 정렬
-      </div>
-      {showAlign && (
-        <div style={{ paddingLeft: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <div>
-            <span style={{ fontSize: 9, color: '#555', display: 'block', marginBottom: 4 }}>가로 정렬</span>
-            <div style={{ display: 'flex', gap: 4 }}>
-              <button
-                onClick={() => updateClipZoom(selectedClipIndex, { panX: -50 + (50 / zoom.scale) })}
-                style={btnStyle}
-                title="왼쪽 정렬"
-              >◀</button>
-              <button
-                onClick={() => updateClipZoom(selectedClipIndex, { panX: 0 })}
-                style={btnStyle}
-                title="가운데 정렬"
-              >◆</button>
-              <button
-                onClick={() => updateClipZoom(selectedClipIndex, { panX: 50 - (50 / zoom.scale) })}
-                style={btnStyle}
-                title="오른쪽 정렬"
-              >▶</button>
+          <InspectorSection id="position" icon={<Move size={15} />} title="영상 위치" summary={fitMode === 'contain' ? '가로 맞춤' : '세로 채우기'} open={openSections.position} onToggle={toggleSection}>
+            <div className="studio-segmented">
+              <button className={fitMode === 'cover' ? 'is-active' : ''} onClick={() => updateClipMeta(selectedClipIndex, { fitMode: 'cover', positionX: 50, positionY: 50 })}>세로 채우기</button>
+              <button className={fitMode === 'contain' ? 'is-active' : ''} onClick={() => updateClipMeta(selectedClipIndex, { fitMode: 'contain', positionX: 50, positionY: 50 })}>가로 맞춤</button>
             </div>
-          </div>
-          <div>
-            <span style={{ fontSize: 9, color: '#555', display: 'block', marginBottom: 4 }}>세로 정렬</span>
-            <div style={{ display: 'flex', gap: 4 }}>
-              <button
-                onClick={() => updateClipZoom(selectedClipIndex, { panY: -50 + (50 / zoom.scale) })}
-                style={btnStyle}
-                title="상단 정렬"
-              >▲</button>
-              <button
-                onClick={() => updateClipZoom(selectedClipIndex, { panY: 0 })}
-                style={btnStyle}
-                title="중앙 정렬"
-              >◆</button>
-              <button
-                onClick={() => updateClipZoom(selectedClipIndex, { panY: 50 - (50 / zoom.scale) })}
-                style={btnStyle}
-                title="하단 정렬"
-              >▼</button>
+            <SliderRow label="좌우" min={0} max={100} value={posX} unit="%" onChange={(value) => updateClipMeta(selectedClipIndex, { positionX: value })} />
+            <SliderRow label="상하" min={0} max={100} value={posY} unit="%" onChange={(value) => updateClipMeta(selectedClipIndex, { positionY: value })} />
+          </InspectorSection>
+
+          <InspectorSection id="audio" icon={isAudioMuted ? <VolumeX size={15} /> : <Volume2 size={15} />} title="영상 소리" summary={isAudioMuted ? '꺼짐' : `켜짐 ${clipVolume}%`} open={openSections.audio} onToggle={toggleSection}>
+            <div className="studio-segmented">
+              <button className={!isAudioMuted ? 'is-active' : ''} onClick={() => updateClipMeta(selectedClipIndex, { audioMuted: false })}>켜짐</button>
+              <button className={isAudioMuted ? 'is-active' : ''} onClick={() => updateClipMeta(selectedClipIndex, { audioMuted: true })}>음소거</button>
             </div>
-          </div>
+            <SliderRow label="볼륨" min={0} max={100} value={clipVolume} unit="%" onChange={(value) => updateClipMeta(selectedClipIndex, { volume: value, audioMuted: false })} />
+            <div className="studio-segmented">
+              <button className={allClipAudioMuted ? 'is-active' : ''} onClick={() => setAllClipAudioMuted(true)}>전체 음소거</button>
+              <button className={!allClipAudioMuted ? 'is-active' : ''} onClick={() => setAllClipAudioMuted(false)}>전체 켜기</button>
+            </div>
+          </InspectorSection>
+
+          <InspectorSection id="align" icon={<AlignCenter size={15} />} title="정렬" summary="가운데" open={openSections.align} onToggle={toggleSection}>
+            <div className="studio-align-row">
+              <button onClick={() => updateClipZoom(selectedClipIndex, { panX: -50 + (50 / zoom.scale) })}><AlignStartHorizontal size={16} />왼쪽</button>
+              <button onClick={() => updateClipZoom(selectedClipIndex, { panX: 0, panY: 0 })}><AlignCenter size={16} />중앙</button>
+              <button onClick={() => updateClipZoom(selectedClipIndex, { panX: 50 - (50 / zoom.scale) })}><AlignEndHorizontal size={16} />오른쪽</button>
+            </div>
+          </InspectorSection>
         </div>
-      )}
+      </div>
+
+      <div className="studio-inspector-footer">
+        <button className="studio-primary-action" type="button" onClick={saveProject}>선택 클립 적용</button>
+        <button className="studio-secondary-action" type="button" onClick={() => copyClipSettingsToAll(selectedClipIndex)}>전체 클립에 복사</button>
+        <span className={`studio-save-status is-${saveStatus}`}>
+          <span />
+          {saveStatus === 'saving' ? '저장 중' : saveStatus === 'failed' ? '실패' : saveStatus === 'saved' ? '저장됨' : '대기'}
+        </span>
+      </div>
     </div>
   );
 };

--- a/dashboard/src/components/studio/ClipPanel.tsx
+++ b/dashboard/src/components/studio/ClipPanel.tsx
@@ -131,11 +131,15 @@ export const ClipPanel: React.FC = () => {
 
   useEffect(() => {
     if (!clip) return;
+    // probe는 source(파일)에만 의존 — clip.end는 첫 응답 실패 시 fallback에만 쓰이므로
+    // deps에 넣으면 trim drag 매 프레임마다 fetch가 fire됨 (네트워크 폭격).
+    const fallback = clip.end + 10;
     fetch(`${getEditorConfig().apiUrl}/api/media/probe/${encodeURIComponent(clip.source)}`)
       .then((r) => r.json())
-      .then((d) => setSourceDuration(d.duration || clip.end + 10))
-      .catch(() => setSourceDuration(clip.end + 10));
-  }, [clip?.source, clip?.end]);
+      .then((d) => setSourceDuration(d.duration || fallback))
+      .catch(() => setSourceDuration(fallback));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clip?.source]);
 
   if (!clip) {
     return (

--- a/dashboard/src/components/studio/EffectPanel.tsx
+++ b/dashboard/src/components/studio/EffectPanel.tsx
@@ -29,8 +29,8 @@ export const EffectPanel: React.FC = () => {
   };
 
   return (
-    <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <div className="studio-panel-content studio-panel-content-effect" style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="studio-panel-header-card" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div style={{ fontSize: 10, fontWeight: 600, color: '#888', textTransform: 'uppercase' }}>
           글로벌 이펙트
         </div>
@@ -47,7 +47,7 @@ export const EffectPanel: React.FC = () => {
         const val = getValue(def.type);
         const isModified = val !== def.defaultVal;
         return (
-          <div key={def.type} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div key={def.type} className="studio-card studio-effect-row" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <label style={{ fontSize: 10, color: isModified ? '#c4b5fd' : '#aaa' }}>
                 {def.icon} {def.label}
@@ -76,7 +76,7 @@ export const EffectPanel: React.FC = () => {
         );
       })}
 
-      <div style={{ fontSize: 9, color: '#444', marginTop: 4 }}>
+      <div className="studio-card" style={{ fontSize: 9, color: '#444', marginTop: 4 }}>
         모든 클립에 일괄 적용됩니다. 100% = 원본
       </div>
     </div>

--- a/dashboard/src/components/studio/ReferencePanel.tsx
+++ b/dashboard/src/components/studio/ReferencePanel.tsx
@@ -49,16 +49,16 @@ export const ReferencePanel: React.FC = () => {
   };
 
   return (
-    <div style={{ display: 'flex', height: '100%', gap: 0 }}>
+    <div className="studio-panel-content studio-panel-content-reference" style={{ display: 'flex', height: '100%', gap: 0 }}>
       {/* 왼쪽: 레퍼런스 영상 재생 (40%) */}
-      <div style={{
+      <div className="studio-reference-preview-card" style={{
         flex: 4,
         display: 'flex',
         flexDirection: 'column',
         borderRight: '1px solid #2a2a2a',
         minWidth: 0,
       }}>
-        <div style={{ padding: '8px 10px', borderBottom: '1px solid #2a2a2a', flexShrink: 0 }}>
+        <div className="studio-panel-header-card" style={{ padding: '8px 10px', borderBottom: '1px solid #2a2a2a', flexShrink: 0 }}>
           <span style={{ color: '#a78bfa', fontWeight: 600, fontSize: 11 }}>🎬 레퍼런스</span>
         </div>
 
@@ -110,14 +110,14 @@ export const ReferencePanel: React.FC = () => {
       </div>
 
       {/* 오른쪽: 레퍼런스 리스트 (60%) */}
-      <div style={{
+      <div className="studio-reference-list-card" style={{
         flex: 6,
         minWidth: 0,
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
       }}>
-        <div style={{ padding: '8px 10px', borderBottom: '1px solid #2a2a2a', flexShrink: 0 }}>
+        <div className="studio-panel-header-card" style={{ padding: '8px 10px', borderBottom: '1px solid #2a2a2a', flexShrink: 0 }}>
           <span style={{ color: '#888', fontWeight: 600, fontSize: 10 }}>목록 ({videos.length})</span>
         </div>
 
@@ -131,6 +131,7 @@ export const ReferencePanel: React.FC = () => {
           }}>
             {videos.map((v) => (
               <div
+                className="studio-reference-thumb"
                 key={v.id}
                 onClick={() => selectRef(v)}
                 style={{

--- a/dashboard/src/components/studio/SubtitlePanel.tsx
+++ b/dashboard/src/components/studio/SubtitlePanel.tsx
@@ -171,9 +171,9 @@ export const SubtitlePanel: React.FC = () => {
   };
 
   return (
-    <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+    <div className="studio-panel-content studio-panel-content-subtitle" style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
       {/* Header with add/delete */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className="studio-panel-header-card" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div style={{ fontSize: 10, fontWeight: 600, color: '#888', textTransform: 'uppercase' }}>
           자막 ({globalSubs.length})
         </div>
@@ -201,12 +201,13 @@ export const SubtitlePanel: React.FC = () => {
 
       {/* Subtitle list */}
       {globalSubs.length > 0 && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 2, maxHeight: 250, overflow: 'auto' }}>
+        <div className="studio-card studio-subtitle-list" style={{ display: 'flex', flexDirection: 'column', gap: 2, maxHeight: 250, overflow: 'auto' }}>
           {globalSubs
             .map((sub, i) => ({ sub, i }))
             .sort((a, b) => a.sub.start - b.sub.start)
             .map(({ sub, i }) => (
             <div
+              className="studio-subtitle-list-item"
               key={i}
               onClick={() => setSelectedSubIndex(i)}
               style={{
@@ -230,7 +231,7 @@ export const SubtitlePanel: React.FC = () => {
       )}
 
       {selectedSubIndex < 0 || selectedSubIndex >= globalSubs.length ? (
-        <div style={{ color: '#555', fontSize: 11 }}>
+        <div className="studio-card" style={{ color: '#555', fontSize: 11 }}>
           자막을 선택하거나 추가하세요
         </div>
       ) : (
@@ -248,7 +249,7 @@ const SubEditor: React.FC<{ index: number }> = ({ index }) => {
   const style = sub.style || {};
 
   return (
-    <>
+    <div className="studio-panel-subeditor">
       {/* Time inputs */}
       <div style={{ display: 'flex', gap: 8 }}>
         <div style={{ flex: 1 }}>
@@ -482,6 +483,6 @@ const SubEditor: React.FC<{ index: number }> = ({ index }) => {
           />
         </div>
       </div>
-    </>
+    </div>
   );
 };

--- a/dashboard/src/components/studio/TransitionPanel.tsx
+++ b/dashboard/src/components/studio/TransitionPanel.tsx
@@ -42,12 +42,12 @@ export const TransitionPanel: React.FC = () => {
   }
 
   return (
-    <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+    <div className="studio-panel-content studio-panel-content-transition" style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
       {/* Fade In/Out */}
-      <div style={{ fontSize: 10, fontWeight: 600, color: '#888', textTransform: 'uppercase' }}>
+      <div className="studio-panel-header-card" style={{ fontSize: 10, fontWeight: 600, color: '#888', textTransform: 'uppercase' }}>
         페이드 인/아웃
       </div>
-      <div style={{ padding: 8, background: '#1a1a1a', borderRadius: 6, border: '1px solid #2a2a2a', display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div className="studio-card" style={{ padding: 8, background: '#1a1a1a', borderRadius: 6, border: '1px solid #2a2a2a', display: 'flex', flexDirection: 'column', gap: 8 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <button
             className={`be-btn ${fadeInOut.enabled ? 'be-btn-on' : ''}`}
@@ -89,12 +89,12 @@ export const TransitionPanel: React.FC = () => {
       </div>
 
       {/* Transitions */}
-      <div style={{ fontSize: 10, fontWeight: 600, color: '#888', textTransform: 'uppercase' }}>
+      <div className="studio-panel-header-card" style={{ fontSize: 10, fontWeight: 600, color: '#888', textTransform: 'uppercase' }}>
         트랜지션
       </div>
 
       {clips.length < 2 && (
-        <div style={{ color: '#555', fontSize: 11 }}>
+        <div className="studio-card" style={{ color: '#555', fontSize: 11 }}>
           클립이 2개 이상일 때 트랜지션을 설정할 수 있습니다
         </div>
       )}
@@ -102,7 +102,7 @@ export const TransitionPanel: React.FC = () => {
       {transitionIndices.map((idx) => {
         const t = transitions[idx] || { type: 'none', duration: 0 };
         return (
-          <div key={idx} style={{ padding: 8, background: '#1a1a1a', borderRadius: 6, border: '1px solid #2a2a2a', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div key={idx} className="studio-card" style={{ padding: 8, background: '#1a1a1a', borderRadius: 6, border: '1px solid #2a2a2a', display: 'flex', flexDirection: 'column', gap: 8 }}>
             <div style={{ fontSize: 10, color: '#888' }}>
               클립 {idx + 1} → 클립 {idx + 2}
             </div>

--- a/dashboard/src/components/studio/store.ts
+++ b/dashboard/src/components/studio/store.ts
@@ -112,6 +112,7 @@ interface EditorState {
   // Clip detail mutations
   updateClipMeta: (index: number, meta: Partial<ClipMeta>) => void;
   setAllClipAudioMuted: (muted: boolean) => void;
+  copyClipSettingsToAll: (index: number) => void;
   updateClipCrop: (index: number, crop: Partial<ClipCrop>) => void;
   updateClipZoom: (index: number, zoom: Partial<ClipZoom>) => void;
 
@@ -809,6 +810,21 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       }));
       const totalDuration = calcTotalDuration(state.clips, clipMeta, state.transitions);
       return { clipMeta, totalDuration };
+    });
+  },
+
+  copyClipSettingsToAll: (index) => {
+    get()._pushHistory();
+    set((state) => {
+      if (index < 0 || index >= state.clips.length) return state;
+      const sourceMeta = state.clipMeta[index] || { speed: 1 };
+      const sourceCrop = state.clipCrops[index] || { x: 0, y: 0, w: 100, h: 100 };
+      const sourceZoom = state.clipZooms[index] || { scale: 1, panX: 0, panY: 0 };
+      const clipMeta = state.clips.map(() => ({ ...sourceMeta }));
+      const clipCrops = state.clips.map(() => ({ ...sourceCrop }));
+      const clipZooms = state.clips.map(() => ({ ...sourceZoom }));
+      const totalDuration = calcTotalDuration(state.clips, clipMeta, state.transitions);
+      return { clipMeta, clipCrops, clipZooms, totalDuration };
     });
   },
 


### PR DESCRIPTION
## Summary
- 영상 편집기 사이드 패널 6탭(자막/클립/BGM/전환/레퍼런스/이펙트) 시각·인터랙션 redesign
- `ClipPanel.tsx` 평면 inline-style → `InspectorSection` 아코디언 6개(speed/crop/zoom/position/audio/align)로 리팩터
- inline-style 산재 → `globals.css` 통합 스타일(+763 lines)로 이전, lucide-react 아이콘 도입
- 신규 store 액션: `copyClipSettingsToAll(index)` — 한 클립 설정을 모든 클립에 일괄 복사

## 핵심 변경
| 파일 | 변경 |
|---|---|
| `app/(dashboard)/video/projects/page.tsx` | 탭 lucide 아이콘 + 패널 폭 정책(절대 380~720, 초기 clamp(420, vw*0.34, 620)) + studio-panel-tabs 클래스 적용 |
| `components/studio/ClipPanel.tsx` | 808 lines 리팩터 — InspectorSection/SliderRow 추출, helper(clamp/formatShortTime/getFileName), lucide 16종 |
| `components/studio/store.ts` | `copyClipSettingsToAll` 신설 (history push 포함) |
| `components/studio/{Bgm,Effect,Reference,Subtitle,Transition}Panel.tsx` | 공통 className 부착(시각 회귀 방지 위해 인라인 스타일 병행 유지) |
| `app/globals.css` | +763 lines — `.studio-panel-tabs` / `.studio-inspector-section*` / `.studio-card` / `.studio-control-row` / 패널별 scope 클래스 |

## Why this approach
- **인라인 → 클래스 부분 마이그레이션**: 시각 회귀 위험 줄이기 위해 인라인 스타일을 즉시 제거하지 않고 클래스 우선순위로 덮어씀. 추후 별도 PR에서 인라인 잔재 제거 가능.
- **lucide-react**: dashboard 다른 곳에서도 표준 아이콘셋. 기존 emoji보다 시각 일관성·DPI scaling 우수.
- **InspectorSection**: ClipPanel 컨트롤이 6 카테고리(speed/crop/zoom/position/audio/align)로 늘면서 평면 배치는 스크롤 비대화. 아코디언으로 시야 집중.

## 검증
- `npx tsc --noEmit` PASS (exit=0)
- 로컬 dev 서버(npm run dev:all) 정상 컴파일, `/video/projects` HTTP 200

## Test plan
- [ ] `/video/projects/?id=<existing>` 진입 → 6탭 아이콘+라벨 정상 표시
- [ ] ClipPanel 아코디언 6 섹션(speed/crop/zoom/position/audio/align) 토글 정상
- [ ] 클립 1개 선택 → 설정 변경 → "모든 클립에 복사" 버튼(있다면) → 다른 클립 동일 적용 확인
- [ ] 사이드 패널 좌측 드래그 핸들 리사이즈 380~720px 범위 정상
- [ ] BGM/자막/전환/레퍼런스/이펙트 탭 각각 진입 — 카드 스타일 깨짐 없음
- [ ] 다크 모드 외 환경(라이트 OS) 영향 없음 확인
- [ ] Timeline · RemotionPreview · 렌더 경로 회귀 없음 (UI scope only)

## 영향 범위
영상 편집기 사이드 패널 시각·인터랙션만. Remotion Player 트리, 미디어 fetch 경로, store core mutation, render path 무관.