### PR TITLE
feat(dashboard/gallery): meta-form metric 4 필드 (BHW BP3 part 2)

### DIFF
--- a/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
+++ b/dashboard/src/app/(dashboard)/gallery/[id]/meta-form.tsx
@@ -45,6 +45,11 @@ export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
     item.duration_seconds?.toString() ?? ""
   );
   const [coverPosterUrl, setCoverPosterUrl] = useState(item.cover_poster_url ?? "");
+  // BHW BP3 — sample case 정량 메트릭 4 필드
+  const [metricLabel, setMetricLabel] = useState(item.metric_label ?? "");
+  const [metricBefore, setMetricBefore] = useState(item.metric_before ?? "");
+  const [metricAfter, setMetricAfter] = useState(item.metric_after ?? "");
+  const [metricUnit, setMetricUnit] = useState(item.metric_unit ?? "");
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
   const toggleKind = (k: GalleryKind) => {
@@ -75,6 +80,10 @@ export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
           ? Number.parseInt(durationSeconds, 10)
           : null,
         cover_poster_url: coverPosterUrl || null,
+        metric_label: metricLabel || null,
+        metric_before: metricBefore || null,
+        metric_after: metricAfter || null,
+        metric_unit: metricUnit || null,
       });
       setSavedAt(new Date().toLocaleTimeString("ko-KR"));
     });
@@ -147,6 +156,31 @@ export function GalleryMetaForm({ item }: { item: GalleryItemWithCover }) {
                 </button>
               );
             })}
+          </div>
+        </Field>
+
+        <Field label="Sample Metric (BHW BP3 — AI 인용 친화)">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Input
+              value={metricLabel}
+              onChange={(e) => setMetricLabel(e.target.value)}
+              placeholder="라벨 (예: 보고서 시간)"
+            />
+            <Input
+              value={metricBefore}
+              onChange={(e) => setMetricBefore(e.target.value)}
+              placeholder="Before (예: 3시간)"
+            />
+            <Input
+              value={metricAfter}
+              onChange={(e) => setMetricAfter(e.target.value)}
+              placeholder="After (예: 10분)"
+            />
+            <Input
+              value={metricUnit}
+              onChange={(e) => setMetricUnit(e.target.value)}
+              placeholder="Unit (선택, 예: 분)"
+            />
           </div>
         </Field>
 

--- a/dashboard/src/app/(dashboard)/gallery/actions.ts
+++ b/dashboard/src/app/(dashboard)/gallery/actions.ts
@@ -78,6 +78,11 @@ export interface GalleryMetaPatch {
   transcript?: string | null;
   duration_seconds?: number | null;
   cover_poster_url?: string | null;
+  // BHW BP3 — sample case 정량 메트릭 (Radarkitai 2026-02 "proprietary data = citation magnet").
+  metric_label?: string | null;
+  metric_before?: string | null;
+  metric_after?: string | null;
+  metric_unit?: string | null;
 }
 
 export async function updateGalleryMeta(id: string, patch: GalleryMetaPatch) {

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -247,6 +247,12 @@ export interface GalleryItem {
   transcript: string | null;
   duration_seconds: number | null;
   cover_poster_url: string | null;
+  // BHW BP3 (Radarkitai 2026-02) — sample case 정량 메트릭. 4 필드 모두 nullable.
+  // label + before + after 3개 모두 채워진 경우만 web 측 UI/JSON-LD 노출.
+  metric_label: string | null;
+  metric_before: string | null;
+  metric_after: string | null;
+  metric_unit: string | null;
 }
 
 export interface GalleryItemWithCover extends GalleryItem {


### PR DESCRIPTION
## Summary
- AWC `gallery_items` schema 의 metric 4 컬럼 ([awc PR #498](https://github.com/intellieffect/awc/pull/498))에 대응하는 dashboard runtime UI 추가
- `GalleryMetaPatch` 4 필드 옵션 추가 → `updateGalleryMeta` action 자동 매핑
- `GalleryItem` type 4 필드 추가 (모두 nullable)
- `meta-form.tsx` 에 "Sample Metric" Field (4-col grid 입력) + state + save patch
- BHW BP3 part 2 (ledger task `t_536da0c`)

## Schema ownership
- AWC = schema **owner** (`supabase/migrations/` 단독, [awc PR #498](https://github.com/intellieffect/awc/pull/498))
- agentic-cms = schema **consumer** (dashboard runtime UI 만, 본 PR) — `supabase/migrations/` 에 SQL 파일 작성 X (CLAUDE.md NON-NEGOTIABLE 룰 준수)

## Test plan
- [ ] awc PR #498 머지 후 dashboard `/gallery/[id]` 진입 → Sample Metric Field 4 입력 노출
- [ ] 메트릭 4 필드 채우고 저장 → DB metric_* 4 컬럼 update
- [ ] awc 디테일 페이지 `/gallery/item/[slug]` → "before → after" 박스 + JSON-LD `additionalProperty` 노출 확인

## Notes
- 검증: `npm install + npx tsc --noEmit` → 본인 변경 + 전체 에러 **0건**.
- 머지 순서: awc PR #498 (schema migration 먼저) → 본 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)