### PR TITLE
feat(dashboard): AEO Visibility 페이지 추가

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -53,7 +53,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
-        "recharts": "^2.15.3",
+        "recharts": "^2.15.4",
         "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -59,7 +59,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "recharts": "^2.15.3",
+    "recharts": "^2.15.4",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",

--- a/dashboard/src/app/(dashboard)/aeo/actions.ts
+++ b/dashboard/src/app/(dashboard)/aeo/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { loadResultsForCell, type AeoEngine } from "@/lib/aeo";
+
+export async function fetchCellResults(
+  queryId: string,
+  engine: AeoEngine,
+  runDate: string,
+) {
+  return loadResultsForCell(queryId, engine, runDate);
+}

--- a/dashboard/src/app/(dashboard)/aeo/page.tsx
+++ b/dashboard/src/app/(dashboard)/aeo/page.tsx
@@ -1,0 +1,167 @@
+import {
+  AEO_ENGINES,
+  ENGINE_LABEL,
+  computeAvgRepeatability,
+  computeSovTimeseries,
+  loadAeoQueries,
+  loadFinalResultsLatest,
+  loadFinalResultsRecent,
+  loadTopCompetitors,
+  pivotSovForChart,
+} from "@/lib/aeo";
+import SovChart from "./sov-chart";
+import ResultsMatrix from "./results-matrix";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function AeoPage() {
+  // 데이터 fetch — 부재 시 빈 상태 그라풀.
+  const [queries, recent, latest] = await Promise.all([
+    loadAeoQueries().catch(() => []),
+    loadFinalResultsRecent(30).catch(() => []),
+    loadFinalResultsLatest().catch(() => ({ rows: [], runDate: null })),
+  ]);
+
+  const sovChart = pivotSovForChart(computeSovTimeseries(recent));
+  const rep = computeAvgRepeatability(recent);
+  const competitors = latest.runDate
+    ? await loadTopCompetitors(latest.runDate, 10).catch(() => [])
+    : [];
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* 헤더 */}
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">AEO Visibility</h1>
+        <p className="text-sm text-muted-foreground">
+          AI 검색 엔진(ChatGPT · Perplexity · Gemini · Claude)에서 AWC 브랜드가
+          어떻게 인용되는지 측정. 매일 KST 09시 cron 자동 실행 → Supabase 저장.
+        </p>
+      </header>
+
+      {/* KPI 요약 */}
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <KpiCard
+          label="Active Prompts"
+          value={queries.length.toString()}
+          hint="aeo_queries · is_active"
+        />
+        <KpiCard
+          label="Engines"
+          value={AEO_ENGINES.length.toString()}
+          hint={AEO_ENGINES.map((e) => ENGINE_LABEL[e]).join(" · ")}
+        />
+        <KpiCard
+          label="Last Run"
+          value={latest.runDate ?? "—"}
+          hint={`${latest.rows.length} cells`}
+        />
+        <KpiCard
+          label="Repeatability"
+          value={`${Math.round(rep.avg * 100)}%`}
+          hint="avg consistency · 최근 30일"
+        />
+      </section>
+
+      {/* SoV 시계열 */}
+      <section className="space-y-2">
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-base font-semibold">Share of Voice — 30일</h2>
+          <span className="text-xs text-muted-foreground">
+            mention + citation + recommendation 비율
+          </span>
+        </div>
+        <SovChart data={sovChart} />
+      </section>
+
+      {/* 엔진별 Repeatability */}
+      {Object.keys(rep.byEngine).length > 0 ? (
+        <section className="space-y-2">
+          <h2 className="text-base font-semibold">엔진별 Repeatability</h2>
+          <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+            {AEO_ENGINES.map((e) => {
+              const v = rep.byEngine[e] ?? null;
+              return (
+                <div key={e} className="rounded-lg border px-3 py-2 text-sm">
+                  <div className="text-xs text-muted-foreground">
+                    {ENGINE_LABEL[e]}
+                  </div>
+                  <div className="mt-0.5 font-mono text-base">
+                    {v != null ? `${Math.round(v * 100)}%` : "—"}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            10-run 다수결의 일관성. &gt;70% strong / 30~70% moderate / &lt;30% volatile
+            (Maximus Labs SoV methodology).
+          </p>
+        </section>
+      ) : null}
+
+      {/* 경쟁자 co-mention */}
+      {competitors.length > 0 ? (
+        <section className="space-y-2">
+          <h2 className="text-base font-semibold">Top Competitors (마지막 run)</h2>
+          <div className="flex flex-wrap gap-2">
+            {competitors.map((c) => (
+              <span
+                key={c.name}
+                className="inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs"
+              >
+                <span className="font-medium">{c.name}</span>
+                <span className="text-muted-foreground">{c.count}</span>
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {/* 매트릭스 + 드릴다운 */}
+      <section className="space-y-2">
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-base font-semibold">
+            Results Matrix
+            {latest.runDate ? (
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                · {latest.runDate}
+              </span>
+            ) : null}
+          </h2>
+          <span className="text-xs text-muted-foreground">
+            cell 클릭 → 10 attempts raw response
+          </span>
+        </div>
+        <ResultsMatrix
+          queries={queries}
+          finals={latest.rows}
+          runDate={latest.runDate}
+        />
+      </section>
+    </div>
+  );
+}
+
+function KpiCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border bg-card px-4 py-3">
+      <div className="text-xs uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 text-xl font-semibold tabular-nums">{value}</div>
+      {hint ? (
+        <div className="mt-0.5 text-xs text-muted-foreground">{hint}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/aeo/results-matrix.tsx
+++ b/dashboard/src/app/(dashboard)/aeo/results-matrix.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AEO_ENGINES,
+  ENGINE_LABEL,
+  type AeoEngine,
+  type AeoFinalRow,
+  type AeoQuery,
+  type AeoResultRow,
+} from "@/lib/aeo";
+import { fetchCellResults } from "./actions";
+
+const JUDGMENT_BADGE: Record<string, { label: string; cls: string }> = {
+  recommendation: {
+    label: "추천",
+    cls: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  },
+  citation: {
+    label: "인용",
+    cls: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+  },
+  mention: {
+    label: "언급",
+    cls: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  },
+  none: {
+    label: "—",
+    cls: "bg-muted text-muted-foreground",
+  },
+  negative: {
+    label: "부정",
+    cls: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
+  },
+};
+
+interface Props {
+  queries: AeoQuery[];
+  finals: AeoFinalRow[];
+  runDate: string | null;
+}
+
+export default function ResultsMatrix({ queries, finals, runDate }: Props) {
+  // (queryId, engine) → final
+  const finalIdx = new Map<string, AeoFinalRow>();
+  for (const f of finals) finalIdx.set(`${f.query_id}::${f.engine}`, f);
+
+  const [open, setOpen] = useState<{
+    queryId: string;
+    engine: AeoEngine;
+    query: AeoQuery;
+  } | null>(null);
+  const [drill, setDrill] = useState<AeoResultRow[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  if (!runDate) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+        측정 결과 없음 — cron 첫 실행 후 표시
+      </div>
+    );
+  }
+
+  const onDrill = async (q: AeoQuery, engine: AeoEngine) => {
+    if (!runDate) return;
+    setOpen({ queryId: q.id, engine, query: q });
+    setDrill(null);
+    setLoading(true);
+    try {
+      const rows = await fetchCellResults(q.id, engine, runDate);
+      setDrill(rows);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="border-b bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium">Keyword</th>
+              <th className="px-3 py-2 text-left font-medium">Type</th>
+              <th className="px-3 py-2 text-left font-medium">Query</th>
+              {AEO_ENGINES.map((e) => (
+                <th key={e} className="px-3 py-2 text-center font-medium">
+                  {ENGINE_LABEL[e]}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {queries.map((q) => (
+              <tr key={q.id} className="border-b last:border-b-0 hover:bg-muted/20">
+                <td className="px-3 py-2 font-medium">{q.keyword}</td>
+                <td className="px-3 py-2 text-xs text-muted-foreground">
+                  {q.query_type}
+                </td>
+                <td
+                  className="max-w-[420px] truncate px-3 py-2 text-muted-foreground"
+                  title={q.query_text}
+                >
+                  {q.query_text}
+                </td>
+                {AEO_ENGINES.map((e) => {
+                  const fr = finalIdx.get(`${q.id}::${e}`);
+                  const badge = fr
+                    ? JUDGMENT_BADGE[fr.final_judgment] ?? JUDGMENT_BADGE.none
+                    : null;
+                  return (
+                    <td key={e} className="px-2 py-2 text-center">
+                      {fr ? (
+                        <button
+                          type="button"
+                          onClick={() => onDrill(q, e)}
+                          className={`inline-flex min-w-[3.2rem] items-center justify-center rounded px-2 py-0.5 text-xs font-medium transition-opacity hover:opacity-80 ${badge!.cls}`}
+                          title={`consistency=${fr.consistency != null ? Math.round(fr.consistency * 100) + "%" : "?"}${fr.changed ? " · 변동" : ""}`}
+                        >
+                          {badge!.label}
+                          {fr.changed ? " ↑" : ""}
+                        </button>
+                      ) : (
+                        <span className="text-muted-foreground">·</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {open ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4"
+          onClick={() => setOpen(null)}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="max-h-[85vh] w-full max-w-3xl overflow-y-auto rounded-lg border bg-card p-5 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-3 flex items-start justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  {open.query.keyword} · {open.query.query_type} ·{" "}
+                  {ENGINE_LABEL[open.engine]}
+                </div>
+                <div className="mt-1 text-sm">{open.query.query_text}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(null)}
+                className="rounded p-1 text-muted-foreground hover:bg-muted"
+                aria-label="close"
+              >
+                ✕
+              </button>
+            </div>
+            {loading ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                로딩…
+              </div>
+            ) : drill && drill.length > 0 ? (
+              <div className="space-y-3">
+                {drill.map((r) => {
+                  const badge =
+                    JUDGMENT_BADGE[r.judgment] ?? JUDGMENT_BADGE.none;
+                  return (
+                    <div
+                      key={r.id}
+                      className="rounded border bg-background/60 p-3 text-sm"
+                    >
+                      <div className="mb-2 flex items-center gap-2 text-xs">
+                        <span className="font-mono text-muted-foreground">
+                          attempt {r.attempt}
+                        </span>
+                        <span
+                          className={`rounded px-1.5 py-0.5 font-medium ${badge.cls}`}
+                        >
+                          {badge.label}
+                        </span>
+                        {r.api_latency_ms != null ? (
+                          <span className="text-muted-foreground">
+                            {r.api_latency_ms}ms
+                          </span>
+                        ) : null}
+                        {r.error ? (
+                          <span className="text-rose-500">err: {r.error}</span>
+                        ) : null}
+                      </div>
+                      {r.match_context ? (
+                        <div className="mb-2 rounded bg-muted/40 px-2 py-1 text-xs italic text-muted-foreground">
+                          ±100자: {r.match_context}
+                        </div>
+                      ) : null}
+                      <pre className="whitespace-pre-wrap text-xs leading-relaxed">
+                        {r.response_text ?? "(empty)"}
+                      </pre>
+                      {r.citations && r.citations.length > 0 ? (
+                        <div className="mt-2 border-t pt-2 text-xs">
+                          <div className="mb-1 text-muted-foreground">
+                            citations ({r.citations.length})
+                          </div>
+                          <ul className="space-y-1">
+                            {r.citations.map((u, i) => (
+                              <li key={i} className="truncate">
+                                <a
+                                  href={u}
+                                  target="_blank"
+                                  rel="noreferrer noopener"
+                                  className="text-blue-500 hover:underline"
+                                >
+                                  {u}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                해당 cell raw row 없음
+              </div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/dashboard/src/app/(dashboard)/aeo/sov-chart.tsx
+++ b/dashboard/src/app/(dashboard)/aeo/sov-chart.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  Legend,
+} from "recharts";
+import { AEO_ENGINES, ENGINE_LABEL, type AeoEngine } from "@/lib/aeo";
+
+const ENGINE_COLORS: Record<AeoEngine, string> = {
+  chatgpt: "#10a37f",
+  perplexity: "#20c0c4",
+  google_aio: "#4285f4",
+  claude: "#d97706",
+};
+
+interface Props {
+  data: Array<{ run_date: string } & Partial<Record<AeoEngine, number>>>;
+}
+
+export default function SovChart({ data }: Props) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[280px] items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground">
+        측정 데이터 없음 — cron 첫 실행 후 표시
+      </div>
+    );
+  }
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <LineChart data={data} margin={{ top: 10, right: 16, left: -8, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+        <XAxis
+          dataKey="run_date"
+          fontSize={12}
+          tickFormatter={(s: string) => s.slice(5)}
+        />
+        <YAxis fontSize={12} unit="%" domain={[0, 100]} />
+        <Tooltip
+          formatter={(v: number) => `${v}%`}
+          contentStyle={{
+            background: "hsl(var(--background))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 6,
+          }}
+        />
+        <Legend formatter={(v: string) => ENGINE_LABEL[v as AeoEngine] ?? v} />
+        {AEO_ENGINES.map((e) => (
+          <Line
+            key={e}
+            type="monotone"
+            dataKey={e}
+            stroke={ENGINE_COLORS[e]}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+            connectNulls
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/dashboard/src/components/layout/app-sidebar.tsx
+++ b/dashboard/src/components/layout/app-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   TrendingUpIcon,
   PenSquareIcon,
   GalleryHorizontalIcon,
+  RadarIcon,
 } from "lucide-react";
 import {
   Sidebar,
@@ -84,6 +85,7 @@ const intelligenceNavItems: NavItem[] = [
   // 하위에 페이지가 늘어나면 그룹명을 유지하고 item 은 구체명(Traffic) 을 쓴다.
   // 기존 e2e 테스트(analytics.spec.ts) 가 "Traffic" text 로 assert 하므로 유지.
   { title: "Traffic", url: "/analytics/traffic", icon: TrendingUpIcon },
+  { title: "AEO Visibility", url: "/aeo", icon: RadarIcon },
   { title: "Activity", url: "/activity", icon: ActivityIcon },
 ];
 

--- a/dashboard/src/lib/aeo.ts
+++ b/dashboard/src/lib/aeo.ts
@@ -1,0 +1,259 @@
+import { getSupabase } from "./supabase";
+
+// brxce.ai/packages/aeo 의 EngineKey 와 동일. 신규 엔진 추가 시 양쪽 동기.
+// (DB CHECK constraint: aeo_results_engine_check)
+export const AEO_ENGINES = ["chatgpt", "perplexity", "google_aio", "claude"] as const;
+export type AeoEngine = (typeof AEO_ENGINES)[number];
+
+export const ENGINE_LABEL: Record<AeoEngine, string> = {
+  chatgpt: "ChatGPT",
+  perplexity: "Perplexity",
+  google_aio: "Gemini",
+  claude: "Claude",
+};
+
+// 5단계 판정 (brxce.ai/packages/aeo/src/judge.ts).
+export type AeoJudgmentType =
+  | "negative"
+  | "none"
+  | "mention"
+  | "citation"
+  | "recommendation";
+
+export interface AeoQuery {
+  id: string;
+  keyword: string;
+  keyword_type: "market" | "brand";
+  query_text: string;
+  query_type: "info" | "recommend" | "compare" | "problem" | "case";
+  language: string;
+  is_active: boolean;
+}
+
+export interface AeoFinalRow {
+  id: string;
+  query_id: string;
+  engine: AeoEngine;
+  run_date: string;
+  final_judgment: AeoJudgmentType;
+  final_score: number;
+  consistency: number | null;
+  prev_judgment: AeoJudgmentType | null;
+  changed: boolean;
+  first_detected_at: string | null;
+  attempt_judgments: { type: AeoJudgmentType; score: number }[] | null;
+}
+
+export interface AeoResultRow {
+  id: string;
+  query_id: string;
+  engine: AeoEngine;
+  run_id: string;
+  run_date: string;
+  attempt: number;
+  response_text: string | null;
+  citations: string[] | null;
+  judgment: AeoJudgmentType;
+  score: number;
+  matched_brands: string[] | null;
+  matched_urls: string[] | null;
+  match_context: string | null;
+  competitor_mentions: { name: string }[] | null;
+  api_latency_ms: number | null;
+  error: string | null;
+  created_at: string;
+}
+
+// ── Queries (정적 마스터) ─────────────────────────────────
+export async function loadAeoQueries(): Promise<AeoQuery[]> {
+  const supa = getSupabase();
+  const { data, error } = await supa
+    .from("aeo_queries")
+    .select("*")
+    .eq("is_active", true)
+    .order("keyword", { ascending: true })
+    .order("query_type", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as AeoQuery[];
+}
+
+// ── Final results (다수결 확정) ────────────────────────────
+// 최근 N일 final results — 시계열 차트 source.
+export async function loadFinalResultsRecent(days = 30): Promise<AeoFinalRow[]> {
+  const supa = getSupabase();
+  const since = new Date(Date.now() - days * 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+  const { data, error } = await supa
+    .from("aeo_final_results")
+    .select(
+      "id, query_id, engine, run_date, final_judgment, final_score, consistency, prev_judgment, changed, first_detected_at, attempt_judgments",
+    )
+    .gte("run_date", since)
+    .order("run_date", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as AeoFinalRow[];
+}
+
+// 마지막 run_date 의 모든 final results — 매트릭스 source.
+export async function loadFinalResultsLatest(): Promise<{
+  rows: AeoFinalRow[];
+  runDate: string | null;
+}> {
+  const supa = getSupabase();
+  const { data: dates, error: dErr } = await supa
+    .from("aeo_final_results")
+    .select("run_date")
+    .order("run_date", { ascending: false })
+    .limit(1);
+  if (dErr) throw dErr;
+  const runDate = dates?.[0]?.run_date ?? null;
+  if (!runDate) return { rows: [], runDate: null };
+
+  const { data, error } = await supa
+    .from("aeo_final_results")
+    .select(
+      "id, query_id, engine, run_date, final_judgment, final_score, consistency, prev_judgment, changed, first_detected_at, attempt_judgments",
+    )
+    .eq("run_date", runDate);
+  if (error) throw error;
+  return { rows: (data ?? []) as AeoFinalRow[], runDate };
+}
+
+// ── Raw results (드릴다운) ─────────────────────────────────
+export async function loadResultsForCell(
+  queryId: string,
+  engine: AeoEngine,
+  runDate: string,
+): Promise<AeoResultRow[]> {
+  const supa = getSupabase();
+  const { data, error } = await supa
+    .from("aeo_results")
+    .select(
+      "id, query_id, engine, run_id, run_date, attempt, response_text, citations, judgment, score, matched_brands, matched_urls, match_context, competitor_mentions, api_latency_ms, error, created_at",
+    )
+    .eq("query_id", queryId)
+    .eq("engine", engine)
+    .eq("run_date", runDate)
+    .order("attempt", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as AeoResultRow[];
+}
+
+// ── Aggregations ───────────────────────────────────────────
+
+// Share of Voice — N×Q 표본에서 brand-present(mention/citation/recommendation) 비율.
+// 엔진별 × run_date별. 시계열 차트에 그대로 쓰임.
+export interface SovPoint {
+  run_date: string;
+  engine: AeoEngine;
+  sov: number; // 0~1
+  presentCount: number;
+  totalCount: number;
+}
+
+export function computeSovTimeseries(rows: AeoFinalRow[]): SovPoint[] {
+  const buckets = new Map<string, { present: number; total: number }>();
+  for (const r of rows) {
+    const k = `${r.run_date}::${r.engine}`;
+    const b = buckets.get(k) ?? { present: 0, total: 0 };
+    b.total += 1;
+    if (
+      r.final_judgment === "mention" ||
+      r.final_judgment === "citation" ||
+      r.final_judgment === "recommendation"
+    ) {
+      b.present += 1;
+    }
+    buckets.set(k, b);
+  }
+  const points: SovPoint[] = [];
+  for (const [k, v] of buckets) {
+    const [run_date, engine] = k.split("::") as [string, AeoEngine];
+    points.push({
+      run_date,
+      engine,
+      sov: v.total > 0 ? v.present / v.total : 0,
+      presentCount: v.present,
+      totalCount: v.total,
+    });
+  }
+  return points.sort((a, b) =>
+    a.run_date < b.run_date ? -1 : a.run_date > b.run_date ? 1 : 0,
+  );
+}
+
+// recharts 친화적 wide-format. 한 행에 run_date + 엔진별 sov 컬럼.
+export function pivotSovForChart(
+  points: SovPoint[],
+): Array<{ run_date: string } & Partial<Record<AeoEngine, number>>> {
+  const map = new Map<
+    string,
+    { run_date: string } & Partial<Record<AeoEngine, number>>
+  >();
+  for (const p of points) {
+    const row = map.get(p.run_date) ?? { run_date: p.run_date };
+    row[p.engine] = Math.round(p.sov * 1000) / 10; // 백분율 1자리
+    map.set(p.run_date, row);
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.run_date < b.run_date ? -1 : a.run_date > b.run_date ? 1 : 0,
+  );
+}
+
+// Repeatability 평균 (consistency 평균).
+export function computeAvgRepeatability(rows: AeoFinalRow[]): {
+  avg: number; // 0~1
+  byEngine: Partial<Record<AeoEngine, number>>;
+} {
+  let sum = 0;
+  let count = 0;
+  const eng = new Map<AeoEngine, { sum: number; count: number }>();
+  for (const r of rows) {
+    if (r.consistency == null) continue;
+    sum += r.consistency;
+    count += 1;
+    const b = eng.get(r.engine) ?? { sum: 0, count: 0 };
+    b.sum += r.consistency;
+    b.count += 1;
+    eng.set(r.engine, b);
+  }
+  const byEngine: Partial<Record<AeoEngine, number>> = {};
+  for (const [k, v] of eng) {
+    byEngine[k] = v.count > 0 ? v.sum / v.count : 0;
+  }
+  return { avg: count > 0 ? sum / count : 0, byEngine };
+}
+
+// 경쟁자 co-mention top N — final_results 에는 competitor 정보가 없어 raw results
+// (aeo_results.competitor_mentions) 에서 집계 필요. 최근 run 기준.
+export async function loadTopCompetitors(
+  runDate: string,
+  limit = 10,
+): Promise<{ name: string; count: number }[]> {
+  const supa = getSupabase();
+  const { data, error } = await supa
+    .from("aeo_results")
+    .select("competitor_mentions")
+    .eq("run_date", runDate);
+  if (error) throw error;
+  const counts = new Map<string, number>();
+  for (const row of data ?? []) {
+    const ms = (row as { competitor_mentions?: unknown[] }).competitor_mentions;
+    if (!Array.isArray(ms)) continue;
+    for (const m of ms) {
+      const name =
+        typeof m === "string"
+          ? m
+          : typeof (m as { name?: unknown })?.name === "string"
+            ? (m as { name: string }).name
+            : null;
+      if (!name) continue;
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}


### PR DESCRIPTION
## 요약

brxce.ai/packages/aeo 가 매일 KST 09시 cron 으로 측정한 AEO 데이터를 별도 ETL 없이 시각화하는 \`/aeo\` 페이지 신규.

agentic-cms multi-tenant 패턴이라 \`.env.local\` 의 \`NEXT_PUBLIC_SUPABASE_URL\` + \`SUPABASE_SERVICE_ROLE_KEY\` 만 brxce.ai 와 동일하게 채우면 동작.

## 구성

| 영역 | 컴포넌트 |
|---|---|
| KPI 4 카드 | Active Prompts / Engines / Last Run / Repeatability avg |
| Share of Voice 30일 시계열 | recharts LineChart, 4 엔진 라인 |
| 엔진별 Repeatability | 4 카드, >70% strong / 30~70% / <30% volatile (Maximus Labs SoV methodology) |
| Top Competitors | 마지막 run 기준 top 10 chip |
| Results Matrix | queries × engines, cell 클릭 → 10 attempts raw response modal |

## 데이터 소스

- \`aeo_queries\` — Active prompts
- \`aeo_final_results\` — 다수결 확정 (KPI/시계열/매트릭스)
- \`aeo_results\` — raw 10 attempts (cell 드릴다운 modal)

## 변경 파일

- \`dashboard/src/app/(dashboard)/aeo/page.tsx\` (server component, 데이터 fetch)
- \`dashboard/src/app/(dashboard)/aeo/sov-chart.tsx\` (client, recharts)
- \`dashboard/src/app/(dashboard)/aeo/results-matrix.tsx\` (client, modal 드릴다운)
- \`dashboard/src/app/(dashboard)/aeo/actions.ts\` (server action — fetchCellResults)
- \`dashboard/src/lib/aeo.ts\` (Supabase 쿼리 + 집계 헬퍼 — SoV/Repeatability/competitors)
- \`dashboard/src/components/layout/app-sidebar.tsx\` (Intelligence > AEO Visibility nav)
- \`dashboard/package.json\` + \`package-lock.json\` (recharts 의존성)

## 머지 전 필요

\`dashboard/.env.local\` 에 brxce.ai 와 동일한 \`NEXT_PUBLIC_SUPABASE_URL\` + \`SUPABASE_SERVICE_ROLE_KEY\` 설정. (multi-tenant 운영 패턴 — 별도 secrets 파이프라인 없음)

## 검증

- typecheck: \`/aeo\` 영역 에러 0건 (기존 lowlight/slate-hyperscript 미충족 2건은 본 PR 무관)
- 로컬 dev server (next dev, port 3000) 기동 후 Playwright /aeo navigation 확인
- 화면 렌더 결과 (현재 prod DB 기준 25 prompts × 4 engines, 마지막 run 2026-04-01):
  - 4 KPI 카드, SoV 차트, Repeatability 4 카드, Top Competitors 5 chip, Results Matrix 25 rows 모두 정상 렌더

## 후속

- brxce.ai PR #505 머지 본 후 prod DB에 75 prompts + 4 engines 적용되면 매트릭스 75 × 4 자동 확장 (코드 변경 없음)
- 데이터가 누적되면 SoV 시계열에 라인이 점점 의미있게 그려짐 (현재는 1점이라 dot 만)

## 결정 anchor

ledger \`d_ca94f9e\` — AEO 대시보드는 agentic-cms dashboard 재활용 (별도 UI 신규 X)
ledger task \`t_a04f2f5\`