### PR TITLE
fix(blog,carousel,studio): 저장 회귀 + ClipPanel nit follow-up

### DIFF
--- a/dashboard/src/app/api/blog-manage/[id]/route.ts
+++ b/dashboard/src/app/api/blog-manage/[id]/route.ts
@@ -57,10 +57,19 @@ export async function PUT(
 ) {
   try {
     const { id } = await params;
-    const body = await req.json();
+    let body: Record<string, unknown>;
+    try {
+      const raw = await req.text();
+      console.log(`[blog-manage PUT ${id}] body bytes: ${raw.length}`);
+      body = JSON.parse(raw);
+    } catch (e) {
+      console.error(`[blog-manage PUT ${id}] body parse failed:`, e);
+      const message = e instanceof Error ? e.message : "본문 파싱 실패";
+      return NextResponse.json({ error: `본문 파싱 실패: ${message}` }, { status: 400 });
+    }
 
-    const VALID_STATUSES = ['draft', 'published', 'archived'] as const;
-    if (body.status !== undefined && !VALID_STATUSES.includes(body.status)) {
+    const VALID_STATUSES: ReadonlyArray<string> = ['draft', 'published', 'archived'];
+    if (body.status !== undefined && (typeof body.status !== 'string' || !VALID_STATUSES.includes(body.status))) {
       return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
     }
 
@@ -104,8 +113,13 @@ export async function PUT(
 
     return NextResponse.json({ success: true });
   } catch (e) {
+    console.error("[blog-manage PUT] unexpected error:", e);
+    const message = e instanceof Error ? e.message : "Internal server error";
     return NextResponse.json(
-      { error: "Internal server error" },
+      {
+        error: message,
+        stack: process.env.NODE_ENV === "development" && e instanceof Error ? e.stack : undefined,
+      },
       { status: 500 }
     );
   }

--- a/dashboard/src/components/blog/BlogManageEditor.tsx
+++ b/dashboard/src/components/blog/BlogManageEditor.tsx
@@ -34,6 +34,36 @@ interface EditorElementNode {
   [key: string]: unknown;
 }
 
+/**
+ * Iterative DFS — content tree 안의 data:image base64 embed를 안전하게 검출.
+ * regex `body.match`는 거대 string에서 V8 stack overflow 일으킴 (사용자 보고 회귀).
+ */
+function findDataImageEmbeds(node: unknown): { count: number; totalBytes: number } {
+  let count = 0;
+  let totalBytes = 0;
+  const visited = new WeakSet<object>();
+  const stack: unknown[] = [node];
+  while (stack.length > 0) {
+    const n = stack.pop();
+    if (n === null || typeof n !== 'object') continue;
+    if (visited.has(n as object)) continue;
+    visited.add(n as object);
+    if (Array.isArray(n)) {
+      for (let i = n.length - 1; i >= 0; i--) stack.push(n[i]);
+      continue;
+    }
+    for (const [key, val] of Object.entries(n as Record<string, unknown>)) {
+      if ((key === 'url' || key === 'src') && typeof val === 'string' && val.startsWith('data:image/')) {
+        count++;
+        totalBytes += val.length;
+      } else if (val !== null && typeof val === 'object') {
+        stack.push(val);
+      }
+    }
+  }
+  return { count, totalBytes };
+}
+
 interface BlogManageEditorProps {
   postId: string;
   initialContent: EditorElementNode[];
@@ -85,16 +115,28 @@ export function BlogManageEditor({ postId, initialContent, onSave, onCancel }: B
     setSaving(true);
     try {
       const content = editor.children;
+      // base64 image embed 검사 — iterative DFS (regex match는 거대 string에서 V8 stack overflow)
+      const embeds = findDataImageEmbeds(content);
+      if (embeds.totalBytes > 0) {
+        console.warn(`[BlogManageEditor] base64 image embeds: ${embeds.count}개, 합계 ${(embeds.totalBytes / 1024).toFixed(1)} KB`);
+      }
+      const body = JSON.stringify({ content, skipPublishedAt: true });
+      console.log(`[BlogManageEditor] PUT body size: ${(body.length / 1024).toFixed(1)} KB`);
       const res = await fetch(`/api/blog-manage/${postId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content, skipPublishedAt: true }),
+        body,
       });
-      if (!res.ok) throw new Error('저장 실패');
+      if (!res.ok) {
+        const data: { error?: string; stack?: string } = await res.json().catch(() => ({}));
+        if (data.stack) console.error('[BlogManageEditor] server stack:', data.stack);
+        throw new Error(data.error || `저장 실패 (HTTP ${res.status})`);
+      }
       toast.success('저장되었습니다.');
       onSave?.();
     } catch (e) {
-      toast.error('저장에 실패했습니다.');
+      const msg = e instanceof Error ? e.message : '저장에 실패했습니다.';
+      toast.error(msg);
       console.error(e);
     } finally {
       setSaving(false);

--- a/dashboard/src/components/studio/ClipPanel.tsx
+++ b/dashboard/src/components/studio/ClipPanel.tsx
@@ -141,6 +141,12 @@ export const ClipPanel: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clip?.source]);
 
+  // 저장 후 사용자가 클립을 다시 수정하면 status pill을 "대기"로 되돌려서
+  // "이미 저장됨"이 아닌 "변경 있음" 상태임을 시각적으로 알린다.
+  useEffect(() => {
+    setSaveStatus((prev) => (prev === 'saved' || prev === 'failed' ? 'idle' : prev));
+  }, [clips, clipMeta, clipCrops, clipZooms]);
+
   if (!clip) {
     return (
       <div className="studio-inspector-empty">
@@ -323,8 +329,8 @@ export const ClipPanel: React.FC = () => {
             <div className="studio-transform-group">
               <div className="studio-transform-heading"><Maximize2 size={14} />크기</div>
               <div className="studio-mini-fields">
-                <label>W<input type="number" value={Number((zoom.scale * 100).toFixed(0))} onChange={(e) => updateClipZoom(selectedClipIndex, { scale: clamp(Number(e.target.value) / 100, 0.5, 3) })} /></label>
-                <label>H<input type="number" value={Number((zoom.scale * 100).toFixed(0))} onChange={(e) => updateClipZoom(selectedClipIndex, { scale: clamp(Number(e.target.value) / 100, 0.5, 3) })} /></label>
+                <label><input type="number" min={50} max={300} value={Number((zoom.scale * 100).toFixed(0))} onChange={(e) => updateClipZoom(selectedClipIndex, { scale: clamp(Number(e.target.value) / 100, 0.5, 3) })} />%</label>
+                <button type="button" onClick={() => updateClipZoom(selectedClipIndex, { scale: 1 })}><RotateCcw size={13} /></button>
               </div>
               <input type="range" min={0.5} max={3} step={0.1} value={zoom.scale} onChange={(e) => updateClipZoom(selectedClipIndex, { scale: Number(e.target.value) })} />
             </div>
@@ -391,7 +397,7 @@ export const ClipPanel: React.FC = () => {
             </div>
           </InspectorSection>
 
-          <InspectorSection id="align" icon={<AlignCenter size={15} />} title="정렬" summary="가운데" open={openSections.align} onToggle={toggleSection}>
+          <InspectorSection id="align" icon={<AlignCenter size={15} />} title="정렬" summary={zoom.panX < -1 ? '왼쪽' : zoom.panX > 1 ? '오른쪽' : '가운데'} open={openSections.align} onToggle={toggleSection}>
             <div className="studio-align-row">
               <button onClick={() => updateClipZoom(selectedClipIndex, { panX: -50 + (50 / zoom.scale) })}><AlignStartHorizontal size={16} />왼쪽</button>
               <button onClick={() => updateClipZoom(selectedClipIndex, { panX: 0, panY: 0 })}><AlignCenter size={16} />중앙</button>
@@ -402,7 +408,7 @@ export const ClipPanel: React.FC = () => {
       </div>
 
       <div className="studio-inspector-footer">
-        <button className="studio-primary-action" type="button" onClick={saveProject}>선택 클립 적용</button>
+        <button className="studio-primary-action" type="button" onClick={saveProject}>프로젝트 저장</button>
         <button className="studio-secondary-action" type="button" onClick={() => copyClipSettingsToAll(selectedClipIndex)}>전체 클립에 복사</button>
         <span className={`studio-save-status is-${saveStatus}`}>
           <span />

--- a/dashboard/src/lib/blog/normalizeEmbeddedImages.ts
+++ b/dashboard/src/lib/blog/normalizeEmbeddedImages.ts
@@ -73,36 +73,56 @@ async function uploadDataImage(
   return data.publicUrl;
 }
 
-async function normalizeNode(
-  value: unknown,
-  supabase: SupabaseClient,
-  postId: string,
-  uploadedPaths: string[]
-): Promise<unknown> {
-  if (Array.isArray(value)) {
-    const normalized = [];
-    for (const item of value) {
-      normalized.push(await normalizeNode(item, supabase, postId, uploadedPaths));
+const MAX_NODES_VISITED = 200_000;
+
+interface DataImageRef {
+  node: Record<string, unknown>;
+  key: string;
+  url: string;
+}
+
+/**
+ * Iterative DFS — collect data:image refs without recursion.
+ * 재귀 버전은 Plate editor.children 같은 깊은 트리에서 stack overflow 발생.
+ * Iterative + visited Set + cap으로 cycle/너무 큰 트리 방어.
+ */
+function collectDataImageRefs(content: unknown): DataImageRef[] {
+  const refs: DataImageRef[] = [];
+  const visited = new WeakSet<object>();
+  const stack: unknown[] = [content];
+  let count = 0;
+
+  while (stack.length > 0) {
+    if (count++ > MAX_NODES_VISITED) {
+      console.warn(`[normalize] visited cap ${MAX_NODES_VISITED} reached — content tree too large or cyclic`);
+      break;
     }
-    return normalized;
-  }
 
-  if (!isPlainObject(value)) {
-    return value;
-  }
+    const node = stack.pop();
+    if (node === null || typeof node !== "object") continue;
+    if (visited.has(node as object)) continue;
+    visited.add(node as object);
 
-  const next: Record<string, unknown> = {};
-
-  for (const [key, child] of Object.entries(value)) {
-    if ((key === "url" || key === "src") && typeof child === "string" && child.startsWith("data:image/")) {
-      next[key] = await uploadDataImage(supabase, postId, child, uploadedPaths);
+    if (Array.isArray(node)) {
+      for (let i = node.length - 1; i >= 0; i--) {
+        const item = node[i];
+        if (item !== null && typeof item === "object") stack.push(item);
+      }
       continue;
     }
 
-    next[key] = await normalizeNode(child, supabase, postId, uploadedPaths);
+    for (const [key, child] of Object.entries(node)) {
+      if ((key === "url" || key === "src") && typeof child === "string" && child.startsWith("data:image/")) {
+        refs.push({ node: node as Record<string, unknown>, key, url: child });
+        continue;
+      }
+      if (child !== null && typeof child === "object") {
+        stack.push(child);
+      }
+    }
   }
 
-  return next;
+  return refs;
 }
 
 export async function normalizeEmbeddedImagesInContent(
@@ -111,9 +131,21 @@ export async function normalizeEmbeddedImagesInContent(
   content: unknown
 ): Promise<{ content: unknown; uploadedPaths: string[] }> {
   const uploadedPaths: string[] = [];
+  const refs = collectDataImageRefs(content);
+
+  if (refs.length === 0) {
+    return { content, uploadedPaths };
+  }
+
   try {
-    const normalizedContent = await normalizeNode(content, supabase, postId, uploadedPaths);
-    return { content: normalizedContent, uploadedPaths };
+    // 모든 data:image 업로드를 병렬로 + in-place 치환
+    await Promise.all(
+      refs.map(async (ref) => {
+        const newUrl = await uploadDataImage(supabase, postId, ref.url, uploadedPaths);
+        ref.node[ref.key] = newUrl;
+      })
+    );
+    return { content, uploadedPaths };
   } catch (error) {
     const message = error instanceof Error ? error.message : "본문 이미지 정규화에 실패했습니다.";
     throw new EmbeddedImageNormalizationError(message, uploadedPaths);

--- a/editor/src/server/routes/carousels.py
+++ b/editor/src/server/routes/carousels.py
@@ -149,31 +149,36 @@ async def get_carousel(carousel_id: str):
         return _serialize_row(found)
 
 
+# ─── DB columns helper ───
+# Supabase carousels 테이블 실제 컬럼: id, title, caption, slides, created_at, updated_at, variant_id
+# template/data/style_config/width/height 컬럼은 schema에 없음 → strip해야 PGRST204 회피.
+_CAROUSELS_DB_COLUMNS = {"title", "caption", "slides", "variant_id", "updated_at"}
+
+
 # ─── POST /api/carousels ───
 
 @router.post("")
 async def create_carousel(body: CarouselCreate):
     now = datetime.now(timezone.utc).isoformat()
 
-    # slides가 있으면 data.slides로 저장
-    data = body.data
-    template = body.template
-    if body.slides:
-        template = "slide-deck"
-        data = {"kind": "slide-deck", "slides": body.slides}
+    # slides 직접 컬럼에 저장 (data 컬럼 없음)
+    slides = body.slides
+    if slides is None and isinstance(body.data, dict):
+        legacy = body.data.get("slides")
+        if isinstance(legacy, list):
+            slides = legacy
 
-    row = {
+    row_full = {
         "id": f"carousel-{uuid.uuid4().hex[:8]}",
         "title": body.title,
-        "template": template,
-        "data": data,
-        "style_config": body.style_config,
-        "width": body.width,
-        "height": body.height,
+        "slides": slides or [],
         "caption": body.caption,
         "created_at": now,
         "updated_at": now,
     }
+    # supabase 컬럼만 선택 (created_at·id·updated_at 포함)
+    db_columns = _CAROUSELS_DB_COLUMNS | {"id", "created_at"}
+    row = {k: v for k, v in row_full.items() if k in db_columns}
 
     if _check_db():
         sb = _get_sb()
@@ -181,6 +186,7 @@ async def create_carousel(body: CarouselCreate):
             resp = sb.table(TABLE_CAROUSELS).insert(row).execute()
             return _serialize_row(resp.data[0]) if resp.data else _serialize_row(row)
         except Exception as e:
+            print(f"[carousel create] failed: {e}, row keys: {list(row.keys())}")
             return JSONResponse({"error": str(e)}, status_code=500)
     else:
         items = _read_local()
@@ -197,23 +203,20 @@ async def update_carousel(carousel_id: str, body: CarouselUpdate):
     update: dict = {"updated_at": now}
     if body.title is not None:
         update["title"] = body.title
-    if body.template is not None:
-        update["template"] = body.template
-    if body.style_config is not None:
-        update["style_config"] = body.style_config
     if body.caption is not None:
         update["caption"] = body.caption
-    if body.width is not None:
-        update["width"] = body.width
-    if body.height is not None:
-        update["height"] = body.height
 
-    # slides → data.slides로 저장
+    # slides → 직접 slides 컬럼에 저장 (data 컬럼 없음)
     if body.slides is not None:
-        update["template"] = "slide-deck"
-        update["data"] = {"kind": "slide-deck", "slides": body.slides}
-    elif body.data is not None:
-        update["data"] = body.data
+        update["slides"] = body.slides
+    elif body.data is not None and isinstance(body.data, dict):
+        # legacy data.slides 페이로드 호환
+        slides_in_data = body.data.get("slides")
+        if isinstance(slides_in_data, list):
+            update["slides"] = slides_in_data
+
+    # supabase 테이블에 없는 컬럼 제거 (PGRST204 방지)
+    update = {k: v for k, v in update.items() if k in _CAROUSELS_DB_COLUMNS}
 
     if _check_db():
         sb = _get_sb()
@@ -222,6 +225,7 @@ async def update_carousel(carousel_id: str, body: CarouselUpdate):
             row = resp.data[0] if resp.data else {"id": carousel_id, **update}
             return _serialize_row(row)
         except Exception as e:
+            print(f"[carousel update] failed: {e}, update keys: {list(update.keys())}")
             return JSONResponse({"error": str(e)}, status_code=500)
     else:
         items = _read_local()


### PR DESCRIPTION
## Summary

세 가지 회귀를 한 PR로 묶음:

1. **블로그 편집기 저장 — `Maximum call stack size exceeded`** (PUT 500)
2. **캐러셀 슬라이드 저장 — `PGRST204 'data' column not found`** (PATCH 500)
3. **ClipPanel UX nit 3건** (PR #52 follow-up t_14ae1d2)

## Commits

### 1. `0887fae` — fix(blog,carousel)

#### Root cause
- `normalizeEmbeddedImagesInContent`의 재귀 함수가 Plate `editor.children`의 깊은/cycle 트리에서 await chain 누적 → V8 stack overflow
- editor 서버 `carousels.py`가 `data: {kind, slides}` + `template`/`style_config`/`width`/`height` 컬럼 사용. supabase carousels 실 schema는 `id, title, caption, slides, created_at, updated_at, variant_id` 7개뿐 → PGRST204
- handleSave가 server error message 무시 + `body.match` regex도 거대 string에서 stack overflow에 합류

#### Fix
| 파일 | 변경 |
|---|---|
| `dashboard/src/lib/blog/normalizeEmbeddedImages.ts` | 재귀 → **iterative DFS**, WeakSet visited cycle 차단, 200K 노드 cap, Promise.all 병렬 upload |
| `dashboard/src/app/api/blog-manage/[id]/route.ts` | body parse 분리 + raw bytes 로그 + outer catch console.error + dev mode stack 반환 |
| `dashboard/src/components/blog/BlogManageEditor.tsx` | server error message toast 노출, base64 검사 regex → iterative `findDataImageEmbeds`, body size 로깅 |
| `editor/src/server/routes/carousels.py` | `_CAROUSELS_DB_COLUMNS` set으로 strip, `data` → `slides` 직접, legacy `body.data.slides` 호환 |

### 2. `a5b52c5` — fix(studio/ClipPanel)

PR #52 review에서 nit으로 보류했던 3건 처리 (t_14ae1d2):
- saveStatus pill 자동 idle 복귀 (변경 감지)
- 변형>크기 W·H 동시 변경 혼란 → W % 단일 input + reset 버튼
- 정렬 summary 하드코딩 "가운데" → panX 기반 동적

## 검증
- `npx tsc --noEmit` PASS
- 캐러셀 PATCH 직접 호출 → 200, caption 정상 저장 확인
- 블로그 PUT 작은 content → 200 success
- 캐러셀 render port 3100도 별도 띄움 (이건 코드 변경 없이 운영 액션)

## Test plan
- [ ] 블로그 편집기 글 수정 → 저장 → 200 + 토스트 success
- [ ] base64 image paste 본문 저장 → toast 메시지가 진짜 server error 노출 (이전엔 generic '저장 실패'만)
- [ ] 캐러셀 슬라이드 편집 → 저장 → 200, 새 slides 영구 반영
- [ ] 캐러셀 다운로드 (port 3100 떠있는 상태에서) → 정상
- [ ] 영상 편집기 ClipPanel → 클립 수정 시 저장 status pill '대기' 복귀
- [ ] 변형>크기 W input 변경 → reset 버튼으로 100%로 되돌림
- [ ] 정렬 슬라이더 panX 변경 시 summary "왼쪽/가운데/오른쪽" 동적 표시