### PR TITLE
feat(gallery): research kind 신설 — case_study와 분류 기준 분리

### DIFF
--- a/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/gallery-table.tsx
@@ -42,6 +42,7 @@ function kindVariant(kind: GalleryKind) {
   if (kind === "ad") return "success" as const;
   if (kind === "case_study") return "info" as const;
   if (kind === "ai_influencer") return "info" as const;
+  if (kind === "research") return "info" as const;
   return "secondary" as const;
 }
 

--- a/dashboard/src/lib/gallery-constants.ts
+++ b/dashboard/src/lib/gallery-constants.ts
@@ -8,6 +8,7 @@ export const GALLERY_KINDS: readonly GalleryKind[] = [
   "ad",
   "case_study",
   "ai_influencer",
+  "research",
   "other",
 ] as const;
 

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -206,6 +206,7 @@ export type GalleryKind =
   | 'ad'
   | 'case_study'
   | 'ai_influencer'
+  | 'research'
   | 'other';
 
 export type GalleryCoverAspect = '1:1' | '16:9' | '9:16' | '4:5' | '3:4';

--- a/src/tools/gallery.ts
+++ b/src/tools/gallery.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CMSAdapter } from '../adapters/interface.js';
 
-const KIND = z.enum(['landing', 'ad', 'case_study', 'ai_influencer', 'other']);
+const KIND = z.enum(['landing', 'ad', 'case_study', 'ai_influencer', 'research', 'other']);
 const ASPECT = z.enum(['1:1', '16:9', '9:16', '4:5', '3:4']);
 const STATUS = z.enum(['draft', 'published', 'archived']);
 const VISIBILITY = z.enum(['internal', 'member', 'public']);

--- a/src/types.ts
+++ b/src/types.ts
@@ -247,6 +247,7 @@ export type GalleryKind =
   | 'ad'
   | 'case_study'
   | 'ai_influencer'
+  | 'research'
   | 'other';
 
 export type GalleryCoverAspect = '1:1' | '16:9' | '9:16' | '4:5' | '3:4';

--- a/supabase/migrations/20260426010000_gallery_research_kind.sql
+++ b/supabase/migrations/20260426010000_gallery_research_kind.sql
@@ -1,0 +1,25 @@
+-- gallery `research` kind 신설.
+--
+-- 배경: 4/26 PR #53 정제로 enum 5축(landing/ad/case_study/ai_influencer/other) 확정.
+--   외부 플랫폼 분석·디자인 시스템 보고서 등 "AWC가 만든 리서치 산출물"을 case_study로 묶기 어려움.
+--   case_study = AWC가 만든 작업물(시안/랜딩 등) / research = AWC가 분석한 외부 대상 — 분류 기준 분리.
+--
+-- 신 enum: landing / ad / case_study / ai_influencer / research / other (6축)
+
+ALTER TABLE gallery_items DROP CONSTRAINT IF EXISTS gallery_items_kind_check;
+ALTER TABLE gallery_items DROP CONSTRAINT IF EXISTS gallery_items_kinds_valid;
+
+ALTER TABLE gallery_items
+  ADD CONSTRAINT gallery_items_kind_check
+    CHECK (kind = ANY (ARRAY[
+      'landing', 'ad', 'case_study', 'ai_influencer', 'research', 'other'
+    ]::text[]));
+
+ALTER TABLE gallery_items
+  ADD CONSTRAINT gallery_items_kinds_valid
+    CHECK (
+      cardinality(kinds) >= 1
+      AND kinds <@ ARRAY[
+        'landing', 'ad', 'case_study', 'ai_influencer', 'research', 'other'
+      ]::text[]
+    );


### PR DESCRIPTION
## Summary

PR #53(5축 정제) 직후 발견된 분류 갭 해소. 외부 플랫폼 분석/디자인 시스템 보고서 8장 + 후속 리서치 산출물 누적을 위해 신규 `research` enum 추가.

**5 → 6 enum**: `landing / ad / case_study / ai_influencer / **research** / other`

## 분류 기준 (ADR 박제 예정)

| kind | 정의 | 예시 |
|---|---|---|
| `case_study` | AWC가 직접 만든 작업물 | Riverside Penthouse 인테리어 시안, AWC 자체 랜딩 |
| `research` ✨ | AWC가 분석한 외부 대상 | ABLY/MUSINSA/지그재그/브랜디 플랫폼·디자인 시스템 보고서 |

## 변경

- `supabase/migrations/20260426010000_gallery_research_kind.sql` — DB CHECK 6 enum 확장
- `src/types.ts` + `dashboard/src/lib/types.ts` — `GalleryKind` union
- `src/tools/gallery.ts` — MCP zod enum
- `dashboard/src/lib/gallery-constants.ts` — `GALLERY_KINDS` SSOT
- `dashboard/src/app/(dashboard)/gallery/gallery-table.tsx` — `kindVariant` info badge

## Stack

PR #53 (`refactor/gallery-kind-format-axis-split`) 머지 후 base 자동 main으로 변경.

## 후속

- brxce.ai PR — `KIND_URL_MAP` + `GALLERY_KINDS` 라벨 "리서치" / `/gallery/research`
- 11건 batch upload (research 8 + ai_influencer 2 + landing 1)
- ADR `case_study vs research` decisions_record

## Test plan

- [x] `tsc --noEmit` (src + dashboard) clean
- [ ] Migration apply (PR #53 머지 후 staging Supabase)
- [ ] Dashboard `/gallery/new` 폼에서 research 옵션 노출 확인
- [ ] AWC Web `/gallery/research` 라우트 노출 확인 (brxce.ai PR 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)