### PR TITLE
refactor(gallery): kind enum 단일 축 정제 + 미디어 포맷 분리

### DIFF
--- a/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
@@ -21,7 +21,11 @@ import type {
   GalleryKind,
   GalleryVisibility,
 } from "@/lib/types";
-import { GALLERY_KIND_FILTERS as KIND_FILTER } from "@/lib/gallery-constants";
+import {
+  GALLERY_KIND_FILTERS as KIND_FILTER,
+  GALLERY_MEDIA_TYPES,
+  type GalleryMediaType,
+} from "@/lib/gallery-constants";
 import {
   setGalleryFeatured,
   updateGalleryRank,
@@ -34,7 +38,6 @@ const STATUS_OPTIONS: GalleryItemStatus[] = ["draft", "published", "archived"];
 const VISIBILITY_OPTIONS: GalleryVisibility[] = ["public", "member", "internal"];
 
 function kindVariant(kind: GalleryKind) {
-  if (kind === "video") return "destructive" as const;
   if (kind === "landing") return "warning" as const;
   if (kind === "ad") return "success" as const;
   if (kind === "case_study") return "info" as const;
@@ -50,12 +53,18 @@ function statusVariant(status: GalleryItemStatus) {
 
 export function GalleryTable({ items }: { items: GalleryItemWithCover[] }) {
   const [kindFilter, setKindFilter] = useState<(typeof KIND_FILTER)[number]>("all");
+  const [mediaFilter, setMediaFilter] = useState<GalleryMediaType>("all");
   const [statusFilter, setStatusFilter] = useState<"all" | GalleryItemStatus>("all");
   const [featuredOnly, setFeaturedOnly] = useState(false);
 
   const filtered = items.filter((i) => {
     const itemKinds = i.kinds && i.kinds.length > 0 ? i.kinds : [i.kind];
     if (kindFilter !== "all" && !itemKinds.includes(kindFilter as GalleryKind)) return false;
+    if (mediaFilter !== "all") {
+      const isVideo = i.cover_mime?.startsWith("video/") ?? false;
+      if (mediaFilter === "video" && !isVideo) return false;
+      if (mediaFilter === "image" && isVideo) return false;
+    }
     if (statusFilter !== "all" && i.status !== statusFilter) return false;
     if (featuredOnly && !i.is_featured) return false;
     return true;
@@ -75,6 +84,21 @@ export function GalleryTable({ items }: { items: GalleryItemWithCover[] }) {
               {KIND_FILTER.map((k) => (
                 <SelectItem key={k} value={k}>
                   {k}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-muted-foreground">Media</span>
+          <Select value={mediaFilter} onValueChange={(v) => setMediaFilter(v as GalleryMediaType)}>
+            <SelectTrigger className="h-8 w-[120px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {GALLERY_MEDIA_TYPES.map((m) => (
+                <SelectItem key={m} value={m}>
+                  {m}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/new/new-form.tsx
@@ -50,7 +50,7 @@ export function NewGalleryForm() {
   const [title, setTitle] = useState("");
   const [slug, setSlug] = useState("");
   const [slugTouched, setSlugTouched] = useState(false);
-  const [kinds, setKinds] = useState<GalleryKind[]>(["image"]);
+  const [kinds, setKinds] = useState<GalleryKind[]>(["ad"]);
   const [coverAspect, setCoverAspect] = useState<GalleryCoverAspect>("16:9");
   const [subtitle, setSubtitle] = useState("");
   const [summary, setSummary] = useState("");
@@ -82,11 +82,7 @@ export function NewGalleryForm() {
     setFile(f);
     if (previewUrl) URL.revokeObjectURL(previewUrl);
     setPreviewUrl(f ? URL.createObjectURL(f) : null);
-    if (f?.type.startsWith("video/")) {
-      setKinds((prev) =>
-        prev.includes("video") ? prev : ["video", ...prev.filter((k) => k !== "image")]
-      );
-    }
+    // 미디어 포맷(image/video) 자동 추론은 cover_media.mime_type 으로 옮겨짐 — kind 자동 변경 없음.
   };
 
   const toggleKind = (k: GalleryKind) => {

--- a/dashboard/src/lib/gallery-constants.ts
+++ b/dashboard/src/lib/gallery-constants.ts
@@ -5,14 +5,14 @@ export const GALLERY_VIDEO_MAX = 100 * 1024 * 1024;
 
 export const GALLERY_KINDS: readonly GalleryKind[] = [
   "landing",
-  "video",
   "ad",
-  "image",
-  "carousel",
   "case_study",
   "ai_influencer",
   "other",
 ] as const;
+
+export const GALLERY_MEDIA_TYPES = ["all", "image", "video"] as const;
+export type GalleryMediaType = (typeof GALLERY_MEDIA_TYPES)[number];
 
 export const GALLERY_KIND_FILTERS: readonly (GalleryKind | "all")[] = [
   "all",

--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -285,7 +285,8 @@ export async function getGalleryItems(
     .select("*, media:cover_media_id(url, mime_type)");
 
   if (opts.status) q = q.eq("status", opts.status);
-  if (opts.kind) q = q.eq("kind", opts.kind);
+  // 다중 카테고리 도입 후 단일 컬럼 .eq 는 누락 위험 → kinds[] contains 매칭으로 정정.
+  if (opts.kind) q = q.contains("kinds", [opts.kind]);
   if (typeof opts.is_featured === "boolean") q = q.eq("is_featured", opts.is_featured);
 
   const { data, error } = await q

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -203,10 +203,7 @@ export interface FinishedVideo {
 // ── Gallery ──────────────────────────────────────────────
 export type GalleryKind =
   | 'landing'
-  | 'video'
   | 'ad'
-  | 'image'
-  | 'carousel'
   | 'case_study'
   | 'ai_influencer'
   | 'other';

--- a/src/tools/gallery.ts
+++ b/src/tools/gallery.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CMSAdapter } from '../adapters/interface.js';
 
-const KIND = z.enum(['landing', 'video', 'ad', 'image', 'carousel', 'case_study', 'ai_influencer', 'other']);
+const KIND = z.enum(['landing', 'ad', 'case_study', 'ai_influencer', 'other']);
 const ASPECT = z.enum(['1:1', '16:9', '9:16', '4:5', '3:4']);
 const STATUS = z.enum(['draft', 'published', 'archived']);
 const VISIBILITY = z.enum(['internal', 'member', 'public']);

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,10 +244,7 @@ export interface ContentRelation {
 // ── Gallery (AWC Web + APP 공용) ──────────────────────────────
 export type GalleryKind =
   | 'landing'
-  | 'video'
   | 'ad'
-  | 'image'
-  | 'carousel'
   | 'case_study'
   | 'ai_influencer'
   | 'other';

--- a/supabase/migrations/20260426000000_gallery_kind_format_axis_split.sql
+++ b/supabase/migrations/20260426000000_gallery_kind_format_axis_split.sql
@@ -1,0 +1,33 @@
+-- gallery `kinds` enum 정리: 미디어 포맷 축(image/video/carousel) 제거.
+--
+-- 배경: 기존 enum이 두 축(용도/주제 + 미디어 포맷)을 혼합 보유.
+--   image/video는 cover_media.mime_type 으로 자동 판정 가능 → kind enum 중복.
+--   carousel은 사용 0건. 제거해도 영향 없음.
+--
+-- 신 enum: landing / ad / case_study / ai_influencer / other
+-- 미디어 포맷 필터는 cover_media.mime_type prefix 매칭으로 별도 처리.
+--
+-- 데이터 마이그레이션은 본 migration 적용 전 별도 UPDATE로 선처리됨
+-- (image/video/carousel 제거 + miumiu-matelasse-wallet 'image' → 'ad' 재분류).
+-- 본 migration 시점에 모든 published row 의 kinds 가 신 enum 안에 있다고 가정.
+--
+-- backward-compat 트리거(`fn_gallery_kinds_sync`) 와 `kind` 단일 컬럼은 유지
+-- (양 레포 일부 코드가 여전히 fallback 으로 사용). cleanup 별건.
+
+ALTER TABLE gallery_items DROP CONSTRAINT IF EXISTS gallery_items_kind_check;
+ALTER TABLE gallery_items DROP CONSTRAINT IF EXISTS gallery_items_kinds_valid;
+
+ALTER TABLE gallery_items
+  ADD CONSTRAINT gallery_items_kind_check
+    CHECK (kind = ANY (ARRAY[
+      'landing', 'ad', 'case_study', 'ai_influencer', 'other'
+    ]::text[]));
+
+ALTER TABLE gallery_items
+  ADD CONSTRAINT gallery_items_kinds_valid
+    CHECK (
+      cardinality(kinds) >= 1
+      AND kinds <@ ARRAY[
+        'landing', 'ad', 'case_study', 'ai_influencer', 'other'
+      ]::text[]
+    );


### PR DESCRIPTION
## Summary

기존 \`kinds\` enum 안에 두 축(용도/주제 + 미디어 포맷)이 혼재. \`image\`/\`video\`는 \`cover_media.mime_type\`으로 자동 판정 가능 → enum 중복. \`carousel\`은 사용 0건. **세 enum을 모두 제거**하고 mime_type 기반 별도 필터로 옮김.

신 enum: **\`landing\` / \`ad\` / \`case_study\` / \`ai_influencer\` / \`other\`** (5개, 단일 축)

## DB migration

\`20260426000000_gallery_kind_format_axis_split.sql\`:
- \`gallery_items_kind_check\` + \`gallery_items_kinds_valid\` CHECK 제약 재정의
- 적용 전 데이터 사전 정렬 (별도 SQL UPDATE):
  - 1건(\`miumiu-matelasse-wallet\`, \`['image']\` single) → \`['ad']\` 재분류
  - 32건 \`kinds[]\`에서 image/video/carousel 제거 (다른 kind 보존)
  - **고아 0건 보장** (검증 후 적용)
- prod 이미 \`apply_migration\` MCP로 적용됨

## 코드 변경

| 파일 | 변경 |
|---|---|
| \`src/types.ts\` | GalleryKind 5개로 축소 |
| \`src/tools/gallery.ts\` | MCP zod enum 5개 |
| \`dashboard/src/lib/types.ts\` | Dashboard GalleryKind 5개 |
| \`dashboard/src/lib/gallery-constants.ts\` | GALLERY_KINDS 5개 + 신규 GALLERY_MEDIA_TYPES + GalleryMediaType |
| \`dashboard/src/lib/queries.ts\` | \`q.eq("kind")\` → \`q.contains("kinds", [..])\` (multi-kind 누락 버그 동시 fix) |
| \`dashboard/.../gallery-table.tsx\` | kindVariant video 분기 제거 + Media 필터 select 신규 (cover_mime prefix) |
| \`dashboard/.../new-form.tsx\` | 기본 \`['image']\` → \`['ad']\` + video 자동 추가 로직 제거 |

## 쌍 PR
- [brxce.ai PR #TBD](https://github.com/intellieffect/awc) — AWC Web KIND_URL_MAP/GALLERY_KINDS 정리 + getGalleryItems mediaType 파라미터 + GalleryMediaToggle 신규

머지 순서 무관 (둘 다 신 enum 한정).

## Test plan
- [ ] Dashboard \`/gallery\` 진입 — Kind 필터에서 image/video/carousel 사라짐, Media 필터(all/image/video) 노출
- [ ] Media 필터 변경 시 cover_mime 기준으로 client filter 작동
- [ ] \`/gallery/new\` 업로드 — 기본 kind ad chip 활성, image/video kind 옵션 사라짐
- [ ] \`/gallery/[id]\` meta-form — image/video chip 사라짐
- [ ] MCP \`create_gallery_item({ kinds: ['image'] })\` → zod 에러 (정상)
- [ ] AWC Web 쌍 PR 머지 후 \`/gallery/image\`, \`/gallery/video\` URL 404 (정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)