### PR TITLE
feat(dashboard/blog-manage): 카테고리 필터 추가

### DIFF
--- a/dashboard/src/app/(dashboard)/blog-manage/page.tsx
+++ b/dashboard/src/app/(dashboard)/blog-manage/page.tsx
@@ -38,6 +38,12 @@ const NEWSLETTER_BADGE: Record<string, { label: string; className: string }> = {
 type StatusFilter = "all" | "draft" | "published" | "archived";
 type SortBy = "created_at" | "updated_at";
 
+interface CategoryOption {
+  id: string;
+  name: string;
+  slug: string;
+}
+
 function renderNewsletterSummary(post: BlogPost) {
   if (!post.newsletter_status) {
     return <span className="text-[#555] text-xs">미발송</span>;
@@ -70,6 +76,21 @@ export default function BlogManagePage() {
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [sortBy, setSortBy] = useState<SortBy>("created_at");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [categories, setCategories] = useState<CategoryOption[]>([]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch("/api/blog-manage/categories");
+        const data = await res.json();
+        setCategories(data.categories || []);
+      } catch (e) {
+        console.error("Failed to fetch categories", e);
+      }
+    };
+    fetchCategories();
+  }, []);
 
   useEffect(() => {
     const fetchPosts = async () => {
@@ -77,6 +98,7 @@ export default function BlogManagePage() {
       try {
         const params = new URLSearchParams();
         if (statusFilter !== "all") params.set("status", statusFilter);
+        if (categoryFilter !== "all") params.set("category", categoryFilter);
         params.set("sort", sortBy);
         params.set("order", "desc");
 
@@ -91,7 +113,7 @@ export default function BlogManagePage() {
     };
 
     fetchPosts();
-  }, [statusFilter, sortBy]);
+  }, [statusFilter, sortBy, categoryFilter]);
 
   const filters: { value: StatusFilter; label: string }[] = [
     { value: "all", label: "전체" },
@@ -120,6 +142,18 @@ export default function BlogManagePage() {
             </button>
           ))}
         </div>
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-[#333] bg-[#0a0a0a] text-sm text-[#fafafa] outline-none"
+        >
+          <option value="all">전체 카테고리</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.slug}>
+              {c.name}
+            </option>
+          ))}
+        </select>
         <select
           value={sortBy}
           onChange={(e) => setSortBy(e.target.value as SortBy)}

--- a/dashboard/src/app/api/blog-manage/categories/route.ts
+++ b/dashboard/src/app/api/blog-manage/categories/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+
+export const revalidate = 300;
+
+/** GET /api/blog-manage/categories — list all blog categories for filter UI */
+export async function GET() {
+  try {
+    const sb = getSupabase();
+    const { data, error } = await sb
+      .from("blog_categories")
+      .select("id, name, slug")
+      .order("name", { ascending: true });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ categories: data || [] });
+  } catch {
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/blog-manage/route.ts
+++ b/dashboard/src/app/api/blog-manage/route.ts
@@ -6,12 +6,31 @@ export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
     const status = searchParams.get("status") || undefined;
+    const categorySlug = searchParams.get("category") || undefined;
     const validSorts = ["created_at", "updated_at", "published_at", "title"];
     const rawSort = searchParams.get("sort") || "created_at";
     const sort = validSorts.includes(rawSort) ? rawSort : "created_at";
     const order = searchParams.get("order") || "desc";
 
     const sb = getSupabase();
+
+    let postIdFilter: string[] | null = null;
+    if (categorySlug) {
+      const { data: catRows, error: catErr } = await sb
+        .from("blog_post_categories")
+        .select("post_id, blog_categories!inner(slug)")
+        .eq("blog_categories.slug", categorySlug);
+
+      if (catErr) {
+        return NextResponse.json({ error: catErr.message }, { status: 500 });
+      }
+
+      postIdFilter = (catRows ?? []).flatMap((row) => (row.post_id ? [row.post_id] : []));
+
+      if (postIdFilter.length === 0) {
+        return NextResponse.json({ posts: [], total: 0 });
+      }
+    }
 
     let query = sb
       .from("blog_posts")
@@ -22,6 +41,10 @@ export async function GET(req: Request) {
 
     if (status) {
       query = query.eq("status", status);
+    }
+
+    if (postIdFilter) {
+      query = query.in("id", postIdFilter);
     }
 
     const { data, error } = await query;


### PR DESCRIPTION
## Summary
- 블로그 관리 목록에서 인사이트/실전 사례 등 카테고리 단위로 게시물 필터링 가능
- `/api/blog-manage`에 `?category=<slug>` 파라미터 추가 (2-step 쿼리: 카테고리 → post_id 추출 후 `.in()` — 게시물별 전체 카테고리 임베드 보존)
- `/api/blog-manage/categories` 신규 GET (5분 revalidate 캐싱)
- 목록 페이지에 카테고리 select 추가, 마운트 시 1회 카테고리 로드

## Test plan
- [ ] /blog-manage 진입 시 "전체 카테고리" 옵션 + DB 카테고리 목록이 셀렉트에 노출
- [ ] 카테고리 선택 시 해당 카테고리 게시물만 보이고, 한 게시물의 다른 카테고리도 표시 유지
- [ ] 매칭 0건일 때 "아직 작성된 글이 없습니다." 정상 표시
- [ ] 상태 + 카테고리 동시 필터 AND 조건 동작
- [ ] 카테고리 엔드포인트 5분간 동일 응답(캐시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)