### PR TITLE
fix(studio/remotion): 미디어 로드 실패 시 Player 영구 정지 방지 (pauseWhenBuffering 제거 + errored placeholder)

### DIFF
--- a/dashboard/src/components/remotion/VideoClip.tsx
+++ b/dashboard/src/components/remotion/VideoClip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { OffthreadVideo, Video, useCurrentFrame, useVideoConfig, interpolate, getRemotionEnvironment } from "remotion";
 import { getEditorConfig } from "@/lib/editor-config";
 
@@ -126,9 +126,18 @@ export const VideoClip: React.FC<ClipProps> = ({
   const objPosY = positionY ?? 50;
   const objectPosition = (objPosX !== 50 || objPosY !== 50) ? `${objPosX}% ${objPosY}%` : undefined;
 
-  // HEVC originals may fail in browser during proxy generation — log only, errorFallback renders placeholder
+  // 404/HEVC decode 실패 등으로 source가 못 떠질 때, Player가 buffering 상태로 멈추지 않도록
+  // 1) preview에서 pauseWhenBuffering 제거 (frame 진행 강제) +
+  // 2) onError 시 errored 플래그 → placeholder 렌더로 다음 frame까지 깔끔히 통과시킨다.
+  // src가 바뀌면 errored 리셋 (편집 중 source 교체 케이스).
+  const [errored, setErrored] = useState(false);
+  useEffect(() => {
+    setErrored(false);
+  }, [src]);
+
   const handleError = (err: Error) => {
     console.debug(`[VideoClip] ${source}: ${err.message}`);
+    setErrored(true);
   };
 
   return (
@@ -141,7 +150,29 @@ export const VideoClip: React.FC<ClipProps> = ({
         opacity: clipOpacity,
       }}
     >
-      {getRemotionEnvironment().isRendering ? (
+      {errored ? (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            background: "#0a0a0a",
+            color: "#7f8590",
+            fontFamily: "system-ui, sans-serif",
+            fontSize: 12,
+            textAlign: "center",
+            padding: 16,
+          }}
+        >
+          <div style={{ fontWeight: 700, color: "#ef6b6b" }}>⚠ 미디어 로드 실패</div>
+          <div style={{ wordBreak: "break-all", maxWidth: "80%" }}>{source}</div>
+          <div style={{ opacity: 0.6 }}>파일이 디스크에 없거나 디코딩 실패</div>
+        </div>
+      ) : getRemotionEnvironment().isRendering ? (
         <OffthreadVideo
           src={src}
           startFrom={startFromFrame}
@@ -166,7 +197,6 @@ export const VideoClip: React.FC<ClipProps> = ({
           playbackRate={speed}
           volume={clipVolume}
           muted={audioMuted}
-          pauseWhenBuffering
           acceptableTimeShiftInSeconds={1}
           onError={handleError}
           style={{


### PR DESCRIPTION
## Summary
영상 편집기 Player가 source 파일이 디스크에 없을 때(404) 그 클립에서 영구 buffering → 다음 모든 클립 재생 불가 회귀 fix.

## Root cause
- `VideoClip.tsx` preview 분기의 `<Video pauseWhenBuffering />` (커밋 [9abe416](https://github.com/intellieffect/agentic-cms/commit/9abe416)에서 Remotion best-practice로 추가)
- src 404 → HTML5 `<video>` 영원히 buffering 상태 → `pauseWhenBuffering=true` → Player frame 진행 중단 → 다음 클립 도달 불가
- 기존 `onError` 핸들러는 `console.debug`만, 복구 동작 없음

## Fix
| 변경 | 효과 |
|---|---|
| `<Video>`에서 `pauseWhenBuffering` 제거 | frame 진행 강제 — 깨진 클립이 와도 재생 흐름 안 멈춤 |
| `errored` state + onError 시 placeholder | 검은 배경 + "미디어 로드 실패" + 파일명 — 사용자가 어떤 클립이 깨졌는지 시각적 인지 |
| `useEffect([src], () => setErrored(false))` | source 교체 시 errored 리셋 (편집 중 source 변경 케이스) |
| `<OffthreadVideo>` (render 분기)는 무변경 | 해당 prop 미보유, 렌더 경로 영향 없음 |

## Why now
사용자가 "3번째 클립에서 멈춤" 보고 → diagnosis 결과 `dajungchoe Money Trees 야간` 프로젝트의 4번째 source `DJI_20260403175336_0443_D.MP4` 가 `/`, `/_proxy/`, `/api/media/probe/` 모두 404 — 디스크에서 사라진 파일. 동일 프로젝트에서 missing source 3개. 전체 39 프로젝트 중 35개가 같은 패턴.

## 검증
- `npx tsc --noEmit` PASS
- 로컬 dev 서버 (`npm run dev:all`) 정상 컴파일

## Test plan
- [ ] dev 서버 재기동 + 브라우저 하드 리프레시
- [ ] `/video/projects/?id=project_1776066093367` (Money Trees 야간) 진입 → 재생 → 4번째 클립에 도달했을 때 placeholder 표시 + 다음 클립으로 진행 확인
- [ ] 멀쩡한 source 클립은 정상 재생 확인 (회귀 없음)
- [ ] 편집 중 source 교체 → errored 상태 리셋 확인
- [ ] 저장 → 다시 로드 → 동작 동일 확인

## 후속 액션 (이 PR 범위 외)
35 프로젝트의 missing source 데이터 위생 정리는 사용자 액션. 가장 심한 케이스: `종혁 - 세로 레퍼런스 프리셋` (14/14 missing). 사용자가 ClipPanel UI에서 깨진 클립 수동 삭제하거나, 별도 cleanup 스크립트 PR 가능.