### PR TITLE
feat(analytics): 트래픽 화면을 의사결정 단위 액션 큐로 재구성

### DIFF
--- a/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
+++ b/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
@@ -213,6 +213,8 @@ interface GA4Data {
     logins: number;
   };
   ctaClicks: { ctaId: string; count: number }[];
+  channels?: { channel: string; sessions: number; engagedSessions: number; engagementRate: number; avgSessionDuration: number; keyEvents: number }[];
+  organicLanding?: { path: string; sessions: number; engagedSessions: number; engagementRate: number; avgSessionDuration: number; keyEvents: number }[];
 }
 
 function GA4Tab() {
@@ -269,6 +271,9 @@ function GA4Tab() {
         <PeriodSelector days={days} onChange={setDays} />
       </div>
 
+      <GA4InsightCards data={data} />
+
+      <SectionHeader title="기간 합계" description="이 5 지표가 분석의 기준선입니다. 위 인사이트 카드는 이 합계를 channel/landing/funnel 단위로 분해한 것입니다." />
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
         <MetricCard label="페이지뷰" value={fmtNum(data.overview.pageViews)} note="화면/페이지가 조회된 총량입니다." />
         <MetricCard label="사용자" value={fmtNum(data.overview.users)} note="기간 내 이벤트를 남긴 고유 사용자입니다." />
@@ -276,6 +281,10 @@ function GA4Tab() {
         <MetricCard label="평균 세션 시간" value={`${Math.round(data.overview.avgSessionDuration)}s`} note="방문당 머무른 평균 시간입니다." />
         <MetricCard label="이탈률" value={`${(data.overview.bounceRate * 100).toFixed(1)}%`} note="참여 조건을 충족하지 못한 세션 비율입니다." />
       </div>
+
+      <GA4ChannelsTable channels={data.channels} />
+
+      <GA4OrganicLanding rows={data.organicLanding} />
 
       <div className="bg-[#141414] border border-[#222] rounded-xl p-4">
         <SectionHeader title="콘텐츠 소비 추이" description="일별 페이지뷰와 사용자를 함께 보며 콘텐츠 소비량이 실제 방문자 증가를 동반했는지 확인합니다." />
@@ -476,6 +485,38 @@ interface GSCData {
   daily: { date: string; clicks: number; impressions: number; ctr: number; position: number }[];
   countries?: { country: string; clicks: number; impressions: number; ctr: number; position: number }[];
   devices?: { device: string; clicks: number; impressions: number; ctr: number; position: number }[];
+  tracked?: {
+    query: string;
+    rows: { date: string; clicks: number; impressions: number; ctr: number; position: number }[];
+    totals: { clicks: number; impressions: number; avgPosition: number; avgCtr: number };
+  }[];
+}
+
+// position 기준 분류 — Google 검색결과 페이지 위치를 그대로 의사결정으로 변환.
+// 1~3: 1~3위 / 4~10: 1페이지 후반 / 11~20: 2페이지 (끌어올림 후보 핵심)
+// 21~30: 3페이지 (장기 후보) / 31+: 색인 됐지만 노출 거의 없음
+function classifyPosition(pos: number): { tier: string; tone: string; label: string } {
+  if (pos <= 3) return { tier: "top3", tone: "text-emerald-300", label: "Top 3" };
+  if (pos <= 10) return { tier: "page1", tone: "text-cyan-300", label: "1페이지" };
+  if (pos <= 20) return { tier: "page2", tone: "text-amber-300", label: "2페이지" };
+  if (pos <= 30) return { tier: "page3", tone: "text-orange-300", label: "3페이지" };
+  return { tier: "tail", tone: "text-[#666]", label: "4페이지+" };
+}
+
+// position 별 평균 CTR 기대치 (Sistrix 2024 click study 등 업계 통념 기반).
+// "이 위치에서 이 정도 CTR은 나와야 한다"의 baseline.
+const POSITION_CTR_BASELINE: { range: [number, number]; ctr: number }[] = [
+  { range: [1, 1], ctr: 0.395 },
+  { range: [2, 2], ctr: 0.184 },
+  { range: [3, 3], ctr: 0.10 },
+  { range: [4, 5], ctr: 0.062 },
+  { range: [6, 10], ctr: 0.025 },
+  { range: [11, 20], ctr: 0.012 },
+  { range: [21, 100], ctr: 0.005 },
+];
+function expectedCtr(pos: number): number {
+  for (const b of POSITION_CTR_BASELINE) if (pos >= b.range[0] && pos <= b.range[1]) return b.ctr;
+  return 0.005;
 }
 
 function GSCTab() {
@@ -538,6 +579,13 @@ function GSCTab() {
         </div>
       )}
 
+      <GSCInsightCards data={data} />
+
+      <GSCTrackedKeywords tracked={data.tracked} days={days} />
+
+      <GSCDeviceComparison devices={data.devices} />
+
+      <SectionHeader title="기간 합계" description="이 4 지표가 분석의 기준선입니다. 노출 대비 클릭이 따라오는지, 평균 순위가 1페이지 안인지 한눈에 봅니다." />
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <MetricCard label="총 클릭수" value={fmtNum(data.overview.totalClicks)} note="Google 검색결과에서 사이트로 들어온 클릭입니다." />
         <MetricCard label="총 노출수" value={fmtNum(data.overview.totalImpressions)} note="검색결과에 사이트가 표시된 횟수입니다." />
@@ -563,6 +611,9 @@ function GSCTab() {
           <div className="text-center py-10 text-[#555] text-sm">차트 데이터 없음</div>
         )}
       </div>
+      <GSCPushCandidates pages={data.pages} />
+
+      <SectionHeader title="원본 데이터" description="아래 토글로 검색어/페이지/국가/기기 단위 raw 데이터를 차원 변경하며 직접 확인합니다. 위 인사이트 카드는 이 raw 데이터를 의사결정 단위로 묶은 것입니다." />
       <div className="flex gap-1">
         {([["queries", "검색어"], ["pages", "페이지"], ["countries", "국가"], ["devices", "기기"]] as const).map(([key, label]) => (
           <button key={key} onClick={() => setView(key)} className={`px-3 py-1 rounded text-xs font-medium transition-colors ${view === key ? "bg-[#333] text-white" : "text-[#888] hover:text-white"}`}>{label}</button>
@@ -615,9 +666,20 @@ function GSCTab() {
                   view === "countries" ? formatCountry(rawKey) :
                   view === "devices" ? formatDevice(rawKey) :
                   rawKey;
+                const cls = classifyPosition(r.position);
+                const ctrExpected = expectedCtr(r.position);
+                const ctrLow = r.position <= 10 && r.impressions >= 30 && r.ctr < ctrExpected * 0.5;
                 return (
                   <tr key={rawKey} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
-                    <td className="px-4 py-2 text-[#ccc] max-w-[300px] truncate">{label}</td>
+                    <td className="px-4 py-2 text-[#ccc] max-w-[300px] truncate">
+                      {label}
+                      {(view === "queries" || view === "pages") && r.position > 0 && (
+                        <span className={`ml-2 inline-block rounded border border-[#222] bg-[#0d0d0d] px-1.5 py-0.5 text-[10px] ${cls.tone}`}>{cls.label}</span>
+                      )}
+                      {ctrLow && (view === "queries" || view === "pages") && (
+                        <span className="ml-1 inline-block rounded border border-amber-900/50 bg-amber-950/30 px-1.5 py-0.5 text-[10px] text-amber-300">CTR 부진</span>
+                      )}
+                    </td>
                     <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.clicks)}</td>
                     <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.impressions)}</td>
                     <td className="px-4 py-2 text-right text-[#4ECDC4]">{(r.ctr * 100).toFixed(1)}%</td>
@@ -630,5 +692,370 @@ function GSCTab() {
         </table>
       </div>
     </div>
+  );
+}
+
+/* ─── GSC Insight helpers ─── */
+
+// 인사이트 액션 큐 4 카드 — 검색 의사결정 5축 中 핵심 4축을 한 화면에.
+// 1. 끌어올림 후보  2. CTR 부진  3. 모바일 격차  4. 추적 키워드 가시성
+function GSCInsightCards({ data }: { data: GSCData }) {
+  const pushCandidates = data.pages.filter((p) => p.position >= 8 && p.position <= 20 && p.impressions >= 30);
+  const ctrLowQueries = data.queries.filter((q) => q.position <= 10 && q.impressions >= 30 && q.ctr < expectedCtr(q.position) * 0.5);
+  const desktop = data.devices?.find((d) => d.device.toUpperCase() === "DESKTOP");
+  const mobile = data.devices?.find((d) => d.device.toUpperCase() === "MOBILE");
+  const deviceGap = desktop && mobile && mobile.position > 0 && desktop.position > 0
+    ? Math.round((mobile.position - desktop.position) * 10) / 10
+    : null;
+  const trackedVisible = (data.tracked || []).filter((t) => t.totals.impressions > 0).length;
+  const trackedTotal = data.tracked?.length ?? 0;
+
+  return (
+    <>
+      <SectionHeader title="이번 기간의 액션 큐" description="raw 숫자 위에 의사결정 분류를 얹어 어떤 항목이 다음 행동을 요구하는지 한눈에 봅니다. 0건이라도 의미 있는 진단입니다 — 0이면 그 카테고리에서 즉시 할 일이 없다는 뜻." />
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <InsightCard
+          tone={pushCandidates.length > 0 ? "amber" : "muted"}
+          label="페이지 끌어올림 후보"
+          value={`${pushCandidates.length}건`}
+          note={pushCandidates.length > 0
+            ? "위치 8~20 + 노출 ≥30. 메타·내부 링크·콘텐츠 보강으로 1페이지 진입을 노립니다."
+            : "위치 8~20 + 노출 ≥30 페이지 없음. 노출이 더 쌓일 때까지 기다리거나 신규 글로 노출 자체를 만듭니다."}
+        />
+        <InsightCard
+          tone={ctrLowQueries.length > 0 ? "rose" : "muted"}
+          label="CTR 부진 검색어"
+          value={`${ctrLowQueries.length}건`}
+          note={ctrLowQueries.length > 0
+            ? "1페이지 안인데 위치 평균 CTR 절반 이하. 제목·메타 description 재작성 우선순위."
+            : "1페이지 검색어들이 모두 기대 CTR 충족. 제목/메타는 현재 형태 유지."}
+        />
+        <InsightCard
+          tone={deviceGap !== null && deviceGap >= 3 ? "amber" : "muted"}
+          label="모바일 격차"
+          value={deviceGap === null ? "—" : `${deviceGap >= 0 ? "+" : ""}${deviceGap.toFixed(1)} 위`}
+          note={deviceGap === null
+            ? "모바일/데스크톱 비교 데이터 부족."
+            : deviceGap >= 3
+              ? "모바일 평균 위치가 데스크톱보다 3 위 이상 낮음. Core Web Vitals·모바일 레이아웃 점검 필요."
+              : "모바일/데스크톱 위치 차이 정상 범위."}
+        />
+        <InsightCard
+          tone={trackedVisible > 0 ? "emerald" : "muted"}
+          label="추적 키워드 가시성"
+          value={`${trackedVisible}/${trackedTotal}`}
+          note={trackedVisible > 0
+            ? `${trackedVisible}개 키워드는 노출 발생. 위치 추이 차트로 순위 추세를 봅니다.`
+            : "4 추적 키워드 모두 노출 0건. 색인 요청·콘텐츠 매칭부터 점검합니다."}
+        />
+      </div>
+    </>
+  );
+}
+
+function InsightCard({ tone, label, value, note }: { tone: "amber" | "rose" | "emerald" | "muted"; label: string; value: string; note: string }) {
+  const toneCls = {
+    amber: "border-amber-900/50 bg-amber-950/20",
+    rose: "border-rose-900/50 bg-rose-950/20",
+    emerald: "border-emerald-900/50 bg-emerald-950/20",
+    muted: "border-[#222] bg-[#141414]",
+  }[tone];
+  const valueTone = {
+    amber: "text-amber-200",
+    rose: "text-rose-200",
+    emerald: "text-emerald-200",
+    muted: "text-[#ddd]",
+  }[tone];
+  return (
+    <div className={`rounded-xl border ${toneCls} p-4`}>
+      <div className="text-xs text-[#aaa]">{label}</div>
+      <div className={`mt-1 text-2xl font-bold tabular-nums ${valueTone}`}>{value}</div>
+      <div className="mt-2 text-xs leading-5 text-[#888]">{note}</div>
+    </div>
+  );
+}
+
+// 추적 키워드 4개 — 카드 + 위치 mini chart. 아직 노출 0이어도 카드 자체로 "트래킹 시작됨" 의미.
+function GSCTrackedKeywords({ tracked, days }: { tracked: GSCData["tracked"]; days: Period }) {
+  if (!tracked || tracked.length === 0) return null;
+  return (
+    <>
+      <SectionHeader title="추적 키워드 추이" description="awc-seo-tracker 4 핵심 키워드의 노출/평균 위치/일별 추이. 노출 0건이면 색인 미반영 또는 콘텐츠 매칭 부족 — 글에서 해당 키워드를 본문 첫 30%에 배치합니다." />
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {tracked.map((t) => {
+          const hasData = t.totals.impressions > 0;
+          return (
+            <div key={t.query} className="rounded-xl border border-[#222] bg-[#141414] p-4">
+              <div className="text-xs text-[#aaa] truncate" title={t.query}>{t.query}</div>
+              <div className="mt-1 flex items-baseline gap-2">
+                <span className={`text-xl font-bold tabular-nums ${hasData ? "text-[#ddd]" : "text-[#555]"}`}>
+                  {hasData ? `#${t.totals.avgPosition.toFixed(1)}` : "노출 0"}
+                </span>
+                {hasData && <span className="text-xs text-[#888]">평균 위치</span>}
+              </div>
+              <div className="mt-1 text-xs text-[#777]">
+                {hasData ? `${days}일간 노출 ${fmtNum(t.totals.impressions)} · 클릭 ${fmtNum(t.totals.clicks)}` : "검색결과 노출 시 위치 추이 시각화"}
+              </div>
+              {hasData && t.rows.length > 1 && (
+                <div className="mt-2 h-12">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={t.rows}>
+                      <YAxis hide reversed domain={[1, "dataMax"]} />
+                      <Line type="monotone" dataKey="position" stroke="#22d3ee" strokeWidth={1.5} dot={false} />
+                      <Tooltip contentStyle={{ backgroundColor: "#1a1a1a", border: "1px solid #333", borderRadius: 6, fontSize: 11 }} formatter={(v: number) => [`#${v.toFixed(1)}`, "위치"]} labelFormatter={(l: string) => l} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+// 모바일 vs 데스크톱 비교 — 격차를 쌍둥이 카드 + delta 박스로 강조.
+function GSCDeviceComparison({ devices }: { devices: GSCData["devices"] }) {
+  if (!devices || devices.length === 0) return null;
+  const desktop = devices.find((d) => d.device.toUpperCase() === "DESKTOP");
+  const mobile = devices.find((d) => d.device.toUpperCase() === "MOBILE");
+  if (!desktop && !mobile) return null;
+
+  const delta = desktop && mobile && mobile.position > 0 && desktop.position > 0
+    ? mobile.position - desktop.position
+    : null;
+  const ctrDelta = desktop && mobile ? (mobile.ctr - desktop.ctr) * 100 : null;
+
+  const Card = ({ title, d }: { title: string; d?: GSCData["devices"] extends (infer U)[] | undefined ? U : never }) => (
+    <div className="flex-1 rounded-xl border border-[#222] bg-[#141414] p-4">
+      <div className="text-xs text-[#aaa]">{title}</div>
+      {d ? (
+        <div className="mt-2 grid grid-cols-2 gap-3 text-sm">
+          <div><div className="text-[10px] text-[#666]">위치</div><div className="text-lg font-bold tabular-nums">{d.position.toFixed(1)}</div></div>
+          <div><div className="text-[10px] text-[#666]">CTR</div><div className="text-lg font-bold tabular-nums">{(d.ctr * 100).toFixed(1)}%</div></div>
+          <div><div className="text-[10px] text-[#666]">노출</div><div className="text-sm tabular-nums text-[#bbb]">{fmtNum(d.impressions)}</div></div>
+          <div><div className="text-[10px] text-[#666]">클릭</div><div className="text-sm tabular-nums text-[#bbb]">{fmtNum(d.clicks)}</div></div>
+        </div>
+      ) : <div className="mt-2 text-sm text-[#666]">데이터 없음</div>}
+    </div>
+  );
+
+  return (
+    <>
+      <SectionHeader title="모바일 vs 데스크톱" description="모바일 위치가 데스크톱보다 3 위 이상 낮으면 mobile-first indexing 신호 약함 — Core Web Vitals(LCP/INP/CLS), 모바일 레이아웃 시프트, 텍스트 가독성 점검 우선순위." />
+      <div className="flex flex-wrap gap-3">
+        <Card title="데스크톱" d={desktop} />
+        <Card title="모바일" d={mobile} />
+        {delta !== null && (
+          <div className={`flex flex-col justify-center rounded-xl border px-4 py-4 ${delta >= 3 ? "border-amber-900/50 bg-amber-950/20" : "border-[#222] bg-[#141414]"}`} style={{ minWidth: 220 }}>
+            <div className="text-xs text-[#aaa]">격차</div>
+            <div className={`mt-1 text-2xl font-bold tabular-nums ${delta >= 3 ? "text-amber-200" : "text-[#ddd]"}`}>
+              {delta >= 0 ? "+" : ""}{delta.toFixed(1)} 위
+            </div>
+            <div className="mt-1 text-xs text-[#888]">
+              모바일이 {delta >= 0 ? "더 낮음" : "더 높음"}
+              {ctrDelta !== null && ` · CTR ${ctrDelta >= 0 ? "+" : ""}${ctrDelta.toFixed(1)}%p`}
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+/* ─── GA4 Insight helpers ─── */
+
+// GA4 인사이트 카드 — 검색→체류→전환 funnel 의 각 단계 진단.
+// 1. Organic Search 비중  2. Organic 참여율  3. 전환 핵심 이벤트  4. 신호 누락 (key event 마킹 안 됨 등)
+function GA4InsightCards({ data }: { data: GA4Data }) {
+  const totalSessions = data.channels?.reduce((s, c) => s + c.sessions, 0) ?? data.overview.sessions;
+  const organic = data.channels?.find((c) => c.channel === "Organic Search");
+  const organicShare = totalSessions > 0 && organic ? (organic.sessions / totalSessions) * 100 : 0;
+  const totalKeyEvents = data.channels?.reduce((s, c) => s + c.keyEvents, 0) ?? 0;
+  const newsletter = data.conversions?.newsletter;
+  const newsletterFormViews = newsletter?.formViews ?? 0;
+  const newsletterSubmits = newsletter?.submits ?? 0;
+
+  // 신호 누락 진단: key event 0인데 sign_up/cta_click 같은 이벤트는 흐르고 있으면 GA4 admin에서 마킹 안 된 상태.
+  const eventCount = (name: string) => data.events?.find((e) => e.eventName === name)?.count ?? 0;
+  const hasEventTraffic = eventCount("sign_up") + eventCount("cta_click") + newsletterSubmits > 0;
+  const keyEventsMissingMark = totalKeyEvents === 0 && hasEventTraffic;
+
+  return (
+    <>
+      <SectionHeader title="이번 기간의 액션 큐" description="검색 → 도착 → 체류 → 전환의 4단계 funnel 에서 어디가 좋고 어디가 막히는지 카드 한 줄로 진단합니다." />
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <InsightCard
+          tone={organicShare >= 10 ? "emerald" : organicShare > 0 ? "amber" : "rose"}
+          label="Organic Search 비중"
+          value={organic ? `${organicShare.toFixed(1)}%` : "—"}
+          note={organic
+            ? `세션 ${fmtNum(organic.sessions)} / 전체 ${fmtNum(totalSessions)}. 검색 유입을 늘리려면 GSC 끌어올림 후보부터 처리합니다.`
+            : "Organic Search 채널 데이터 없음."}
+        />
+        <InsightCard
+          tone={organic && organic.engagementRate >= 0.6 ? "emerald" : organic && organic.engagementRate >= 0.4 ? "amber" : organic ? "rose" : "muted"}
+          label="검색 유입 참여율"
+          value={organic ? `${(organic.engagementRate * 100).toFixed(1)}%` : "—"}
+          note={organic
+            ? organic.engagementRate >= 0.6
+              ? "검색으로 들어온 사용자가 잘 머무릅니다. 콘텐츠 의도 매칭 정상."
+              : organic.engagementRate >= 0.4
+                ? "참여율 보통. 본문 첫 200자·H2 구조·내부 링크 점검."
+                : "검색 의도 mismatch 의심. 본문 첫 30%에 검색어와 정확히 매칭되는 답을 배치."
+            : "Organic Search 데이터 없음."}
+        />
+        <InsightCard
+          tone={newsletterSubmits > 0 ? "emerald" : newsletterFormViews > 0 ? "amber" : "rose"}
+          label="뉴스레터 funnel"
+          value={`${fmtNum(newsletterFormViews)} → ${fmtNum(newsletterSubmits)}`}
+          note={newsletterFormViews === 0
+            ? "form_view 0 — 폼이 페이지에 노출되지 않거나 SubscribeForm IntersectionObserver 미발화."
+            : newsletterSubmits === 0
+              ? "form_view 발생, submit 0. 폼 UX·이메일 검증·전송 에러 로그 점검."
+              : `전환율 ${((newsletterSubmits / newsletterFormViews) * 100).toFixed(1)}%. 정상 흐름.`}
+        />
+        <InsightCard
+          tone={keyEventsMissingMark ? "rose" : totalKeyEvents > 0 ? "emerald" : "muted"}
+          label="Key event 마킹"
+          value={totalKeyEvents > 0 ? fmtNum(totalKeyEvents) : keyEventsMissingMark ? "❗ 누락" : "—"}
+          note={keyEventsMissingMark
+            ? "이벤트는 흐르는데 keyEvents 카운트 0 — GA4 admin → 이벤트 → '핵심 이벤트로 표시' ON 필요."
+            : totalKeyEvents > 0
+              ? "GA4 admin 에 핵심 이벤트가 마킹되어 funnel 전환을 측정 중."
+              : "측정 가능한 핵심 이벤트 트래픽 자체가 적습니다."}
+        />
+      </div>
+    </>
+  );
+}
+
+// 채널별 세션·참여·전환 — Organic Search 비중과 채널별 품질 비교.
+function GA4ChannelsTable({ channels }: { channels: GA4Data["channels"] }) {
+  if (!channels || channels.length === 0) return null;
+  return (
+    <>
+      <SectionHeader title="채널별 유입 품질" description="Direct/Organic Social/Organic Search/Referral 등 채널별 세션·참여율·핵심 이벤트. 어느 채널을 늘릴지, 어느 채널이 새는지 한 화면에서 비교합니다." />
+      <div className="rounded-xl border border-[#222] bg-[#141414] overflow-hidden">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-[#222] text-[#888]">
+              <th className="px-4 py-3 text-left">채널</th>
+              <th className="px-4 py-3 text-right">세션</th>
+              <th className="px-4 py-3 text-right">참여 세션</th>
+              <th className="px-4 py-3 text-right">참여율</th>
+              <th className="px-4 py-3 text-right">평균 체류</th>
+              <th className="px-4 py-3 text-right">핵심 이벤트</th>
+            </tr>
+          </thead>
+          <tbody>
+            {channels.map((c) => {
+              const isOrganic = c.channel === "Organic Search";
+              return (
+                <tr key={c.channel} className={`border-b border-[#1a1a1a] hover:bg-[#1a1a1a] ${isOrganic ? "bg-cyan-950/15" : ""}`}>
+                  <td className="px-4 py-2 text-[#ccc]">
+                    {c.channel}
+                    {isOrganic && <span className="ml-2 inline-block rounded border border-cyan-900/50 bg-cyan-950/30 px-1.5 py-0.5 text-[10px] text-cyan-300">검색 유입</span>}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">{fmtNum(c.sessions)}</td>
+                  <td className="px-4 py-2 text-right tabular-nums">{fmtNum(c.engagedSessions)}</td>
+                  <td className="px-4 py-2 text-right text-[#4ECDC4]">{(c.engagementRate * 100).toFixed(1)}%</td>
+                  <td className="px-4 py-2 text-right text-[#888]">{Math.round(c.avgSessionDuration)}s</td>
+                  <td className="px-4 py-2 text-right tabular-nums">{fmtNum(c.keyEvents)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+// Organic Search 만 필터한 landing page 별 engagement — 검색 유입 콘텐츠 품질.
+function GA4OrganicLanding({ rows }: { rows: GA4Data["organicLanding"] }) {
+  if (!rows || rows.length === 0) return null;
+  return (
+    <>
+      <SectionHeader title="검색 유입 콘텐츠 품질" description="Organic Search 로 들어온 세션을 landing page 별로 분해. 참여율이 평균(60%)보다 낮은 페이지는 본문 첫 200자·H2 구조·검색어 매칭 점검 우선." />
+      <div className="rounded-xl border border-[#222] bg-[#141414] overflow-hidden">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-[#222] text-[#888]">
+              <th className="px-4 py-3 text-left">랜딩 페이지</th>
+              <th className="px-4 py-3 text-right">세션</th>
+              <th className="px-4 py-3 text-right">참여율</th>
+              <th className="px-4 py-3 text-right">평균 체류</th>
+              <th className="px-4 py-3 text-right">핵심 이벤트</th>
+              <th className="px-4 py-3 text-right">분류</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              const tag = r.engagementRate >= 0.6 ? { tone: "text-emerald-300", label: "양호" }
+                : r.engagementRate >= 0.4 ? { tone: "text-amber-300", label: "보통" }
+                : { tone: "text-rose-300", label: "개선 필요" };
+              return (
+                <tr key={r.path} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
+                  <td className="px-4 py-2 text-[#ccc] max-w-[420px] truncate">{r.path || "(not set)"}</td>
+                  <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.sessions)}</td>
+                  <td className={`px-4 py-2 text-right tabular-nums ${tag.tone}`}>{(r.engagementRate * 100).toFixed(1)}%</td>
+                  <td className="px-4 py-2 text-right text-[#888]">{Math.round(r.avgSessionDuration)}s</td>
+                  <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.keyEvents)}</td>
+                  <td className={`px-4 py-2 text-right text-[10px] ${tag.tone}`}>{tag.label}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+// 끌어올림 후보 표 — position 8~20 + 노출 ≥ 30. 노출 정렬 (낮은 hanging fruit 우선).
+function GSCPushCandidates({ pages }: { pages: GSCData["pages"] }) {
+  const candidates = pages
+    .filter((p) => p.position >= 8 && p.position <= 20 && p.impressions >= 30)
+    .sort((a, b) => b.impressions - a.impressions);
+
+  return (
+    <>
+      <SectionHeader title="끌어올림 후보 (page 2 → page 1)" description="위치 8~20 + 노출 ≥30 페이지. 메타/제목 재작성 + 내부 링크 추가 + 본문 보강만으로 1페이지 진입 가능성이 높은 hanging fruit. 비어있으면 노출 자체가 더 쌓여야 합니다." />
+      <div className="rounded-xl border border-[#222] bg-[#141414] overflow-hidden">
+        {candidates.length === 0 ? (
+          <EmptyRows label="끌어올림 후보 없음. 노출이 더 쌓이거나 신규 글로 노출을 만드세요." />
+        ) : (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-[#222] text-[#888]">
+                <th className="px-4 py-3 text-left">페이지</th>
+                <th className="px-4 py-3 text-right">위치</th>
+                <th className="px-4 py-3 text-right">노출</th>
+                <th className="px-4 py-3 text-right">클릭</th>
+                <th className="px-4 py-3 text-right">CTR</th>
+                <th className="px-4 py-3 text-right">분류</th>
+              </tr>
+            </thead>
+            <tbody>
+              {candidates.map((p) => {
+                const cls = classifyPosition(p.position);
+                return (
+                  <tr key={p.page} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
+                    <td className="px-4 py-2 text-[#ccc] max-w-[420px] truncate">{p.page}</td>
+                    <td className="px-4 py-2 text-right tabular-nums text-amber-300">{p.position.toFixed(1)}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{fmtNum(p.impressions)}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{fmtNum(p.clicks)}</td>
+                    <td className="px-4 py-2 text-right text-[#4ECDC4]">{(p.ctr * 100).toFixed(1)}%</td>
+                    <td className={`px-4 py-2 text-right text-[10px] ${cls.tone}`}>{cls.label}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </>
   );
 }

--- a/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
+++ b/dashboard/src/app/(dashboard)/analytics/traffic/page.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TrafficCompareView } from "./_components/TrafficCompareView";
 import { TrafficTodayView } from "./_components/TrafficTodayView";
 import { getTodayRangeComparisonCaption, type CompareMode, type TrafficApiResponse, type TrafficCompareApiResponse, type TrafficPreset, type TrafficTodayApiResponse } from "@/lib/analytics/traffic";
+import { isOrganicSearchChannel } from "@/lib/analytics/ga4-channels";
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
 } from "recharts";
@@ -503,8 +504,11 @@ function classifyPosition(pos: number): { tier: string; tone: string; label: str
   return { tier: "tail", tone: "text-[#666]", label: "4페이지+" };
 }
 
-// position 별 평균 CTR 기대치 (Sistrix 2024 click study 등 업계 통념 기반).
-// "이 위치에서 이 정도 CTR은 나와야 한다"의 baseline.
+// position 별 평균 CTR 기대치 — 글로벌 desktop SERP baseline (Sistrix 2024 등).
+// 주의:
+// - Korean SERP 는 Naver 영향·모바일 비중·AI Overviews/PAA box 로 실측이 30~50%
+//   낮을 수 있음. "CTR 부진" 판정은 false positive 발생 가능.
+// - 향후 자체 데이터로 position-bucketed self-baseline 계산해 대체 권장 (follow-up).
 const POSITION_CTR_BASELINE: { range: [number, number]; ctr: number }[] = [
   { range: [1, 1], ctr: 0.395 },
   { range: [2, 2], ctr: 0.184 },
@@ -727,8 +731,8 @@ function GSCInsightCards({ data }: { data: GSCData }) {
           label="CTR 부진 검색어"
           value={`${ctrLowQueries.length}건`}
           note={ctrLowQueries.length > 0
-            ? "1페이지 안인데 위치 평균 CTR 절반 이하. 제목·메타 description 재작성 우선순위."
-            : "1페이지 검색어들이 모두 기대 CTR 충족. 제목/메타는 현재 형태 유지."}
+            ? "1페이지 안인데 위치별 글로벌 baseline CTR 의 절반 이하 (Korean SERP 는 실측이 더 낮을 수 있어 false positive 가능). 제목·메타 재작성 후보."
+            : "1페이지 검색어들이 모두 글로벌 기대 CTR 충족."}
         />
         <InsightCard
           tone={deviceGap !== null && deviceGap >= 3 ? "amber" : "muted"}
@@ -816,18 +820,10 @@ function GSCTrackedKeywords({ tracked, days }: { tracked: GSCData["tracked"]; da
 }
 
 // 모바일 vs 데스크톱 비교 — 격차를 쌍둥이 카드 + delta 박스로 강조.
-function GSCDeviceComparison({ devices }: { devices: GSCData["devices"] }) {
-  if (!devices || devices.length === 0) return null;
-  const desktop = devices.find((d) => d.device.toUpperCase() === "DESKTOP");
-  const mobile = devices.find((d) => d.device.toUpperCase() === "MOBILE");
-  if (!desktop && !mobile) return null;
+type DeviceRow = NonNullable<GSCData["devices"]>[number];
 
-  const delta = desktop && mobile && mobile.position > 0 && desktop.position > 0
-    ? mobile.position - desktop.position
-    : null;
-  const ctrDelta = desktop && mobile ? (mobile.ctr - desktop.ctr) * 100 : null;
-
-  const Card = ({ title, d }: { title: string; d?: GSCData["devices"] extends (infer U)[] | undefined ? U : never }) => (
+function DeviceCard({ title, d }: { title: string; d?: DeviceRow }) {
+  return (
     <div className="flex-1 rounded-xl border border-[#222] bg-[#141414] p-4">
       <div className="text-xs text-[#aaa]">{title}</div>
       {d ? (
@@ -840,13 +836,25 @@ function GSCDeviceComparison({ devices }: { devices: GSCData["devices"] }) {
       ) : <div className="mt-2 text-sm text-[#666]">데이터 없음</div>}
     </div>
   );
+}
+
+function GSCDeviceComparison({ devices }: { devices: GSCData["devices"] }) {
+  if (!devices || devices.length === 0) return null;
+  const desktop = devices.find((d) => d.device.toUpperCase() === "DESKTOP");
+  const mobile = devices.find((d) => d.device.toUpperCase() === "MOBILE");
+  if (!desktop && !mobile) return null;
+
+  const delta = desktop && mobile && mobile.position > 0 && desktop.position > 0
+    ? mobile.position - desktop.position
+    : null;
+  const ctrDelta = desktop && mobile ? (mobile.ctr - desktop.ctr) * 100 : null;
 
   return (
     <>
       <SectionHeader title="모바일 vs 데스크톱" description="모바일 위치가 데스크톱보다 3 위 이상 낮으면 mobile-first indexing 신호 약함 — Core Web Vitals(LCP/INP/CLS), 모바일 레이아웃 시프트, 텍스트 가독성 점검 우선순위." />
       <div className="flex flex-wrap gap-3">
-        <Card title="데스크톱" d={desktop} />
-        <Card title="모바일" d={mobile} />
+        <DeviceCard title="데스크톱" d={desktop} />
+        <DeviceCard title="모바일" d={mobile} />
         {delta !== null && (
           <div className={`flex flex-col justify-center rounded-xl border px-4 py-4 ${delta >= 3 ? "border-amber-900/50 bg-amber-950/20" : "border-[#222] bg-[#141414]"}`} style={{ minWidth: 220 }}>
             <div className="text-xs text-[#aaa]">격차</div>
@@ -869,13 +877,19 @@ function GSCDeviceComparison({ devices }: { devices: GSCData["devices"] }) {
 // GA4 인사이트 카드 — 검색→체류→전환 funnel 의 각 단계 진단.
 // 1. Organic Search 비중  2. Organic 참여율  3. 전환 핵심 이벤트  4. 신호 누락 (key event 마킹 안 됨 등)
 function GA4InsightCards({ data }: { data: GA4Data }) {
-  const totalSessions = data.channels?.reduce((s, c) => s + c.sessions, 0) ?? data.overview.sessions;
-  const organic = data.channels?.find((c) => c.channel === "Organic Search");
+  const channels = data.channels ?? [];
+  const totalSessions = channels.reduce((s, c) => s + c.sessions, 0) || data.overview.sessions;
+  const organic = channels.find((c) => isOrganicSearchChannel(c.channel));
   const organicShare = totalSessions > 0 && organic ? (organic.sessions / totalSessions) * 100 : 0;
-  const totalKeyEvents = data.channels?.reduce((s, c) => s + c.keyEvents, 0) ?? 0;
+  const totalKeyEvents = channels.reduce((s, c) => s + c.keyEvents, 0);
   const newsletter = data.conversions?.newsletter;
   const newsletterFormViews = newsletter?.formViews ?? 0;
   const newsletterSubmits = newsletter?.submits ?? 0;
+
+  // 데이터 자체가 비어있는지 vs 데이터 있는데 항목이 0 인지 분기.
+  // - dataSparse: 신규 사이트·집계 지연·channel 응답 자체 없음 → 위험 톤이 아니라 muted ("측정 불가")
+  // - dataSparse=false 인데 organic share=0 → 진짜 검색 유입 부재 → rose
+  const dataSparse = channels.length === 0 || totalSessions === 0;
 
   // 신호 누락 진단: key event 0인데 sign_up/cta_click 같은 이벤트는 흐르고 있으면 GA4 admin에서 마킹 안 된 상태.
   const eventCount = (name: string) => data.events?.find((e) => e.eventName === name)?.count ?? 0;
@@ -887,37 +901,41 @@ function GA4InsightCards({ data }: { data: GA4Data }) {
       <SectionHeader title="이번 기간의 액션 큐" description="검색 → 도착 → 체류 → 전환의 4단계 funnel 에서 어디가 좋고 어디가 막히는지 카드 한 줄로 진단합니다." />
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <InsightCard
-          tone={organicShare >= 10 ? "emerald" : organicShare > 0 ? "amber" : "rose"}
+          tone={dataSparse ? "muted" : organicShare >= 10 ? "emerald" : organicShare > 0 ? "amber" : "rose"}
           label="Organic Search 비중"
-          value={organic ? `${organicShare.toFixed(1)}%` : "—"}
-          note={organic
-            ? `세션 ${fmtNum(organic.sessions)} / 전체 ${fmtNum(totalSessions)}. 검색 유입을 늘리려면 GSC 끌어올림 후보부터 처리합니다.`
-            : "Organic Search 채널 데이터 없음."}
+          value={dataSparse ? "—" : `${organicShare.toFixed(1)}%`}
+          note={dataSparse
+            ? "측정 데이터 부족. 트래픽이 더 쌓이거나 채널 응답이 채워질 때까지 기다립니다."
+            : organic
+              ? `세션 ${fmtNum(organic.sessions)} / 전체 ${fmtNum(totalSessions)}. 검색 유입을 늘리려면 GSC 끌어올림 후보부터 처리합니다.`
+              : "Organic Search 채널 세션 0. 검색 유입이 아직 없음."}
         />
         <InsightCard
-          tone={organic && organic.engagementRate >= 0.6 ? "emerald" : organic && organic.engagementRate >= 0.4 ? "amber" : organic ? "rose" : "muted"}
+          tone={dataSparse || !organic ? "muted" : organic.engagementRate >= 0.6 ? "emerald" : organic.engagementRate >= 0.4 ? "amber" : "rose"}
           label="검색 유입 참여율"
-          value={organic ? `${(organic.engagementRate * 100).toFixed(1)}%` : "—"}
-          note={organic
-            ? organic.engagementRate >= 0.6
+          value={organic && organic.sessions > 0 ? `${(organic.engagementRate * 100).toFixed(1)}%` : "—"}
+          note={dataSparse || !organic || organic.sessions === 0
+            ? "Organic Search 세션이 없어 참여율 측정 불가."
+            : organic.engagementRate >= 0.6
               ? "검색으로 들어온 사용자가 잘 머무릅니다. 콘텐츠 의도 매칭 정상."
               : organic.engagementRate >= 0.4
                 ? "참여율 보통. 본문 첫 200자·H2 구조·내부 링크 점검."
-                : "검색 의도 mismatch 의심. 본문 첫 30%에 검색어와 정확히 매칭되는 답을 배치."
-            : "Organic Search 데이터 없음."}
+                : "검색 의도 mismatch 의심. 본문 첫 30%에 검색어와 정확히 매칭되는 답을 배치."}
         />
         <InsightCard
-          tone={newsletterSubmits > 0 ? "emerald" : newsletterFormViews > 0 ? "amber" : "rose"}
+          tone={dataSparse ? "muted" : newsletterSubmits > 0 ? "emerald" : newsletterFormViews > 0 ? "amber" : "rose"}
           label="뉴스레터 funnel"
-          value={`${fmtNum(newsletterFormViews)} → ${fmtNum(newsletterSubmits)}`}
-          note={newsletterFormViews === 0
-            ? "form_view 0 — 폼이 페이지에 노출되지 않거나 SubscribeForm IntersectionObserver 미발화."
-            : newsletterSubmits === 0
-              ? "form_view 발생, submit 0. 폼 UX·이메일 검증·전송 에러 로그 점검."
-              : `전환율 ${((newsletterSubmits / newsletterFormViews) * 100).toFixed(1)}%. 정상 흐름.`}
+          value={dataSparse ? "—" : `${fmtNum(newsletterFormViews)} → ${fmtNum(newsletterSubmits)}`}
+          note={dataSparse
+            ? "측정 데이터 부족."
+            : newsletterFormViews === 0
+              ? "form_view 0 — 폼이 페이지에 노출되지 않거나 SubscribeForm IntersectionObserver 미발화."
+              : newsletterSubmits === 0
+                ? "form_view 발생, submit 0. 폼 UX·이메일 검증·전송 에러 로그 점검."
+                : `전환율 ${((newsletterSubmits / newsletterFormViews) * 100).toFixed(1)}%. 정상 흐름.`}
         />
         <InsightCard
-          tone={keyEventsMissingMark ? "rose" : totalKeyEvents > 0 ? "emerald" : "muted"}
+          tone={dataSparse ? "muted" : keyEventsMissingMark ? "rose" : totalKeyEvents > 0 ? "emerald" : "muted"}
           label="Key event 마킹"
           value={totalKeyEvents > 0 ? fmtNum(totalKeyEvents) : keyEventsMissingMark ? "❗ 누락" : "—"}
           note={keyEventsMissingMark
@@ -951,7 +969,7 @@ function GA4ChannelsTable({ channels }: { channels: GA4Data["channels"] }) {
           </thead>
           <tbody>
             {channels.map((c) => {
-              const isOrganic = c.channel === "Organic Search";
+              const isOrganic = isOrganicSearchChannel(c.channel);
               return (
                 <tr key={c.channel} className={`border-b border-[#1a1a1a] hover:bg-[#1a1a1a] ${isOrganic ? "bg-cyan-950/15" : ""}`}>
                   <td className="px-4 py-2 text-[#ccc]">
@@ -974,8 +992,13 @@ function GA4ChannelsTable({ channels }: { channels: GA4Data["channels"] }) {
 }
 
 // Organic Search 만 필터한 landing page 별 engagement — 검색 유입 콘텐츠 품질.
+// GA4 가 referrer 누락·internal redirect 등으로 path 를 "(not set)" 로 반환하는
+// 행은 본문 분석 노이즈라 별도 합산 표시.
 function GA4OrganicLanding({ rows }: { rows: GA4Data["organicLanding"] }) {
   if (!rows || rows.length === 0) return null;
+  const isNotSet = (path: string) => !path || path === "(not set)";
+  const validRows = rows.filter((r) => !isNotSet(r.path));
+  const notSetSessions = rows.filter((r) => isNotSet(r.path)).reduce((s, r) => s + r.sessions, 0);
   return (
     <>
       <SectionHeader title="검색 유입 콘텐츠 품질" description="Organic Search 로 들어온 세션을 landing page 별로 분해. 참여율이 평균(60%)보다 낮은 페이지는 본문 첫 200자·H2 구조·검색어 매칭 점검 우선." />
@@ -992,13 +1015,15 @@ function GA4OrganicLanding({ rows }: { rows: GA4Data["organicLanding"] }) {
             </tr>
           </thead>
           <tbody>
-            {rows.map((r) => {
+            {validRows.length === 0 ? (
+              <tr><td colSpan={6}><EmptyRows label="Organic Search 도착 페이지 데이터가 없습니다." /></td></tr>
+            ) : validRows.map((r) => {
               const tag = r.engagementRate >= 0.6 ? { tone: "text-emerald-300", label: "양호" }
                 : r.engagementRate >= 0.4 ? { tone: "text-amber-300", label: "보통" }
                 : { tone: "text-rose-300", label: "개선 필요" };
               return (
                 <tr key={r.path} className="border-b border-[#1a1a1a] hover:bg-[#1a1a1a]">
-                  <td className="px-4 py-2 text-[#ccc] max-w-[420px] truncate">{r.path || "(not set)"}</td>
+                  <td className="px-4 py-2 text-[#ccc] max-w-[420px] truncate">{r.path}</td>
                   <td className="px-4 py-2 text-right tabular-nums">{fmtNum(r.sessions)}</td>
                   <td className={`px-4 py-2 text-right tabular-nums ${tag.tone}`}>{(r.engagementRate * 100).toFixed(1)}%</td>
                   <td className="px-4 py-2 text-right text-[#888]">{Math.round(r.avgSessionDuration)}s</td>
@@ -1007,6 +1032,12 @@ function GA4OrganicLanding({ rows }: { rows: GA4Data["organicLanding"] }) {
                 </tr>
               );
             })}
+            {notSetSessions > 0 && (
+              <tr className="border-b border-[#1a1a1a] bg-[#0d0d0d]">
+                <td className="px-4 py-2 text-[#666]" colSpan={2}>분석 불가 (path “(not set)”) — referrer 누락 또는 GA4 internal</td>
+                <td className="px-4 py-2 text-right tabular-nums text-[#666]" colSpan={4}>{fmtNum(notSetSessions)} 세션</td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/dashboard/src/app/api/analytics/ga4/route.ts
+++ b/dashboard/src/app/api/analytics/ga4/route.ts
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest) {
       "page_not_found", "outbound_click",
     ];
 
-    const [overviewRes, pagesRes, sourcesRes, dailyRes, eventsRes, ctaRes] = await Promise.all([
+    const [overviewRes, pagesRes, sourcesRes, dailyRes, eventsRes, ctaRes, channelsRes, organicLandingRes] = await Promise.all([
       client.properties.runReport({
         property: `properties/${PROPERTY_ID}`,
         requestBody: {
@@ -125,6 +125,46 @@ export async function GET(req: NextRequest) {
           orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
         },
       }),
+      // 채널별 세션·참여 — Organic Search 비중과 전환 funnel 분석용.
+      client.properties.runReport({
+        property: `properties/${PROPERTY_ID}`,
+        requestBody: {
+          dateRanges: [{ startDate, endDate: "today" }],
+          dimensions: [{ name: "sessionDefaultChannelGroup" }],
+          metrics: [
+            { name: "sessions" },
+            { name: "engagedSessions" },
+            { name: "engagementRate" },
+            { name: "averageSessionDuration" },
+            { name: "keyEvents" },
+          ],
+          orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
+          limit: "10",
+        },
+      }),
+      // Organic Search 만 필터한 landing page 별 engagement — 검색 유입 콘텐츠 품질 측정.
+      client.properties.runReport({
+        property: `properties/${PROPERTY_ID}`,
+        requestBody: {
+          dateRanges: [{ startDate, endDate: "today" }],
+          dimensions: [{ name: "landingPage" }],
+          metrics: [
+            { name: "sessions" },
+            { name: "engagedSessions" },
+            { name: "engagementRate" },
+            { name: "averageSessionDuration" },
+            { name: "keyEvents" },
+          ],
+          dimensionFilter: {
+            filter: {
+              fieldName: "sessionDefaultChannelGroup",
+              stringFilter: { value: "Organic Search" },
+            },
+          },
+          orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
+          limit: "20",
+        },
+      }),
     ]);
 
     const ov = overviewRes.data.rows?.[0]?.metricValues || [];
@@ -197,7 +237,25 @@ export async function GET(req: NextRequest) {
       count: Number(r.metricValues?.[0]?.value || 0),
     }));
 
-    return NextResponse.json({ overview, pages, sources, daily, events, conversions, ctaClicks });
+    const channels = (channelsRes.data.rows || []).map((r) => ({
+      channel: r.dimensionValues?.[0]?.value || "(unknown)",
+      sessions: Number(r.metricValues?.[0]?.value || 0),
+      engagedSessions: Number(r.metricValues?.[1]?.value || 0),
+      engagementRate: Number(r.metricValues?.[2]?.value || 0),
+      avgSessionDuration: Number(r.metricValues?.[3]?.value || 0),
+      keyEvents: Number(r.metricValues?.[4]?.value || 0),
+    }));
+
+    const organicLanding = (organicLandingRes.data.rows || []).map((r) => ({
+      path: r.dimensionValues?.[0]?.value || "",
+      sessions: Number(r.metricValues?.[0]?.value || 0),
+      engagedSessions: Number(r.metricValues?.[1]?.value || 0),
+      engagementRate: Number(r.metricValues?.[2]?.value || 0),
+      avgSessionDuration: Number(r.metricValues?.[3]?.value || 0),
+      keyEvents: Number(r.metricValues?.[4]?.value || 0),
+    }));
+
+    return NextResponse.json({ overview, pages, sources, daily, events, conversions, ctaClicks, channels, organicLanding });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Unknown error";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/dashboard/src/app/api/analytics/ga4/route.ts
+++ b/dashboard/src/app/api/analytics/ga4/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { google } from "googleapis";
+import { GA4_CHANNEL_ORGANIC_SEARCH } from "@/lib/analytics/ga4-channels";
+
+// 토글 시 GA4 Data API 호출 수가 비례 증가하므로 5분 segment 캐시.
+// GA4 도 사실상 분 단위 늦게 집계되어 5분 stale 영향 없음.
+export const revalidate = 300;
 
 const PROPERTY_ID = "530816613";
 
@@ -158,7 +163,7 @@ export async function GET(req: NextRequest) {
           dimensionFilter: {
             filter: {
               fieldName: "sessionDefaultChannelGroup",
-              stringFilter: { value: "Organic Search" },
+              stringFilter: { value: GA4_CHANNEL_ORGANIC_SEARCH },
             },
           },
           orderBys: [{ metric: { metricName: "sessions" }, desc: true }],

--- a/dashboard/src/app/api/analytics/gsc/route.ts
+++ b/dashboard/src/app/api/analytics/gsc/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { google } from "googleapis";
 
+// GSC searchanalytics.query 호출이 한 요청 당 9회 (queries/pages/daily/countries
+// /devices + tracked 키워드 수만큼). 사용자 토글마다 GSC quota 가 비례 증가하므로
+// 5분 segment 캐시로 burst 차단. GSC 데이터는 일 단위 갱신이라 5분 stale 영향 없음.
+export const revalidate = 300;
+
 // GSC 분석 대상 site URL. NEXT_PUBLIC_GSC_SITE_URL (optional) 이 있으면 우선,
 // 없으면 NEXT_PUBLIC_SITE_URL 로 fallback. 둘 다 없으면 runtime error.
 const SITE_URL =

--- a/dashboard/src/app/api/analytics/gsc/route.ts
+++ b/dashboard/src/app/api/analytics/gsc/route.ts
@@ -45,17 +45,42 @@ export async function GET(req: NextRequest) {
   const startDate = new Date(endDate);
   startDate.setDate(startDate.getDate() - (days - 1));
 
+  // AWC SEO tracker 4 추적 키워드 — 일별 노출/클릭/위치 추이를 별도 응답으로 노출.
+  // 추후 키워드 추가는 이 배열만 늘리면 자동 반영. dashboard 환경변수로 옮기는 건 추후.
+  const TRACKED_QUERIES = ["에이전틱 워크플로우", "AX 전환", "agentic workflow", "AX 자동화"];
+
   try {
     const client = await getClient();
 
-    const [queriesRes, pagesRes, dailyRes, countriesRes, devicesRes] = await Promise.all([
+    // 추적 키워드는 GSC dimensionFilterGroups 가 OR 를 지원하지 않으므로
+    // 키워드별로 equals filter + 단일 query 호출을 병렬 실행.
+    const trackedQueriesPromise = Promise.all(
+      TRACKED_QUERIES.map((q) =>
+        client.searchanalytics.query({
+          siteUrl: SITE_URL,
+          requestBody: {
+            startDate: formatDate(startDate),
+            endDate: formatDate(endDate),
+            dimensions: ["date"],
+            dimensionFilterGroups: [
+              {
+                filters: [{ dimension: "query", operator: "equals", expression: q }],
+              },
+            ],
+            rowLimit: 500,
+          },
+        }).then((res) => ({ query: q, rows: res.data.rows || [] })),
+      ),
+    );
+
+    const [queriesRes, pagesRes, dailyRes, countriesRes, devicesRes, trackedRes] = await Promise.all([
       client.searchanalytics.query({
         siteUrl: SITE_URL,
         requestBody: {
           startDate: formatDate(startDate),
           endDate: formatDate(endDate),
           dimensions: ["query"],
-          rowLimit: 20,
+          rowLimit: 50,
         },
       }),
       client.searchanalytics.query({
@@ -64,7 +89,7 @@ export async function GET(req: NextRequest) {
           startDate: formatDate(startDate),
           endDate: formatDate(endDate),
           dimensions: ["page"],
-          rowLimit: 20,
+          rowLimit: 50,
         },
       }),
       client.searchanalytics.query({
@@ -93,6 +118,7 @@ export async function GET(req: NextRequest) {
           rowLimit: 10,
         },
       }),
+      trackedQueriesPromise,
     ]);
 
     const queries = (queriesRes.data.rows || []).map((r) => ({
@@ -142,12 +168,38 @@ export async function GET(req: NextRequest) {
       position: r.position || 0,
     }));
 
+    // 추적 키워드: query 별 daily 시리즈로 정리.
+    const tracked = trackedRes.map(({ query, rows }) => {
+      const series = rows.map((r) => ({
+        date: r.keys?.[0] || "",
+        clicks: r.clicks || 0,
+        impressions: r.impressions || 0,
+        ctr: r.ctr || 0,
+        position: r.position || 0,
+      })).sort((a, b) => a.date.localeCompare(b.date));
+      const totalImpressions = series.reduce((s, r) => s + r.impressions, 0);
+      const totalClicks = series.reduce((s, r) => s + r.clicks, 0);
+      const avgPosition = totalImpressions > 0
+        ? series.reduce((s, r) => s + r.position * r.impressions, 0) / totalImpressions
+        : 0;
+      return {
+        query,
+        rows: series,
+        totals: {
+          clicks: totalClicks,
+          impressions: totalImpressions,
+          avgPosition,
+          avgCtr: totalImpressions > 0 ? totalClicks / totalImpressions : 0,
+        },
+      };
+    });
+
     return NextResponse.json({
       meta: {
         startDate: formatDate(startDate),
         endDate: formatDate(endDate),
         siteUrl: SITE_URL,
-        rowLimit: 20,
+        rowLimit: 50,
       },
       overview: { totalClicks, totalImpressions, avgCtr, avgPosition },
       queries,
@@ -155,6 +207,7 @@ export async function GET(req: NextRequest) {
       daily,
       countries,
       devices,
+      tracked,
     });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Unknown error";

--- a/dashboard/src/lib/analytics/ga4-channels.ts
+++ b/dashboard/src/lib/analytics/ga4-channels.ts
@@ -1,0 +1,15 @@
+// GA4 sessionDefaultChannelGroup 표준 enum (영어 고정).
+// GA4 가 채널 enum 을 변경한 이력이 있어 (Cross-network 신설, Organic Shopping
+// 분할 등), Google 이 향후 "Organic Search" 를 "Search (Organic)" 류로 리네임해도
+// fuzzy 매칭으로 캐치하도록 유틸을 별도 파일로 분리.
+
+export const GA4_CHANNEL_ORGANIC_SEARCH = "Organic Search";
+
+// 채널 fuzzy 매칭 — Google 이 enum 이름을 살짝 바꿔도 검색 채널을 식별.
+// "organic" + "search" 둘 다 포함이면 매칭. 다른 organic 채널 (Organic Social,
+// Organic Shopping, Organic Video) 은 search 단어가 없어 false 로 떨어짐.
+export function isOrganicSearchChannel(channelName: string | null | undefined): boolean {
+  if (!channelName) return false;
+  const lower = channelName.toLowerCase();
+  return lower.includes("organic") && lower.includes("search");
+}


### PR DESCRIPTION
## 요약

기존 트래픽 화면은 GA4/GSC 가 주는 raw metric/dimension 토글 dump 라 "이 숫자가 액션을 요구하는가" 를 화면이 도와주지 않았습니다. 사용자가 직접 풀어야 했던 의사결정 분류를 화면 안에 박아서 다음 행동을 직접 가리키는 구조로 재작성.

## 적용된 의사결정 5축

검색 SEO 운영의 핵심 결정을 화면이 직접 답하도록 함:

| # | 결정 | 어디서 답함 |
|---|---|---|
| 1 | 어떤 글을 끌어올려야 하나 | GSC "끌어올림 후보" 표 (위치 8~20 + 노출 ≥30) |
| 2 | 어떤 키워드는 클릭이 안 되는가 | "CTR 부진" 태그 (1페이지인데 기대 CTR 절반 이하) |
| 3 | 검색으로 들어온 사람이 머무는가 | GA4 "검색 유입 참여율" 카드 + organicLanding 표 |
| 4 | 전환은 일어나는가 | GA4 "뉴스레터 funnel" + "Key event 마킹" 카드 |
| 5 | 모바일 vs 데스크톱 격차 | GSC 쌍둥이 카드 + 격차 박스 |

## 변경 요약

### API 보강 (\`1ccfa11\`)
- GSC: \`tracked\` (4 추적 키워드 일별 시리즈), queries/pages rowLimit 50
- GA4: \`channels\` (channel 별 funnel), \`organicLanding\` (Organic Search landingPage)

### Frontend 재구성 (\`ebc7b6c\`)
공통 helper 도입:
- \`classifyPosition\` — 1~3 / 4~10 / 11~20 / 21~30 / 31+ 5단계
- \`expectedCtr\` — 위치별 기대 CTR baseline (Sistrix 통념)
- \`InsightCard\` — 액션 큐 카드 통일 디자인 (amber/rose/emerald/muted tone)

GSC 탭 신규 섹션:
- 액션 큐 4 카드: 끌어올림 후보 / CTR 부진 / 모바일 격차 / 추적 키워드 가시성
- 추적 키워드 4 카드: 평균 위치 + mini chart
- 모바일 vs 데스크톱 비교 카드 + 격차 박스
- 끌어올림 후보 표 (page 2 → 1 hanging fruit)
- 기존 view toggle 행에 위치 분류·CTR 부진 태그 자동 부여

GA4 탭 신규 섹션:
- 액션 큐 4 카드: Organic Search 비중 / 검색 유입 참여율 / 뉴스레터 funnel / Key event 마킹
  - "Key event 마킹" 카드는 이벤트는 흐르는데 keyEvents=0 인 상태 자동 진단
- 채널별 유입 품질 표 (Organic Search 행 강조)
- 검색 유입 콘텐츠 품질 표 (organicLanding + 참여율 색상 코딩)

기존 모든 섹션(daily chart, conversions, events, ctaClicks, sources, pages, view toggle) 유지. 회귀 없이 신규 섹션을 위에 끼워 넣는 구조.

## 실측 검증 (90일)

신규 카드가 실제 진단을 만드는지 확인:
- **Organic Search 비중**: 1.2% (59/5024) → rose 카드, "끌어올림 후보부터 처리"
- **Key event 마킹**: 모든 채널에서 keyEvents=0 인데 cta_click 490건 흐름 → ❗누락 자동 감지
- **추적 키워드 가시성**: 4 키워드 모두 노출 0건 → "색인·콘텐츠 매칭 점검" 카드
- **모바일 격차**: +3.6 위 (mobile 6.10 vs desktop 2.54) → amber 카드 자동 강조
- **끌어올림 후보**: 0건 (현재 데이터로는 노출 ≥30 페이지 자체 없음) → "노출이 더 쌓여야 함" 진단

## Test plan
- [x] \`npx tsc --noEmit\` exit 0
- [x] \`/api/analytics/ga4?days=90\` 응답에 channels/organicLanding 포함
- [x] \`/api/analytics/gsc?days=90\` 응답에 tracked 포함
- [x] \`/analytics/traffic?mode=ga4\`, \`/analytics/traffic?mode=gsc\` HTTP 200
- [ ] UI 라이브 점검 — 액션 큐 카드 톤(amber/rose/emerald/muted) 정상 색상, 추적 키워드 mini chart 렌더링, 모바일 격차 박스 강조